### PR TITLE
Update Elasticsearch Output Plugin to retry bulk

### DIFF
--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.requirements << "jar 'org.elasticsearch:elasticsearch', '1.4.0'"
 
   # Gem dependencies
+  s.add_runtime_dependency 'concurrent-ruby'
   s.add_runtime_dependency 'elasticsearch', ['>= 1.0.6', '~> 1.0']
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']

--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -258,7 +258,7 @@ describe "outputs/elasticsearch" do
     end
   end
 
-  describe "wildcard substitution in index templates", :todo => true do
+  describe "wildcard substitution in index templates", :elasticsearch => true do
     require "logstash/outputs/elasticsearch"
 
     let(:template) { '{"template" : "not important, will be updated by :index"}' }
@@ -380,7 +380,108 @@ describe "outputs/elasticsearch" do
     end
   end
 
-  describe "elasticsearch protocol", :elasticsearch => true do
+  describe "failures in bulk class expected behavior", :elasticsearch => true do
+
+
+    let(:template) { '{"template" : "not important, will be updated by :index"}' }
+    let(:event1) { LogStash::Event.new("somevalue" => 100, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
+    let(:action1) { ["index", {:_id=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event1] }
+    let(:event2) { LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0] }, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
+    let(:action2) { ["index", {:_id=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event2] }
+    let(:max_retries) { 3 }
+
+    def mock_actions_with_response(*resp)
+      LogStash::Outputs::Elasticsearch::Protocols::HTTPClient
+        .any_instance.stub(:bulk).and_return(*resp)
+      LogStash::Outputs::Elasticsearch::Protocols::NodeClient
+        .any_instance.stub(:bulk).and_return(*resp)
+      LogStash::Outputs::Elasticsearch::Protocols::TransportClient
+        .any_instance.stub(:bulk).and_return(*resp)
+    end
+
+    ["node", "transport", "http"].each do |protocol|
+      context "with protocol => #{protocol}" do
+        subject do
+          require "logstash/outputs/elasticsearch"
+          settings = {
+            "manage_template" => true,
+            "index" => "logstash-2014.11.17",
+            "template_overwrite" => true,
+            "protocol" => protocol,
+            "host" => "localhost",
+            "retry_max_items" => 10,
+            "retry_max_interval" => 1,
+            "max_retries" => max_retries
+          }
+          next LogStash::Outputs::ElasticSearch.new(settings)
+        end
+
+        before :each do
+          # Delete all templates first.
+          require "elasticsearch"
+
+          # Clean ES of data before we start.
+          @es = Elasticsearch::Client.new
+          @es.indices.delete_template(:name => "*")
+          @es.indices.delete(:index => "*")
+          @es.indices.refresh
+        end
+
+        it "should return no errors if all bulk actions are successful" do
+          mock_actions_with_response({"errors" => false})
+          expect(subject).to receive(:submit).with([action1, action2]).once.and_call_original
+          subject.register
+          subject.receive(event1)
+          subject.receive(event2)
+          subject.buffer_flush(:final => true)
+          sleep(2)
+        end
+
+        it "should retry actions with response status of 503" do
+          mock_actions_with_response({"errors" => true, "statuses" => [200, 200, 503, 503]},
+                                     {"errors" => true, "statuses" => [200, 503]},
+                                     {"errors" => false})
+          expect(subject).to receive(:submit).with([action1, action1, action1, action2]).ordered.once.and_call_original
+          expect(subject).to receive(:submit).with([action1, action2]).ordered.once.and_call_original
+          expect(subject).to receive(:submit).with([action2]).ordered.once.and_call_original
+
+          subject.register
+          subject.receive(event1)
+          subject.receive(event1)
+          subject.receive(event1)
+          subject.receive(event2)
+          subject.buffer_flush(:final => true)
+          sleep(3)
+        end
+        
+        it "should retry actions with response status of 429" do
+          mock_actions_with_response({"errors" => true, "statuses" => [429]},
+                                     {"errors" => false})
+          expect(subject).to receive(:submit).with([action1]).twice.and_call_original
+          subject.register
+          subject.receive(event1)
+          subject.buffer_flush(:final => true)
+          sleep(3)
+        end
+
+        it "should retry an event until max_retries reached" do
+          mock_actions_with_response({"errors" => true, "statuses" => [429]},
+                                     {"errors" => true, "statuses" => [429]},
+                                     {"errors" => true, "statuses" => [429]},
+                                     {"errors" => true, "statuses" => [429]},
+                                     {"errors" => true, "statuses" => [429]},
+                                     {"errors" => true, "statuses" => [429]})
+          expect(subject).to receive(:submit).with([action1]).exactly(max_retries).times.and_call_original
+          subject.register
+          subject.receive(event1)
+          subject.buffer_flush(:final => true)
+          sleep(3)
+        end
+      end
+    end
+  end
+
+  describe "elasticsearch protocol" do
     # ElasticSearch related jars
 #LogStash::Environment.load_elasticsearch_jars!
     # Load elasticsearch protocol


### PR DESCRIPTION
Some actions may fail within the ES client bulk call.
Now, some messages (specifically errors 429 and 503s) will be
retried up to 3 times. If there are still actions that are
unsuccessfully indexed, Stud Buffer will continue its current
behavior (to retry indefinitely).

Stud Buffer will replay all events it first attempted to flush
to Elasticsearch. This means duplicate events may find themselves
in Elasticsearch.

(migrated from https://github.com/elasticsearch/logstash/pull/1997 with a few modifications to make 
tests run once plugin is installed)