### PR TITLE
rename apache license string to match maven-tools format for apache-2.0

### DIFF
--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
   s.version         = '0.1.9'
-  s.licenses        = ['Apache License (2.0)']
+  s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"
   s.authors         = ["Elasticsearch"]


### PR DESCRIPTION
maven-tools is only happy with certain license strings: https://github.com/torquebox/maven-tools/blob/master/lib/maven/tools/licenses.rb#L8

so here is the change
