### PR TITLE
Update API support

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -257,6 +257,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # - index: indexes a document (an event from Logstash).
   # - delete: deletes a document by id
   # - create: indexes a document, fails if a document by that id already exists in the index.
+  # - update: updates a document by id
   # following action is not supported by HTTP protocol
   # - create_unless_exists: creates a document, fails if no id is provided
   #

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -65,7 +65,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   attr_reader :client
 
   include Stud::Buffer
-  RETRYABLE_CODES = [429, 503]
+  RETRYABLE_CODES = [409, 429, 503]
   SUCCESS_CODES = [200, 201]
 
   config_name "elasticsearch"
@@ -317,6 +317,14 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # Note, this is NOT a SOCKS proxy, but a plain HTTP proxy
   config :proxy
 
+  # Enable doc_as_upsert for update mode
+  # create a new document with source if document_id doesn't exists
+  config :doc_as_upsert, :validate => :boolean, :default => false
+
+  # Set upsert content for update mode
+  # create a new document with this parameter as json string if document_id doesn't exists
+  config :upsert, :validate => :string, :default => ""
+
   public
   def register
     @submit_mutex = Mutex.new
@@ -388,6 +396,13 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     }
 
     common_options.merge! setup_basic_auth()
+
+    # Update API setup
+    update_options = {
+      :upsert => @upsert,
+      :doc_as_upsert => @doc_as_upsert
+    }
+    common_options.merge! update_options
 
     client_class = case @protocol
       when "transport"
@@ -507,7 +522,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     document_id = @document_id ? event.sprintf(@document_id) : nil
     routing = @routing ? event.sprintf(@routing) : nil
-    buffer_receive([event.sprintf(@action), { :_id => document_id, :_index => index, :_type => type, :_routing => routing }, event])
+    upsert = if @upsert != ""
+                LogStash::Json.load(event.sprintf(@upsert))
+              else
+                nil
+              end
+    buffer_receive([event.sprintf(@action), { :_id => document_id, :_index => index, :_type => type, :_routing => routing, :_upsert => upsert }, event])
   end # def receive
 
   public

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -114,6 +114,7 @@ module LogStash::Outputs::Elasticsearch
               raise(LogStash::ConfigurationError, "Specifying action => 'update' without a document '_id' is not supported.")
             end
           end
+          args.delete(:_upsert)
           if source
             next [ { action => args }, source ]
           else

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -269,6 +269,7 @@ module LogStash::Outputs::Elasticsearch
           when "update"
             unless args[:_id].nil?
               request = org.elasticsearch.action.update.UpdateRequest.new(args[:_index], args[:_type], args[:_id])
+              request.routing(args[:_routing]) if args[:_routing]
               request.doc(source)
               if @options[:doc_as_upsert]
                 request.docAsUpsert(true)

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -1,0 +1,87 @@
+require_relative "../../../spec/es_spec_helper"
+
+describe "all protocols update actions", :integration => true do
+  require "logstash/outputs/elasticsearch"
+  require "elasticsearch"
+
+  def get_es_output( protocol, id = nil, upsert = nil, doc_as_upsert=nil)
+    settings = {
+      "manage_template" => true,
+      "index" => "logstash-update",
+      "template_overwrite" => true,
+      "protocol" => protocol,
+      "host" => get_host(),
+      "port" => get_port(protocol),
+      "action" => "update"
+    }
+    settings['upsert'] = upsert unless upsert.nil?
+    settings['document_id'] = id unless id.nil?
+    settings['doc_as_upsert'] = doc_as_upsert unless doc_as_upsert.nil?
+    LogStash::Outputs::ElasticSearch.new(settings)
+  end
+
+  before :each do
+    @es = get_client
+    # Delete all templates first.
+    # Clean ES of data before we start.
+    @es.indices.delete_template(:name => "*")
+    # This can fail if there are no indexes, ignore failure.
+    @es.indices.delete(:index => "*") rescue nil
+    @es.index(
+      :index => 'logstash-update',
+      :type => 'logs',
+      :id => "123",
+      :body => { :message => 'Test' }
+    )
+    @es.indices.refresh
+  end
+
+  ["node", "transport", "http"].each do |protocol|
+    context "update only with #{protocol} protocol" do
+      it "should failed without a document_id" do
+        event = LogStash::Event.new("somevalue" => 100, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0})
+        action = ["update", {:_id=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event]
+        subject = get_es_output(protocol)
+        subject.register
+        expect { subject.flush([action]) }.to raise_error
+      end
+
+      it "should not create new document" do
+        subject = get_es_output(protocol, "456")
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "sample message here"))
+        subject.buffer_flush(:final => true)
+        expect {@es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)}.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+      end
+
+      it "should update existing document" do
+        subject = get_es_output(protocol, "123")
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "updated message here"))
+        subject.buffer_flush(:final => true)
+        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        insist { r["_source"]["message"] } == 'updated message here'
+      end
+    end
+
+    context "upsert with #{protocol} protocol" do
+      it "should create new documents with upsert content" do
+        subject = get_es_output(protocol, "456", '{"message": "upsert message"}')
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "sample message here"))
+        subject.buffer_flush(:final => true)
+        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        insist { r["_source"]["message"] } == 'upsert message'
+      end
+
+      it "should create new documents with event/doc as upsert" do
+        subject = get_es_output(protocol, "456", nil, true)
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "sample message here"))
+        subject.buffer_flush(:final => true)
+        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        insist { r["_source"]["message"] } == 'sample message here'
+      end
+    end
+  end
+end

