### PR TITLE
Add scripted update for HTTP protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 before_install:
   - curl -s https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.0.0/elasticsearch-2.0.0.tar.gz  > elasticsearch.tar.gz
-  - tar -xzf elasticsearch.tar.gz
-  - cd elasticsearch*/ && bin/elasticsearch &
+  - mkdir elasticsearch && tar -xzf elasticsearch.tar.gz --strip-components=1 -C ./elasticsearch/.
+  - ln -sn ../../spec/fixtures/scripts elasticsearch/config/.
+  - cd elasticsearch && bin/elasticsearch -Des.script.inline=on -Des.script.indexed=on &
   - sleep 10 && curl http://localhost:9200
 language: ruby
 cache: bundler

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -132,7 +132,10 @@ module LogStash; module Outputs; class ElasticSearch;
       }
 
       params[:parent] = event.sprintf(@parent) if @parent
-      params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @action == 'update' && @upsert != ""
+      if @action == 'update'
+        params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @upsert != ""
+        params[:_script] = event.sprintf(@script) if @script != ""
+      end
       params
     end
 

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -106,7 +106,16 @@ module LogStash; module Outputs; class ElasticSearch
       mod.config :max_retries, :validate => :number, :default => 3
 
       # Set script name for scripted update mode
-      mod.config :script, :validate => :string, :default => ""
+      config :script, :validate => :string, :default => ""
+
+      # Define the type of script referenced by "script" variable
+      #  inline : "script" contains inline script
+      #  indexed : "script" contains the name of script directly indexed in elasticsearch
+      #  file    : "script" contains the name of script stored in elasticseach's config directory
+      mod.config :script_type, :validate => ["inline", 'indexed', "file"]
+
+      # Set the language of the used script
+      mod.config :script_lang, :validate => :string, :default => ""
 
       # Set variable name passed to script (scripted update)
       mod.config :script_var_name, :validate => :string, :default => "event"

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -105,6 +105,15 @@ module LogStash; module Outputs; class ElasticSearch
       # DEPRECATED This setting no longer does anything. It will be marked obsolete in a future version.
       mod.config :max_retries, :validate => :number, :default => 3
 
+      # Set script name for scripted update mode
+      mod.config :script, :validate => :string, :default => ""
+
+      # Set variable name passed to script (scripted update)
+      mod.config :script_var_name, :validate => :string, :default => "event"
+
+      # if enabled, script is in charge of creating non-existent document (scripted update)
+      mod.config :scripted_upsert, :validate => :boolean, :default => false
+
       # Set max interval between bulk retries.
       mod.config :retry_max_interval, :validate => :number, :default => 2
 

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -106,7 +106,7 @@ module LogStash; module Outputs; class ElasticSearch
       mod.config :max_retries, :validate => :number, :default => 3
 
       # Set script name for scripted update mode
-      config :script, :validate => :string, :default => ""
+      mod.config :script, :validate => :string, :default => ""
 
       # Define the type of script referenced by "script" variable
       #  inline : "script" contains inline script

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -112,7 +112,7 @@ module LogStash; module Outputs; class ElasticSearch
       #  inline : "script" contains inline script
       #  indexed : "script" contains the name of script directly indexed in elasticsearch
       #  file    : "script" contains the name of script stored in elasticseach's config directory
-      mod.config :script_type, :validate => ["inline", 'indexed', "file"]
+      mod.config :script_type, :validate => ["inline", 'indexed', "file"], :default => ["inline"]
 
       # Set the language of the used script
       mod.config :script_lang, :validate => :string, :default => ""

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -53,7 +53,12 @@ module LogStash; module Outputs; class ElasticSearch;
               else
                 source['upsert'] = args.delete(:_upsert) if args[:_upsert]
               end
-              source['script'] = args.delete(:_script)
+              if @options[:script_type] == "indexed"
+                source['script_id'] = args.delete(:_script)
+              else
+                source['script'] = args.delete(:_script)
+              end
+              source['script_lang'] = @options[:script_lang] if @options[:script_lang] != ''
             else
               source = { 'doc' => source }
               if @options[:doc_as_upsert]

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -149,36 +149,33 @@ module LogStash; module Outputs; class ElasticSearch;
 
     # Build a bulk item for an elasticsearch update action
     def update_action_builder(args, source)
