### PR TITLE
Make port obsolete

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -90,7 +90,7 @@ module LogStash::Outputs::Elasticsearch
 
       uris = hosts.map do |host|
         proto = client_settings[:ssl] ? "https"  : "http"
-        if !(host =~ /:/).nil?
+        if host =~ /:\d+\z/
           "#{proto}://#{host}#{client_settings[:path]}"
         else
           # Use default port of 9200 if none provided with host.

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -8,7 +8,7 @@ describe "outputs/elasticsearch" do
     let(:options) {
       {
         "index" => "my-index",
-        "hosts" => "localhost",
+        "hosts" => ["localhost","localhost:9202"],
         "path" => "some-path"
       }
     }
@@ -30,7 +30,6 @@ describe "outputs/elasticsearch" do
         expect(eso.path).to eql(options["path"])
       end
 
-
       it "should properly set the path on the HTTP client adding slashes" do
         expect(manticore_host).to include("/" + options["path"] + "/")
       end
@@ -44,6 +43,19 @@ describe "outputs/elasticsearch" do
         it "should properly set the path on the HTTP client without adding slashes" do
           expect(manticore_host).to include(options["path"])
         end
+      end
+    end
+    describe "without a port specified" do
+      it "should properly set the default port (9200) on the HTTP client" do
+        expect(manticore_host).to include("9200")
+      end
+    end
+    describe "with a port other than 9200 specified" do
+      let(:manticore_host) {
+        eso.client.send(:client).transport.options[:hosts].last
+      }
+      it "should properly set the specified port on the HTTP client" do
+        expect(manticore_host).to include("9202")
       end
     end
   end


### PR DESCRIPTION
 - Update flag and docs
 - Remove references from code
 - Make sure default port 9200 is added if no port specified
 - Add tests to validate changes

The Atom editor cleaned up a bunch of trailing white space issues.  Sorry about that.

fixes #262