### PR TITLE
Clarify default behaviour of 'document_type' when no value is explicitly set

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -85,7 +85,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # The document type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.
-  # When no value is provided, the event 'type' in corresponding Logstash input will be used.
+  # if a 'type' has been set for the related 'input' definition then its value will be used to 'document_type',
+  # otherwise 'document_type' will be assigned the default value of 'logs'
   config :document_type, :validate => :string
 
   # Starting in Logstash 1.3 (unless you set option `manage_template` to false)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -85,8 +85,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # The document type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.
-  # When no value is provided, the event 'type' in corresponding Logstash input will be used.
-  # If also no explicit 'type' has been set within the input, then the default value 'logs' will be used
+  # Unless you set 'document_type', the event 'type' will be used if it exists 
+  # otherwise the document type  will be assigned the value of 'logs'
   config :document_type, :validate => :string
 
   # Starting in Logstash 1.3 (unless you set option `manage_template` to false)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -85,8 +85,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # The document type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.
-  # if a 'type' has been set for the related 'input' definition then its value will be used to 'document_type',
-  # otherwise 'document_type' will be assigned the default value of 'logs'
+  # When no value is provided, the event 'type' in corresponding Logstash input will be used.
+  # If also no explicit 'type' has been set within the input, then the default value 'logs' will be used
   config :document_type, :validate => :string
 
   # Starting in Logstash 1.3 (unless you set option `manage_template` to false)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -85,6 +85,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # The document type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.
+  # When no value is provided, the event 'type' in corresponding Logstash input will be used.
   config :document_type, :validate => :string
 
   # Starting in Logstash 1.3 (unless you set option `manage_template` to false)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -86,7 +86,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # The document type to write events to. Generally you should try to write only
   # similar events to the same 'type'. String expansion `%{foo}` works here.
   # Unless you set 'document_type', the event 'type' will be used if it exists 
-  # otherwise the document type  will be assigned the value of 'logs'
+  # otherwise the document type will be assigned the value of 'logs'
   config :document_type, :validate => :string
 
   # Starting in Logstash 1.3 (unless you set option `manage_template` to false)


### PR DESCRIPTION
Clarify behaviour of document_type when no value is provided via config file. Logstash input type value will be used.