### PR TITLE
set a default host for transport protocol if none is specified

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -291,7 +291,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       end
     end
 
-    if @host.nil? && @protocol == "http"
+    if @host.nil? && @protocol != "node" # node can use zen discovery
       @logger.info("No 'host' set in elasticsearch output. Defaulting to localhost")
       @host = ["localhost"]
     end

--- a/spec/outputs/elasticsearch_spec.rb
+++ b/spec/outputs/elasticsearch_spec.rb
@@ -960,6 +960,30 @@ describe "ship lots of events w/ default index_type and dynamic routing key usin
 
   describe "transport protocol" do
 
+    context "host not configured" do
+      subject do
+        require "logstash/outputs/elasticsearch"
+        settings = {
+          "protocol" => "transport",
+          "node_name" => "mynode"
+        }
+        next LogStash::Outputs::ElasticSearch.new(settings)
+      end
+
+      it "should set host to localhost" do
+        expect(LogStash::Outputs::Elasticsearch::Protocols::TransportClient).to receive(:new).with({
+          :host => "localhost",
+          :port => "9300-9305",
+          :protocol => "transport",
+          :client_settings => {
+            "client.transport.sniff" => false,
+            "node.name" => "mynode"
+          }
+        })
+        subject.register
+      end
+    end
+
     context "sniffing => true" do
 
       subject do


### PR DESCRIPTION
Not setting a `host` when using transport protocol will make logstash loop indefinitely with a cryptic exception:

```
{:timestamp=>"2015-04-24T12:33:02.866000+0200", :message=>"Failed to flush outgoing items", :outgoing_count=>1, :exception=>#<NoMethodError: undefined method 
`[]' for nil:NilClass>, :backtrace=>["/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch-0.1.18-java/lib/logstash/outputs/elasticsearc 
h.rb:440:in `flush'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:219:in `buffer_flush'", "org/jruby/RubyHash.java:1341:in `ea 
ch'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:216:in `buffer_flush'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0 
.19/lib/stud/buffer.rb:193:in `buffer_flush'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.19/lib/stud/buffer.rb:159:in `buffer_receive'", "/opt/log 
stash/vendor/bundle/jruby/1.9/gems/logstash-output-elasticsearch-0.1.18-java/lib/logstash/outputs/elasticsearch.rb:402:in `receive'", "/opt/logstash/lib/logs 
tash/outputs/base.rb:88:in `handle'", "(eval):23:in `initialize'", "org/jruby/RubyProc.java:271:in `call'", "/opt/logstash/lib/logstash/pipeline.rb:279:in `o 
utput'", "/opt/logstash/lib/logstash/pipeline.rb:235:in `outputworker'", "/opt/logstash/lib/logstash/pipeline.rb:163:in `start_outputs'"], :level=>:warn}
```