### PR TITLE
Milestone missing, prevents running plugin

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -37,6 +37,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   include Stud::Buffer
 
   config_name "elasticsearch"
+  milestone 3
 
   # The index to write events to. This can be dynamic using the `%{foo}` syntax.
   # The default value will partition your indices by day so you can more easily


### PR DESCRIPTION
The milestone line is missing from this plugin, it therefore cannot be run. Used the milestone from https://github.com/elasticsearch/logstash/blob/1.4/lib/logstash/outputs/elasticsearch.rb#L36