### PR TITLE
disable timeouts when using http protocol

### DIFF
--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -65,6 +65,8 @@ module LogStash::Outputs::Elasticsearch
 
         client_options = {
           :host => [uri],
+          :socket_timeout => 0,  # do not timeout socket reads
+          :request_timeout => 0, # and requests
           :transport_options => options[:client_settings]
         }
         client_options[:transport_class] = ::Elasticsearch::Transport::Transport::HTTP::Manticore

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'concurrent-ruby'
-  s.add_runtime_dependency 'elasticsearch', ['>= 1.0.6', '~> 1.0']
+  s.add_runtime_dependency 'elasticsearch', ['>= 1.0.9', '~> 1.0']
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'


### PR DESCRIPTION
"no timeouts" has been the standard behaviour in previous versions, but when manticore was introduced as the http library by default, it brought its default timeout settings along.

This patch forces manticore to disable timeouts thus returning to the previous behaviour.

fixes #103 