### PR TITLE
Remove `"path": "full"` from geoip mapping

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -31,7 +31,6 @@
          "geoip"  : {
            "type" : "object",
              "dynamic": true,
-             "path": "full",
              "properties" : {
                "location" : { "type" : "geo_point" }
              }


### PR DESCRIPTION
This causes recent (see: master) builds of elasticsearch to fail new
index create when drawing from the default mapping. "path": "full" is no
longer supported, but the default behavior in elasticsearch is such that
operations that rely on the path notation should still function
normally.

Fixes #94 