### PR TITLE
Disable norms for _all field in the template

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -5,7 +5,7 @@
   },
   "mappings" : {
     "_default_" : {
-       "_all" : {"enabled" : true},
+       "_all" : {"enabled" : true, "omit_norms" : true},
        "dynamic_templates" : [ {
          "message_field" : {
            "match" : "message",


### PR DESCRIPTION
For logs, length normalization for this field probably does more harm than good.
It could even cause confusion for scoring, because its a combination of so
many structured fields, different from traditional search use cases.

We can save a good deal of memory by disabling norms, like the other fields.

See https://github.com/elastic/elasticsearch/pull/4573 which added this option to ES.