### PR TITLE
Fix #239 : parse @action before checking for update mode

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -526,11 +526,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       :_routing => @routing ? event.sprintf(@routing) : nil
     }
     
-    action = event.sprintf(@action)
+    sprinted_action = event.sprintf(@action)
 
     params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if action == 'update' && @upsert != ""
 
-    buffer_receive([action, params, event])
+    buffer_receive([sprinted_action, params, event])
   end # def receive
 
   public

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -400,7 +400,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     # Update API setup
     update_options = {
-      :upsert => @upsert,
       :doc_as_upsert => @doc_as_upsert
     }
     common_options.merge! update_options
@@ -528,7 +527,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     
     sprinted_action = event.sprintf(@action)
 
-    params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if action == 'update' && @upsert != ""
+    params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if sprinted_action == 'update' && @upsert != ""
 
     buffer_receive([sprinted_action, params, event])
   end # def receive

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -403,7 +403,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       :upsert => @upsert,
       :doc_as_upsert => @doc_as_upsert
     }
-    common_options.merge! update_options if @action == 'update'
+    common_options.merge! update_options
 
     client_class = case @protocol
       when "transport"
@@ -526,9 +526,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       :_routing => @routing ? event.sprintf(@routing) : nil
     }
     
-    params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @action == 'update' && @upsert != ""
+    action = event.sprintf(@action)
 
-    buffer_receive([event.sprintf(@action), params, event])
+    params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if action == 'update' && @upsert != ""
+
+    buffer_receive([action, params, event])
   end # def receive
 
   public


### PR DESCRIPTION
This fixes #239 on v1.0.7 ! but it's also merge-able on master (2.0)

Repair update mode, when action parameter use event field as value.