### PR TITLE
Add missing base64 require

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -7,7 +7,6 @@ require "stud/buffer"
 require "socket" # for Socket.gethostname
 require "uri" # for escaping user input
 require 'logstash-output-elasticsearch_jars.rb'
-require "base64"
 
 # This output lets you store logs in Elasticsearch and is the most recommended
 # output for Logstash. If you plan on using the Kibana web interface, you'll

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -1,5 +1,6 @@
 require "logstash/outputs/elasticsearch"
 require "cabin"
+require "base64"
 
 module LogStash::Outputs::Elasticsearch
   module Protocols


### PR DESCRIPTION
when used with basic auth it breaks:

uninitialized constant `LogStash::Outputs::Elasticsearch::Protocols::HTTPClient::Base64`

https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/lib/logstash/outputs/elasticsearch/protocol.rb#L73