-      if args[:_id]
-        if args[:_script]
-          # Use the event as a hash from your script with variable name defined by script_var_name (default: "event")
-          # Ex: event["@timestamp"]
-          source = { 'script' => {'params' => { @options[:script_var_name] => source }} }
-          if @options[:scripted_upsert]
-            source['scripted_upsert'] = true
-            source['upsert'] = {}
-          else
-            source['upsert'] = args.delete(:_upsert) if args[:_upsert]
-          end    
-          case @options[:script_type]
-          when "indexed"
-            source['script']['id'] = args.delete(:_script)
-          when "file"               
-            source['script']['file'] = args.delete(:_script)
-          when "inline"
-            source['script']['inline'] = args.delete(:_script)
-          end
-          source['script']['lang'] = @options[:script_lang] if @options[:script_lang] != ''
+      if args[:_script]
+        # Use the event as a hash from your script with variable name defined
+        # by script_var_name (default: "event")
+        # Ex: event["@timestamp"]
+        source = { 'script' => {'params' => { @options[:script_var_name] => source }} }
+        if @options[:scripted_upsert]
+          source['scripted_upsert'] = true
+          source['upsert'] = {}
         else
-          source = { 'doc' => source }
-          if @options[:doc_as_upsert]
-            source['doc_as_upsert'] = true
-          else
-            source['upsert'] = args.delete(:_upsert) if args[:_upsert]
-          end
+          source['upsert'] = args.delete(:_upsert) if args[:_upsert]
         end
+        case @options[:script_type]
+        when 'indexed'
+          source['script']['id'] = args.delete(:_script)
+        when 'file'
+          source['script']['file'] = args.delete(:_script)
+        when 'inline'
+          source['script']['inline'] = args.delete(:_script)
+        end
+        source['script']['lang'] = @options[:script_lang] if @options[:script_lang] != ''
       else
-        raise(LogStash::ConfigurationError, "Specifying action => 'update' without a document '_id' is not supported.")
+        source = { 'doc' => source }
+        if @options[:doc_as_upsert]
+          source['doc_as_upsert'] = true
+        else
+          source['upsert'] = args.delete(:_upsert) if args[:_upsert]
+        end
       end
       [args, source]
     end

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -18,10 +18,16 @@ module LogStash; module Outputs; class ElasticSearch;
       common_options.merge! setup_basic_auth(logger, params)
 
       # Update API setup
+      raise( Logstash::ConfigurationError,
+        "doc_as_upsert and scripted_upsert are mutually exclusive."
+      ) if params["doc_as_upsert"] and params["scripted_upsert"]
+
+      # Update API setup
       update_options = {
-        :upsert => params["upsert"],
         :doc_as_upsert => params["doc_as_upsert"],
         :script_var_name => params["script_var_name"],
+        :script_type => params["script_type"],
+        :script_lang => params["script_lang"],
         :scripted_upsert => params["scripted_upsert"]
       }
       common_options.merge! update_options if params["action"] == 'update'

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -22,6 +22,11 @@ module LogStash; module Outputs; class ElasticSearch;
         "doc_as_upsert and scripted_upsert are mutually exclusive."
       ) if params["doc_as_upsert"] and params["scripted_upsert"]
 
