### PR TITLE
Fix documentation style 

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -12,8 +12,7 @@ require 'logstash-output-elasticsearch_jars.rb'
 # output for Logstash. If you plan on using the Kibana web interface, you'll
 # need to use this output.
 #
-#   *VERSION NOTE*: Your Elasticsearch cluster must be running Elasticsearch
-#   1.0.0 or later.
+#   *VERSION NOTE*: Your Elasticsearch cluster must be running Elasticsearch 1.0.0 or later.
 #
 # If you want to set other Elasticsearch options that are not exposed directly
 # as configuration options, there are two methods:


### PR DESCRIPTION
Fixed a carry return that caused an strange look an field in the live docs.

see attached image:

![elasticsearch-output](https://cloud.githubusercontent.com/assets/68540/5130590/14a50cec-70ec-11e4-9005-79c98d5b5e42.png)
