### PR TITLE
Update elasticsearch output to respect the 'index'

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -205,6 +205,14 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # Set the truststore password
   config :truststore_password, :validate => :password
 
+  # helper function to replace placeholders
+  # in index names to wildcards
+  # example:
+  #    "logs-%{YYYY}" -> "logs-*"
+  def wildcard_substitute(name)
+    name.gsub(/%\{[^}]+\}/, "*")
+  end
+
   public
   def register
     client_settings = {}
@@ -364,8 +372,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       end
     end
     template_json = IO.read(@template).gsub(/\n/,'')
-    @logger.info("Using mapping template", :template => template_json)
-    return LogStash::Json.load(template_json)
+    template = LogStash::Json.load(template_json)
+    template['template'] = wildcard_substitute(@index)
+    @logger.info("Using mapping template", :template => template)
+    return template
   end # def get_template
 
   protected


### PR DESCRIPTION
Now the elasticsearch output plugin will respect the
'index' plugin setting and override the default index
template to update the indexes it matches on based on
the 'index' setting.

Any placeholders ("%{...}") will be translated to '*' so the
template matching pattern is generic and in line with elasticsearch
wildcarding.