--- a/spec/unit/outputs/elasticsearch/protocol_spec.rb
+++ b/spec/unit/outputs/elasticsearch/protocol_spec.rb
@@ -6,10 +6,12 @@ describe LogStash::Outputs::Elasticsearch::Protocols::NodeClient do
   context "successful" do
     it "should map correctly" do
       index_response = org.elasticsearch.action.index.IndexResponse.new("my_index", "my_type", "my_id", 123, true)
+      update_response = org.elasticsearch.action.update.UpdateResponse.new("my_index", "my_type", "my_id", 123, false)
       delete_response = org.elasticsearch.action.delete.DeleteResponse.new("my_index", "my_type", "my_id", 123, true)
       bulk_item_response_index = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "index", index_response)
+      bulk_item_response_update = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "update", update_response)
       bulk_item_response_delete = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "delete", delete_response)
-      bulk_response = org.elasticsearch.action.bulk.BulkResponse.new([bulk_item_response_index, bulk_item_response_delete], 0)
+      bulk_response = org.elasticsearch.action.bulk.BulkResponse.new([bulk_item_response_index, bulk_item_response_update, bulk_item_response_delete], 0)
       ret = LogStash::Outputs::Elasticsearch::Protocols::NodeClient.normalize_bulk_response(bulk_response)
       insist { ret } == {"errors" => false}
     end
@@ -19,10 +21,11 @@ describe LogStash::Outputs::Elasticsearch::Protocols::NodeClient do
     it "should map correctly" do
       failure = org.elasticsearch.action.bulk.BulkItemResponse::Failure.new("my_index", "my_type", "my_id", "error message", org.elasticsearch.rest.RestStatus::BAD_REQUEST)
       bulk_item_response_index = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "index", failure)
+      bulk_item_response_update = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "update", failure)
       bulk_item_response_delete = org.elasticsearch.action.bulk.BulkItemResponse.new(32, "delete", failure)
-      bulk_response = org.elasticsearch.action.bulk.BulkResponse.new([bulk_item_response_index, bulk_item_response_delete], 0)
+      bulk_response = org.elasticsearch.action.bulk.BulkResponse.new([bulk_item_response_index, bulk_item_response_update, bulk_item_response_delete], 0)
       actual = LogStash::Outputs::Elasticsearch::Protocols::NodeClient.normalize_bulk_response(bulk_response)
-      insist { actual } == {"errors" => true, "statuses" => [400, 400]}
+      insist { actual } == {"errors" => true, "statuses" => [400, 400, 400]}
     end
   end
 end


### PR DESCRIPTION
This PR addresses issue #16 and #114 

Add the ability to update existing ES document and support of upsert (if document doesn't exists, create it)

### Configuration changes :
 * add "update" to action parameter
 * new parameter "doc_as_upsert"=> boolean : if document doesn't exists, use event as source for creating it
 * new parameter "upsert" => json_string: unused if "doc_as_upsert" is true, give control on the source for creating document if it doesn't exists. (support %{[field]} resolution)  

### Implementation questions/notes:
 * Adding retry on 409 http error code (version conflict) may introduce unwanted behaviors on other action (or not) ?
 * I am not convinced about json_string as "upsert" parameter format (need to serialize/deserialize json with use of event.sprintf), but give full control ... 

### Example with http protocol:
test.conf
```
input {
  file {
    path => "/logs/test.log"
    codec => "json"
    start_position => "beginning"
  }
}

output {
  if [use_case] == "doc_upsert" {
    elasticsearch {
      host => "elasticsearch"
      protocol => "http"
      action => "update"
      document_id => "%{[uid]}"
      doc_as_upsert => true
    }    
  } else if [use_case] == "doc_static_upsert" {
    elasticsearch {
      host => "elasticsearch"
      protocol => "http"
      action => "update"
      document_id => "%{[uid]}"
      upsert => '{"static_field": "demo"}'
    }        
  } else if [use_case] == "doc_dynamic_upsert" {
    elasticsearch {
      host => "elasticsearch"
      protocol => "http"
      action => "update"
      document_id => "%{[uid]}"
      upsert => '{"use_case": "%{[use_case]}", "dynamic": { "fieldC": "%{[dynamic_field][fieldC]}"}}'
    }        
  } else {
    elasticsearch {
      host => "elasticsearch"
      protocol => "http"
    }    
  }
}
```
test.log
```
{ "use_case": "doc_upsert", "uid": "1", "fieldA": "abcd" }
{ "use_case": "doc_upsert", "uid": "1", "fieldB": "cdef" }
{ "use_case": "doc_static_upsert", "uid": "2", "fieldA": "abcd" }
{ "use_case": "doc_static_upsert", "uid": "2", "fieldB": "cdef" }
{ "use_case": "doc_dynamic_upsert", "uid": "3", "fieldA": "abcd", "dynamic_field": {"fieldC": "ghij"} }
{ "use_case": "placebo"}
```

