### PR TITLE
fix http protocol status response handling and only attempt to call retry_push if necessary

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -425,7 +425,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
           @logger.warn "failed action with response of #{resp_code}, dropping action: #{action}"
         end
       end
-      retry_push(actions_to_retry)
+      retry_push(actions_to_retry) unless actions_to_retry.empty?
     end
   end
 

--- a/spec/outputs/elasticsearch/protocol_spec.rb
+++ b/spec/outputs/elasticsearch/protocol_spec.rb
@@ -1,0 +1,52 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/elasticsearch/protocol"
+require "java"
+
+describe LogStash::Outputs::Elasticsearch::Protocols::NodeClient do
+  context "successful" do
+    it "should map correctly" do
+      index_response = org.elasticsearch.action.index.IndexResponse.new("my_index", "my_type", "my_id", 123, true)
+      delete_response = org.elasticsearch.action.delete.DeleteResponse.new("my_index", "my_type", "my_id", 123, true)
+      bulk_item_response_index = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "index", index_response)
+      bulk_item_response_delete = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "delete", delete_response)
+      bulk_response = org.elasticsearch.action.bulk.BulkResponse.new([bulk_item_response_index, bulk_item_response_delete], 0)
+      ret = LogStash::Outputs::Elasticsearch::Protocols::NodeClient.normalize_bulk_response(bulk_response)
+      insist { ret } == {"errors" => false}
+    end
+  end
+
+  context "contains failures" do
+    it "should map correctly" do
+      failure = org.elasticsearch.action.bulk.BulkItemResponse::Failure.new("my_index", "my_type", "my_id", "error message", org.elasticsearch.rest.RestStatus::BAD_REQUEST)
+      bulk_item_response_index = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "index", failure)
+      bulk_item_response_delete = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "delete", failure)
+      bulk_response = org.elasticsearch.action.bulk.BulkResponse.new([bulk_item_response_index, bulk_item_response_delete], 0)
+      actual = LogStash::Outputs::Elasticsearch::Protocols::NodeClient.normalize_bulk_response(bulk_response)
+      insist { actual } == {"errors" => true, "statuses" => [400, 400]}
+    end
+  end
+end
+
+describe LogStash::Outputs::Elasticsearch::Protocols::HTTPClient do
+  context "successful" do
+    it "should map correctly" do
+      bulk_response = {"took"=>74, "errors"=>false, "items"=>[{"create"=>{"_index"=>"logstash-2014.11.17",
+                                                                          "_type"=>"logs", "_id"=>"AUxTS2C55Jrgi-hC6rQF",
+                                                                          "_version"=>1, "status"=>201}}]} 
+      actual = LogStash::Outputs::Elasticsearch::Protocols::HTTPClient.normalize_bulk_response(bulk_response)
+      insist { actual } == {"errors"=> false}
+    end
+  end
+
+  context "contains failures" do
+    it "should map correctly" do
+      bulk_response = {"took"=>71, "errors"=>true,
+                       "items"=>[{"create"=>{"_index"=>"logstash-2014.11.17",
+                                             "_type"=>"logs", "_id"=>"AUxTQ_OI5Jrgi-hC6rQB", "status"=>400,
+                                             "error"=>"MapperParsingException[failed to parse]..."}}]}
+      actual = LogStash::Outputs::Elasticsearch::Protocols::HTTPClient.normalize_bulk_response(bulk_response)
+      insist { actual } == {"errors"=> true, "statuses"=> [400]}
+    end
+  end
+end
+


### PR DESCRIPTION

- fix for how errors are parsed in the http protocol
- added more tests for error parsing from client responses in bulk api calls
- now retry_push is only called if there are events to be retried (it was being called regardless beforehand)