### PR TITLE
Remove dependency on generator plugin for specs

### DIFF
--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -4,6 +4,7 @@ require "logstash/plugin"
 require "logstash/json"
 require "stud/try"
 require "longshoreman"
+require "logstash/outputs/elasticsearch"
 
 CONTAINER_NAME = "logstash-output-elasticsearch-#{rand(999).to_s}"
 CONTAINER_IMAGE = "elasticsearch"


### PR DESCRIPTION
This un-breaks the current builds by removing the dependency on the `generator` input which does not work because there is not yet a released version that works with LS2.0