### PR TITLE
revert index template wildcard overwriting.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -393,7 +393,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     end
     template_json = IO.read(@template).gsub(/\n/,'')
     template = LogStash::Json.load(template_json)
-    template['template'] = wildcard_substitute(@index)
     @logger.info("Using mapping template", :template => template)
     return template
   end # def get_template
@@ -611,15 +610,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     @retry_flush_mutex.synchronize {
       @retry_queue_needs_flushing.signal if @retry_queue.size >= @retry_max_items
     }
-  end
-
-  # helper function to replace placeholders
-  # in index names to wildcards
-  # example:
-  #    "logs-%{YYYY}" -> "logs-*"
-  private
-  def wildcard_substitute(name)
-    name.gsub(/%\{[^}]+\}/, "*")
   end
 
   @@plugins = Gem::Specification.find_all{|spec| spec.name =~ /logstash-output-elasticsearch-/ }

--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -583,34 +583,6 @@ describe "ship lots of events w/ default index_type and dynamic routing key usin
     end
   end
 
-  describe "wildcard substitution in index templates", :elasticsearch => true do
-    require "logstash/outputs/elasticsearch"
-
-    let(:template) { '{"template" : "not important, will be updated by :index"}' }
-
-    def settings_with_index(index)
-      return {
-        "manage_template" => true,
-        "template_overwrite" => true,
-        "protocol" => "http",
-        "host" => "localhost",
-        "index" => "#{index}"
-      }
-    end
-
-    it "should substitude placeholders" do
-      IO.stub(:read).with(anything) { template }
-      es_output = LogStash::Outputs::ElasticSearch.new(settings_with_index("index-%{YYYY}"))
-      insist { es_output.get_template['template'] } == "index-*"
-    end
-
-    it "should do nothing to an index with no placeholder" do
-      IO.stub(:read).with(anything) { template }
-      es_output = LogStash::Outputs::ElasticSearch.new(settings_with_index("index"))
-      insist { es_output.get_template['template'] } == "index"
-    end
-  end
-
   describe "index template expected behavior", :elasticsearch => true do
     ["node", "transport", "http"].each do |protocol|
       context "with protocol => #{protocol}" do


### PR DESCRIPTION
This was originally done to close https://github.com/elastic/logstash/issues/1901 and pr for this was here: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/4, but does not seem to be
clear enough and necessary. It leads to lazy behavior, and makes it
difficult to take control of the exact template pattern.