### PR TITLE
Forward proxy support for ES servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.3
+ - Add HTTP proxy support 
+
 ## 1.0.2
  - Upgrade Manticore HTTP Client
 

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -68,7 +68,8 @@ module LogStash::Outputs::Elasticsearch
           :ssl => options[:client_settings][:ssl],
           :transport_options => {  # manticore settings so we
             :socket_timeout => 0,  # do not timeout socket reads
-            :request_timeout => 0  # and requests
+            :request_timeout => 0,  # and requests
+            :proxy => options[:client_settings][:proxy]
           },
           :transport_class => ::Elasticsearch::Transport::Transport::HTTP::Manticore
         }

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '1.0.2'
+  s.version         = '1.0.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"

--- a/spec/unit/outputs/elasticsearch_proxy_spec.rb
+++ b/spec/unit/outputs/elasticsearch_proxy_spec.rb
@@ -1,0 +1,59 @@
+require_relative "../../../spec/es_spec_helper"
+require 'stud/temporary'
+require 'elasticsearch'
+require "logstash/outputs/elasticsearch"
+
+describe "Proxy option" do
+  let(:settings) {
+    {
+      "protocol" => "http",
+      "host" => "node01",
+      "proxy" => proxy
+    }
+  }
+  subject {
+    LogStash::Outputs::ElasticSearch.new(settings)
+  }
+
+  before do
+    allow(::Elasticsearch::Client).to receive(:new).with(any_args)
+  end
+
+  describe "valid configs" do
+    before do
+      subject.register
+    end
+
+    context "when specified as a string" do
+      let(:proxy) { "http://127.0.0.1:1234" }
+
+      it "should set the proxy to the exact value" do
+        expect(::Elasticsearch::Client).to have_received(:new) do |options|
+          expect(options[:transport_options][:proxy]).to eql(proxy)
+        end
+      end
+    end
+
+    context "when specified as a hash" do
+      let(:proxy) { {"host" => "127.0.0.1", "protocol" => "http"} }
+
+      it "should pass through the proxy values as symbols" do
+        expected = {:host => proxy["host"], :protocol => proxy["protocol"]}
+        expect(::Elasticsearch::Client).to have_received(:new) do |options|
+          expect(options[:transport_options][:proxy]).to eql(expected)
+        end
+      end
+    end
+  end
+
+  describe "invalid configs" do
+    let(:proxy) { ["bad", "stuff"] }
+
+    it "should have raised an exception" do
+      expect {
+        subject.register
+      }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+end


### PR DESCRIPTION
This adds support for http forward proxies. Tested with the following config:

Logstash:
```
input {
  stdin {}
}

output {
  elasticsearch {
    protocol => http
    proxy => "http://52.2.157.171:80"
    host => "127.0.0.1"`
  }
}
```

nginx
```
    server {
        listen       80;

        location / {
            resolver 8.8.8.8;
            proxy_pass http://$http_host$uri$is_args$args;
        }

        error_page   500 502 503 504  /50x.html;
        location = /50x.html {
            root   html;
  }
```