### PR TITLE
Add missing action values in documentation

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -191,7 +191,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # `protocol` on non-java rubies is "http"
   config :protocol, :validate => [ "node", "transport", "http" ]
 
-  # The Elasticsearch action to perform. Valid actions are: `index`, `delete`.
+  # The Elasticsearch action to perform. Valid actions are: `index`, `delete`,
+  # `create`, `create_unless_exists`
   #
   # Use of this setting *REQUIRES* you also configure the `document_id` setting
   # because `delete` actions all require a document id.


### PR DESCRIPTION
These seemed to be missing (despite being documented just below).