### PR TITLE
Fix the jar-dependency issue blocking the bootstrap of this gem

### DIFF
--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '0.1.14'
+  s.version         = '0.1.15'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
-  s.add_runtime_dependency 'jar-dependencies'
 
   s.add_development_dependency 'ftw', '~> 0.0.42'
   s.add_development_dependency 'logstash-input-generator'
@@ -37,6 +36,16 @@ Gem::Specification.new do |s|
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM
     s.add_runtime_dependency "manticore", '~> 0.3'
+    # Currently there is a blocking issue with the latest (3.1.1.0.9) version of 
+    # `ruby-maven` # and installing jars dependencies. If you are declaring a gem 
+    # in a gemfile # using the :github option it will make the bundle install crash,
+    # before upgrading this gem you need to test the version with any plugins
+    # that require jars.
+    #
+    # Ticket: https://github.com/elasticsearch/logstash/issues/2595
+    s.add_runtime_dependency 'jar-dependencies', '0.1.7'
+    s.add_runtime_dependency 'ruby-maven', '3.1.1.0.8'
+    s.add_runtime_dependency "maven-tools", '1.0.7'
   end
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Fixed #53 as it bound jar-dependencies and ruby-maven to the known working version.

Check https://github.com/elasticsearch/logstash/issues/2595 for more detials on the issue and when I can be fix upstream.