+      raise(
+        LogStash::ConfigurationError,
+        "Specifying action => 'update' needs a document_id."
+      ) if params['action'] == 'update' and params.fetch('document_id', '') == ''
+
       # Update API setup
       update_options = {
         :doc_as_upsert => params["doc_as_upsert"],

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -20,7 +20,9 @@ module LogStash; module Outputs; class ElasticSearch;
       # Update API setup
       update_options = {
         :upsert => params["upsert"],
-        :doc_as_upsert => params["doc_as_upsert"]
+        :doc_as_upsert => params["doc_as_upsert"],
+        :script_var_name => params["script_var_name"],
+        :scripted_upsert => params["scripted_upsert"]
       }
       common_options.merge! update_options if params["action"] == 'update'
 

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
       rescue Docker::Error::NotFoundError
         scriptDir = File.expand_path File.dirname(__FILE__) + '/fixtures/scripts'
         Longshoreman.new("#{CONTAINER_IMAGE}:#{CONTAINER_TAG}", CONTAINER_NAME, {
-          'Cmd' => [ "-Des.script.inline=on" ],
+          'Cmd' => [ "-Des.script.inline=on", "-Des.script.indexed=on" ],
           'HostConfig' => {
             'Binds' => ["#{scriptDir}:/usr/share/elasticsearch/config/scripts"],
             'PublishAllPorts' => true

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -8,7 +8,7 @@ require "logstash/outputs/elasticsearch"
 
 CONTAINER_NAME = "logstash-output-elasticsearch-#{rand(999).to_s}"
 CONTAINER_IMAGE = "elasticsearch"
-CONTAINER_TAG = "1.6"
+CONTAINER_TAG = "2.0"
 
 DOCKER_INTEGRATION = ENV["DOCKER_INTEGRATION"]
 

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -45,7 +45,13 @@ RSpec.configure do |config|
         ls = Longshoreman::new
         ls.container.get(CONTAINER_NAME)
       rescue Docker::Error::NotFoundError
-        Longshoreman.new("#{CONTAINER_IMAGE}:#{CONTAINER_TAG}", CONTAINER_NAME)
+        scriptDir = File.expand_path File.dirname(__FILE__) + '/fixtures/scripts'
+        Longshoreman.new("#{CONTAINER_IMAGE}:#{CONTAINER_TAG}", CONTAINER_NAME, {
+          'HostConfig' => {
+            'Binds' => ["#{scriptDir}:/usr/share/elasticsearch/config/scripts"],
+            'PublishAllPorts' => true
+          }
+        })
         # TODO(talevy): verify ES is running instead of static timeout
         sleep 10
       end

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |config|
       rescue Docker::Error::NotFoundError
         scriptDir = File.expand_path File.dirname(__FILE__) + '/fixtures/scripts'
         Longshoreman.new("#{CONTAINER_IMAGE}:#{CONTAINER_TAG}", CONTAINER_NAME, {
+          'Cmd' => [ "-Des.script.inline=on" ],
           'HostConfig' => {
             'Binds' => ["#{scriptDir}:/usr/share/elasticsearch/config/scripts"],
             'PublishAllPorts' => true

--- a/spec/fixtures/scripts/scripted_update.groovy
+++ b/spec/fixtures/scripts/scripted_update.groovy
@@ -1,0 +1,2 @@
+ctx._source.counter += event["count"]
+

--- a/spec/fixtures/scripts/scripted_update_nested.groovy
+++ b/spec/fixtures/scripts/scripted_update_nested.groovy
@@ -1,0 +1,2 @@
+ctx._source.counter += event["data"]["count"]
+

--- a/spec/fixtures/scripts/scripted_upsert.groovy
+++ b/spec/fixtures/scripts/scripted_upsert.groovy
@@ -1,0 +1,2 @@
+ctx._source.counter = event["counter"]
+

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -32,11 +32,8 @@ describe "Update actions", :integration => true do
   end
 
   it "should fail without a document_id" do
-    subject = get_es_output()
-    subject.register
-    subject.receive(LogStash::Event.new("somevalue" => 100))
-    expect(subject.logger).to receive(:warn).at_least(1).with(anything,hash_including(:class => 'LogStash::ConfigurationError'))
-    subject.flush
+    subject = get_es_output
+    expect { subject.register }.to raise_error(LogStash::ConfigurationError)
   end
 
   context "when update only" do

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -32,11 +32,11 @@ describe "Update actions", :integration => true do
   end
 
   it "should fail without a document_id" do
-    event = LogStash::Event.new("somevalue" => 100, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0})
-    action = ["update", {:_id=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event]
-    subject = get_es_output
+    subject = get_es_output()
     subject.register
-    expect { subject.flush([action]) }.to raise_error
+    subject.receive(LogStash::Event.new("somevalue" => 100))
+    expect(subject.logger).to receive(:warn).at_least(1).with(anything,hash_including(:class => 'LogStash::ConfigurationError'))
+    subject.flush
   end
 
   context "when update only" do
@@ -63,7 +63,7 @@ describe "Update actions", :integration => true do
       subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update' })
       subject.register
       subject.receive(LogStash::Event.new("count" => 2))
-      subject.flush(:final => true)
+      subject.flush
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
       insist { r["_source"]["counter"] } == 3
     end
@@ -72,7 +72,7 @@ describe "Update actions", :integration => true do
       subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update_nested' })
       subject.register
       subject.receive(LogStash::Event.new("data" => { "count" => 3 }))
-      subject.flush(:final => true)
+      subject.flush
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
       insist { r["_source"]["counter"] } == 4
     end
@@ -86,7 +86,7 @@ describe "Update actions", :integration => true do
       })
       subject.register
       subject.receive(LogStash::Event.new("count" => 3 ))
-      subject.flush(:final => true)
+      subject.flush
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
       insist { r["_source"]["counter"] } == 4
     end
@@ -97,7 +97,7 @@ describe "Update actions", :integration => true do
       subject = get_es_output({ 'document_id' => "456", 'upsert' => '{"message": "upsert message"}' })
       subject.register
       subject.receive(LogStash::Event.new("message" => "sample message here"))
-      subject.flush(:final => true)
+      subject.flush
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
       insist { r["_source"]["message"] } == 'upsert message'
     end
@@ -106,7 +106,7 @@ describe "Update actions", :integration => true do
       subject = get_es_output({ 'document_id' => "456", 'doc_as_upsert' => true })
       subject.register
       subject.receive(LogStash::Event.new("message" => "sample message here"))
-      subject.flush(:final => true)
+      subject.flush
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
       insist { r["_source"]["message"] } == 'sample message here'
     end
@@ -116,7 +116,7 @@ describe "Update actions", :integration => true do
         subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_update', 'upsert' => '{"message": "upsert message"}' })
         subject.register
         subject.receive(LogStash::Event.new("message" => "sample message here"))
-        subject.flush(:final => true)
+        subject.flush
         r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'upsert message'
       end
@@ -125,7 +125,7 @@ describe "Update actions", :integration => true do
         subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_upsert', 'scripted_upsert' => true })
         subject.register
         subject.receive(LogStash::Event.new("counter" => 1))
-        subject.flush(:final => true)
+        subject.flush
         r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
         insist { r["_source"]["counter"] } == 1
       end

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -60,7 +60,7 @@ describe "Update actions", :integration => true do
     
   context "when using script" do
     it "should increment a counter with event/doc 'count' variable" do
-      subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update' })
+      subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update', 'script_type' => 'file' })
       subject.register
       subject.receive(LogStash::Event.new("count" => 2))
       subject.flush
@@ -69,7 +69,7 @@ describe "Update actions", :integration => true do
     end
 
     it "should increment a counter with event/doc '[data][count]' nested variable" do
-      subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update_nested' })
+      subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update_nested', 'script_type' => 'file' })
       subject.register
       subject.receive(LogStash::Event.new("data" => { "count" => 3 }))
       subject.flush
@@ -113,7 +113,7 @@ describe "Update actions", :integration => true do
 
     context "when using script" do
       it "should create new documents with upsert content" do
-        subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_update', 'upsert' => '{"message": "upsert message"}' })
+        subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_update', 'upsert' => '{"message": "upsert message"}', 'script_type' => 'file' })
         subject.register
         subject.receive(LogStash::Event.new("message" => "sample message here"))
         subject.flush
@@ -122,7 +122,7 @@ describe "Update actions", :integration => true do
       end
 
       it "should create new documents with event/doc as script params" do
-        subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_upsert', 'scripted_upsert' => true })
+        subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_upsert', 'scripted_upsert' => true, 'script_type' => 'file' })
         subject.register
         subject.receive(LogStash::Event.new("counter" => 1))
         subject.flush


### PR DESCRIPTION
This PR add scripting support to "update" action for HTTP protocol only  (Issues #114 and #117)

For using it, set the new parameter 'script' to the name of your script. Events will be passed as script params and you can access it from your script with variable name "event" (you can change it with script_var_name parameter) of hash type.

Upsert is supported, but you can set the new paremeter scripted_upsert to "true" if you want your script to create non-existent document.

Exemple:
logstash.conf
```ruby
output {
  elasticsearch {
      protocol => "http"
      host => "localhost"
      action => "update"
      document_id => "%{id}"
      script => "update_my_doc"
      script_var_name => "event"
  }
}
```
groovy script to put in your elasticsearch root dir : config/scripts/update_my_doc.groovy
```groovy
ctx._source.counter += event["count"]
```

With the following event : 
```ruby
{ "@timestamp" => "...", "id" => "123", "count" => 2 }
```
the document with id "123" will have its field "counter" incremented by 2