### PR TITLE
add descriptive text about why a field is deprecated

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -51,7 +51,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # similar events to the same 'type'. String expansion `%{foo}` works here.
   # 
   # Deprecated in favor of `document_type` field.
-  config :index_type, :validate => :string, :deprecated => true
+  config :index_type, :validate => :string, :deprecated => "Please use the 'document_type' setting instead. It has the same effect, but is more appropriately named."
 
   # The document type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.


### PR DESCRIPTION
update to: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/105

in response to: https://github.com/logstash-plugins/logstash-output-elasticsearch/commit/fa80d95dea7e30682920d861e4c44d673892b20e#commitcomment-11036062