### PR TITLE
add action update

### DIFF
--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -233,6 +233,24 @@ module LogStash::Outputs::Elasticsearch
             request.id(args[:_id]) if args[:_id]
             request.routing(args[:_routing]) if args[:_routing]
             request.source(source)
+          when "update"
+            unless args[:_id].nil?
+              request = org.elasticsearch.action.update.UpdateRequest.new(args[:_index], args[:_type], args[:_id])
+              request.id(args[:_id])
+              request.routing(args[:_routing]) if args[:_routing]
+              request.retryOnConflict(Integer(args[:_retry_on_conflict])) if args[:_retry_on_conflict]
+              if args[:_script]
+                request.script(args[:_script])
+                if args[:_scriptParams]
+                  request.addScriptParam(args[:_scriptParams]['label'], args[:_scriptParams]['params'])
+                end
+              else
+                request.doc(source)
+                request.docAsUpsert(true)
+              end
+            else
+              raise(LogStash::ConfigurationError, "Specifying action => 'udpate' without a document '_id' is not supported.")
+            end
           when "delete"
             request = org.elasticsearch.action.delete.DeleteRequest.new(args[:_index])
             request.id(args[:_id])
@@ -255,7 +273,6 @@ module LogStash::Outputs::Elasticsearch
             end
           else
             raise(LogStash::ConfigurationError, "action => '#{action_name}' is not currently supported.")
-          #when "update"
         end # case action
 
         request.type(args[:_type]) if args[:_type]


### PR DESCRIPTION
for the moment we can only made index/create/delete action in output elasticsearch plugin! but in my current project i need to udpate some documents so i use the UpdateRequest api.

and example to the document that i send to use the doc : 
{"document_id":"2754","action":"update","retry_on_conflict":3,"uuid":"33bda5p","co":27,"vdu":[{"du":33},{"du":34}]}

or for use the script : 
{"document_id":"2754","script":"ctx._source.vdu += duration","scriptParams": {"label":"duration", "params" :[ {"du":69},{"du":173} ]},"action":"update","retry_on_conflict":3}

https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-action