### PR TITLE
Feature: Add Shield authentication for node transport

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -261,6 +261,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       raise(LogStash::ConfigurationError, "action => 'create_unless_exists' is not supported under the HTTP protocol");
     end
 
+    # Node protocol supports auth with the shield.user option
+    if @protocol == "node" && @user && @password
+      client_settings["shield.user"] = @user + ":" + @password.value
+    end
+
     if ["node", "transport"].include?(@protocol)
       # Node or TransportClient; requires JRuby
       raise(LogStash::PluginLoadingError, "This configuration requires JRuby. If you are not using JRuby, you must set 'protocol' to 'http'. For example: output { elasticsearch { protocol => \"http\" } }") unless LogStash::Environment.jruby?
@@ -542,6 +547,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   private
   def setup_basic_auth
     return {} unless @user && @password
+    return {} if @protocol == "node" # Authentication already setup for "node" protocol
 
     if @protocol =~ /http/
       {

--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -886,24 +886,40 @@ describe "ship lots of events w/ default index_type and dynamic routing key usin
   end
 
   describe "Authentication option" do
-    ["node", "transport"].each do |protocol|
-      context "with protocol => #{protocol}" do
-        subject do
-          require "logstash/outputs/elasticsearch"
-          settings = {
-            "protocol" => protocol,
-            "node_name" => "logstash",
-            "cluster" => "elasticsearch",
-            "host" => "node01",
-            "user" => "test",
-            "password" => "test"
-          }
-          next LogStash::Outputs::ElasticSearch.new(settings)
-        end
+    context "with protocol => node" do
+      subject do
+        require "logstash/outputs/elasticsearch"
+        settings = {
+          "protocol" => "node",
+          "node_name" => "logstash",
+          "cluster" => "elasticsearch",
+          "host" => "node01",
+          "user" => "test",
+          "password" => "test"
+        }
+        next LogStash::Outputs::ElasticSearch.new(settings)
+      end
 
-        it "should fail in register" do
-          expect {subject.register}.to raise_error
-        end
+      it "should fail in register" do
+        expect {subject.register}.nil?
+      end
+    end
+    context "with protocol => transport" do
+      subject do
+        require "logstash/outputs/elasticsearch"
+        settings = {
+          "protocol" => "transport",
+          "node_name" => "logstash",
+          "cluster" => "elasticsearch",
+          "host" => "node01",
+          "user" => "test",
+          "password" => "test"
+        }
+        next LogStash::Outputs::ElasticSearch.new(settings)
+      end
+
+      it "should fail in register" do
+        expect {subject.register}.to raise_error
       end
     end
   end


### PR DESCRIPTION
When specifying a username and password with the Elasticsearch node protocol this patch assumes your connecting to Elasticsearch using Shield. 

An example configuration would be:

```
output {
  elasticsearch {
    user     => "es_admin"
    password => "administrator"
    host     => "localhost"
    protocol => "node"
  }
}
```