### PR TITLE
Add support for create actions in the node client

### DIFF
--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -45,11 +45,22 @@ module LogStash::Outputs::Elasticsearch
       #
       # If any action is missing a required arg, then a
       # Logstash::ConfigurationError is raised.
-      def validate(action, args)
-        if action == "create"
+      #
+      # After validation, this will return the "real" action name (e.g.,
+      # "create_unless_exists" once validated is just "create"). If the
+      # incoming action is unrecognized, then it is returned as-is.
+      def validateAction(action, args)
+        action_name = action
+
+        # This is a specialization of "create" that requires the ID to be specified
+        if action == "create_unless_exists"
           # create operations without an _id is pointless and almost certainly unintentional
-          raise(LogStash::ConfigurationError, "Specifying action => 'create' without a document '_id' is not supported.") if args[:_id].nil?
+          raise(LogStash::ConfigurationError, "Specifying action => 'create_unless_exists' without a document '_id' is not supported.") if args[:_id].nil?
+
+          action_name = "create"
         end
+
+        return action_name
       end
 
       public(:initialize, :template_install)
@@ -91,12 +102,12 @@ module LogStash::Outputs::Elasticsearch
 
       def bulk(actions)
         @client.bulk(:body => actions.collect do |action, args, source|
-          validate(action, args)
+          action_name = validateAction(action, args)
 
           if source
-            next [ { action => args }, source ]
+            next [ { action_name => args }, source ]
           else
-            next { action => args }
+            next { action_name => args }
           end
         end.flatten)
       end # def bulk
@@ -207,9 +218,9 @@ module LogStash::Outputs::Elasticsearch
       end # def bulk
 
       def build_request(action, args, source)
-        validate(action, args)
+        action_name = validateAction(action, args)
 
-        case action
+        case action_name
         when "index"
             request = org.elasticsearch.action.index.IndexRequest.new(args[:_index])
             request.id(args[:_id]) if args[:_id]
@@ -220,9 +231,11 @@ module LogStash::Outputs::Elasticsearch
           #when "update"
           when "create"
             request = org.elasticsearch.action.index.IndexRequest.new(args[:_index])
-            request.id(args[:_id])
+            request.id(args[:_id]) if args[:_id]
             request.source(source)
             request.opType(org.elasticsearch.action.index.IndexRequest.OpType.CREATE)
+          else
+            raise(LogStash::ConfigurationError, "action => '#{action_name}' is not currently supported.")
         end # case action
 
         request.type(args[:_type]) if args[:_type]

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -222,7 +222,7 @@ module LogStash::Outputs::Elasticsearch
         action_name = validate_action(action, args)
 
         case action_name
-        when "index"
+          when "index"
             request = org.elasticsearch.action.index.IndexRequest.new(args[:_index])
             request.id(args[:_id]) if args[:_id]
             request.source(source)

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -48,8 +48,9 @@ module LogStash::Outputs::Elasticsearch
       #
       # After validation, this will return the "real" action name (e.g.,
       # "create_unless_exists" once validated is just "create"). If the
-      # incoming action is unrecognized, then it is returned as-is.
-      def validateAction(action, args)
+      # incoming action is unrecognized or not validated, then it is returned
+      # as-is.
+      def validate_action(action, args)
         action_name = action
 
         # This is a specialization of "create" that requires the ID to be specified
@@ -102,7 +103,7 @@ module LogStash::Outputs::Elasticsearch
 
       def bulk(actions)
         @client.bulk(:body => actions.collect do |action, args, source|
-          action_name = validateAction(action, args)
+          action_name = validate_action(action, args)
 
           if source
             next [ { action_name => args }, source ]
@@ -218,7 +219,7 @@ module LogStash::Outputs::Elasticsearch
       end # def bulk
 
       def build_request(action, args, source)
-        action_name = validateAction(action, args)
+        action_name = validate_action(action, args)
 
         case action_name
         when "index"

--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -31,7 +31,7 @@ describe "outputs/elasticsearch" do
       elasticsearch {
         host => "127.0.0.1"
         index => "#{index}"
-        action => "create"
+        action => "create_unless_exists"
         flush_size => 1
       }
     }
@@ -73,10 +73,12 @@ describe "outputs/elasticsearch" do
           elasticsearch {
             host => "127.0.0.1"
             index => "#{index}"
-            action => "create"
+            action => "create_unless_exists"
           }
         }
         CONFIG
+
+        # ^^^ SHOULD FAIL AND THE FAILURE SHOULD CAUSE THE TEST TO PASS
 
         # TODO: pickypg -- I have no idea how to check for raise_error
         agent do


### PR DESCRIPTION
- Adds validation to require `_id` for create actions (including for the http protocol)

**Help**: I don't know how to properly test for the error condition. The `"create action fails without _id"` test fails because I'm not testing it right, but I don't know how to properly catch the error.

Note: #2 (retry on bulk failure) may need to special case failure to create (ignore it).

Closes #28 