### PR TITLE
move plugin require code to bottom of class

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -462,14 +462,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     buffer_flush(:final => true)
     retry_flush
   end
-
-  @@plugins = Gem::Specification.find_all{|spec| spec.name =~ /logstash-output-elasticsearch-/ }
-
-  @@plugins.each do |plugin|
-    name = plugin.name.split('-')[-1]
-    require "logstash/outputs/elasticsearch/#{name}"
-  end
-
   protected
   def start_local_elasticsearch
     @logger.info("Starting embedded Elasticsearch local node.")
@@ -594,4 +586,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   def wildcard_substitute(name)
     name.gsub(/%\{[^}]+\}/, "*")
   end
+
+  @@plugins = Gem::Specification.find_all{|spec| spec.name =~ /logstash-output-elasticsearch-/ }
+
+  @@plugins.each do |plugin|
+    name = plugin.name.split('-')[-1]
+    require "logstash/outputs/elasticsearch/#{name}"
+  end
+
 end # class LogStash::Outputs::Elasticsearch

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '0.1.11'
+  s.version         = '0.1.12'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"


### PR DESCRIPTION
since some plugins modify existing methods in host class,
this loop must be at the bottom, where all methods have been declared