### PR TITLE
Add support and integration tests for document versions.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -326,6 +326,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # create a new document with this parameter as json string if document_id doesn't exists
   config :upsert, :validate => :string, :default => ""
 
+  # The version for the event, useful when using an external version scheme
+  config :version, :validate => :string
+
+  # The version type for the event, see the versioning section in the https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html[Index API Documention]
+  config :version_type, :validate => :string
+
   public
   def register
     @submit_mutex = Mutex.new
@@ -523,7 +529,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       :_id => @document_id ? event.sprintf(@document_id) : nil,
       :_index => event.sprintf(@index),
       :_type => type,
-      :_routing => @routing ? event.sprintf(@routing) : nil
+      :_routing => @routing ? event.sprintf(@routing) : nil,
+      :_version => @version ? event.sprintf(@version) : nil,
+      :_version_type => @version_type ? event.sprintf(@version_type) : nil
     }
     
     params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @action == 'update' && @upsert != ""

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -115,7 +115,7 @@ module LogStash::Outputs::Elasticsearch
             end
           end
           args.delete(:_upsert)
-          if source
+          if source and action != 'delete'
             next [ { action => args }, source ]
           else
             next { action => args }
@@ -246,15 +246,21 @@ module LogStash::Outputs::Elasticsearch
             request = org.elasticsearch.action.index.IndexRequest.new(args[:_index])
             request.id(args[:_id]) if args[:_id]
             request.routing(args[:_routing]) if args[:_routing]
+            request.version(args[:_version].to_i) if args[:_version]
+            request.versionType(org.elasticsearch.index.VersionType.fromString(args[:_version_type])) if args[:_version_type]
             request.source(source)
           when "delete"
             request = org.elasticsearch.action.delete.DeleteRequest.new(args[:_index])
             request.id(args[:_id])
             request.routing(args[:_routing]) if args[:_routing]
+            request.version(args[:_version].to_i) if args[:_version]
+            request.versionType(org.elasticsearch.index.VersionType.fromString(args[:_version_type])) if args[:_version_type]
           when "create"
             request = org.elasticsearch.action.index.IndexRequest.new(args[:_index])
             request.id(args[:_id]) if args[:_id]
             request.routing(args[:_routing]) if args[:_routing]
+            request.version(args[:_version].to_i) if args[:_version]
+            request.versionType(org.elasticsearch.index.VersionType.fromString(args[:_version_type])) if args[:_version_type]
             request.source(source)
             request.opType("create")
           when "create_unless_exists"
@@ -262,6 +268,8 @@ module LogStash::Outputs::Elasticsearch
               request = org.elasticsearch.action.index.IndexRequest.new(args[:_index])
               request.id(args[:_id])
               request.routing(args[:_routing]) if args[:_routing]
+              request.version(args[:_version].to_i) if args[:_version]
+              request.versionType(org.elasticsearch.index.VersionType.fromString(args[:_version_type])) if args[:_version_type]
               request.source(source)
               request.opType("create")
             else
@@ -271,6 +279,8 @@ module LogStash::Outputs::Elasticsearch
             unless args[:_id].nil?
               request = org.elasticsearch.action.update.UpdateRequest.new(args[:_index], args[:_type], args[:_id])
               request.routing(args[:_routing]) if args[:_routing]
+              request.version(args[:_version].to_i) if args[:_version]
+              request.versionType(org.elasticsearch.index.VersionType.fromString(args[:_version_type])) if args[:_version_type]
               request.doc(source)
               if @options[:doc_as_upsert]
                 request.docAsUpsert(true)

--- a/spec/integration/outputs/version_spec.rb
+++ b/spec/integration/outputs/version_spec.rb
@@ -1,0 +1,62 @@
+require_relative "../../../spec/es_spec_helper"
+
+describe "all actions with external versioning", :integration => true do
+  require "logstash/outputs/elasticsearch"
+  require "elasticsearch"
+
+  def get_es_output( protocol, action = "index", id = nil, version = nil)
+    settings = {
+      "manage_template" => true,
+      "index" => "logstash-version",
+      "template_overwrite" => true,
+      "protocol" => protocol,
+      "host" => get_host(),
+      "port" => get_port(protocol),
+      "action" => action
+    }
+    settings['document_id'] = id unless id.nil?
+    settings['version'] = version unless version.nil?
+    settings['version_type'] = "external" unless version.nil?
+    LogStash::Outputs::ElasticSearch.new(settings)
+  end
+
+  before :each do
+    @es = get_client
+    # Delete all templates first.
+    # Clean ES of data before we start.
+    @es.indices.delete_template(:name => "*")
+    # This can fail if there are no indexes, ignore failure.
+    @es.indices.delete(:index => "*") rescue nil
+    @es.index(
+      :index => 'logstash-version',
+      :type => 'logs',
+      :id => "123",
+      :verison => "123",
+      :version_type => "external",
+      :body => { :message => 'Test' }
+    )
+    @es.indices.refresh
+  end
+
+  ["node", "transport", "http"].each do |protocol|
+    ["index", "delete", "update"].each do |action|
+      context "#{action} action with #{protocol} protocol" do
+        it "should failed with the current version" do
+          event = LogStash::Event.new("message" => "Updated test")
+          action = ["index", {:_id => "123", :version => "123", :version_type => "external", :_index=>"logstash-version", :_type=>"logs"}, event]
+          subject = get_es_output(protocol, action, "123", "123")
+          subject.register
+          expect { subject.flush([action]) }.to raise_error
+        end
+
+        it "should update with a newer version" do
+          event = LogStash::Event.new("message" => "Updated test")
+          action = ["index", {:_id => "123", :version => "124", :version_type => "external", :_index=>"logstash-version", :_type=>"logs"}, event]
+          subject = get_es_output(protocol, action, "123", "124")
+          subject.register
+          expect { subject.flush([action]) }.to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for external document versioning described here: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#index-versioning.