### PR TITLE
Updated ElasticSearch embeded version

### DIFF
--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '0.1.14'
+  s.version         = '0.1.15'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Jar dependencies
-  s.requirements << "jar 'org.elasticsearch:elasticsearch', '1.4.0'"
+  s.requirements << "jar 'org.elasticsearch:elasticsearch', '1.4.3'"
 
   # Gem dependencies
   s.add_runtime_dependency 'concurrent-ruby'


### PR DESCRIPTION
To work with Kibana4-RC1, elasticsearch must be at version 1.4.3.
This is problematic if logstash is connected in node mode.