### PR TITLE
[Test] Facets are deprecated in favor of Aggregations.

### DIFF
--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -84,8 +84,8 @@ describe "index template expected behavior", :integration => true do
       end
 
       it "should index stopwords like 'at' " do
-        results = @es.search(:body => { "facets" => { "t" => { "terms" => { "field" => "country" } } } })["facets"]["t"]
-        terms = results["terms"].collect { |t| t["term"] }
+        results = @es.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country" } } } })["aggregations"]["my_agg"]
+        terms = results["buckets"].collect { |b| b["key"] }
 
         insist { terms }.include?("us")
 


### PR DESCRIPTION
Elasticsearch 2.0 will not support facets anymore, this is
an update to the tests to move to using aggregations