### PR TITLE
Fix misleading documentation for HTTP(S) auth

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -147,8 +147,14 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # For more details on actions, check out the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html[Elasticsearch bulk API documentation]
   config :action, :validate => %w(index delete create update), :default => "index"
 
-  # Username and password (only valid when protocol is HTTP; this setting works with HTTP or HTTPS auth)
+  # Username for HTTP(S) auth. See also password setting.
+  #
+  # This setting is only valid when protocol is HTTP.
   config :user, :validate => :string
+  
+  # Password for HTTP(S) auth. See also user setting.
+  #
+  # This setting is only valid when protocol is HTTP.
   config :password, :validate => :password
 
   # HTTP Path at which the Elasticsearch server lives. Use this if you must run ES behind a proxy that remaps


### PR DESCRIPTION
Previously the site (https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-user) had the following documentation for user field:

    Username and password (only valid when protocol is HTTP; this setting works with HTTP or HTTPS auth)

And the password setting didn't have any documentation at all.

At least to me this was quite misleading, because I thought it means I can provide something like user => 'username:password'.

Fixed by separating documentation for user & password fields, and referencing them from each other.