### PR TITLE
NodeClient does not get cleaned up during tests

### DIFF
--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -148,7 +148,7 @@ module LogStash::Outputs::Elasticsearch
         @settings = org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder
         if options[:host]
           @settings.put("discovery.zen.ping.multicast.enabled", false)
-          @settings.put("discovery.zen.ping.unicast.hosts", hosts(options))
+          @settings.put("discovery.zen.ping.unicast.hosts", NodeClient.hosts(options))
         end
 
         @settings.put("node.client", true)
@@ -163,7 +163,7 @@ module LogStash::Outputs::Elasticsearch
         return @settings
       end
 
-      def hosts(options)
+      def self.hosts(options)
         # http://www.elasticsearch.org/guide/reference/modules/discovery/zen/
         result = Array.new
         if options[:host].class == Array
@@ -198,7 +198,7 @@ module LogStash::Outputs::Elasticsearch
           end
         end
         result.flatten.join(",")
-      end # def hosts
+      end # def self.hosts
 
       def build_client(options)
         nodebuilder = org.elasticsearch.node.NodeBuilder.nodeBuilder

--- a/spec/integration/outputs/elasticsearch/node_spec.rb
+++ b/spec/integration/outputs/elasticsearch/node_spec.rb
@@ -5,7 +5,7 @@ describe "elasticsearch node client", :integration => true do
   # Test ElasticSearch Node Client
   # Reference: http://www.elasticsearch.org/guide/reference/modules/discovery/zen/
   
-  subject { LogStash::Outputs::Elasticsearch::Protocols::NodeClient.new(:host => get_host()) }
+  subject { LogStash::Outputs::Elasticsearch::Protocols::NodeClient }
 
   it "should support hosts in both string and array" do
     # Because we defined *hosts* method in NodeClient as private,


### PR DESCRIPTION
during the `node_spec.rb` tests, NodeClient does not get
cleaned-up correctly. Since we are just testing a utility
function within the class, I have changed the `#hosts` method
to be a class variable (still private). This should now let
`bundle exec rspec --tag integration` terminate.