### PR TITLE
New setting: timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+  - Add timeout setting.
+  
 ## 1.0.7
  - Add update API support
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -326,6 +326,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # create a new document with this parameter as json string if document_id doesn't exists
   config :upsert, :validate => :string, :default => ""
 
+
+  # Set the timeout for network operations and requests sent Elasticsearch. If
+  # a timeout occurs, the request will be retried.
+  config :timeout, :validate => :number
+
   public
   def register
     @submit_mutex = Mutex.new
@@ -396,6 +401,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       :client_settings => client_settings
     }
 
+    common_options[:timeout] = @timeout if @timeout
     common_options.merge! setup_basic_auth()
 
     # Update API setup

--- a/lib/logstash/outputs/elasticsearch/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch/protocol.rb
@@ -62,13 +62,14 @@ module LogStash::Outputs::Elasticsearch
 
       def build_client(options)
         uri = "#{options[:protocol]}://#{options[:host]}:#{options[:port]}#{options[:client_settings][:path]}"
+        timeout = options[:timeout] || 0
 
         client_options = {
           :host => [uri],
           :ssl => options[:client_settings][:ssl],
           :transport_options => {  # manticore settings so we
-            :socket_timeout => 0,  # do not timeout socket reads
-            :request_timeout => 0,  # and requests
+            :socket_timeout => timeout,  # do not timeout socket reads
+            :request_timeout => timeout,  # and requests
             :proxy => options[:client_settings][:proxy]
           },
           :transport_class => ::Elasticsearch::Transport::Transport::HTTP::Manticore

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '1.0.7'
+  s.version         = '1.1.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'longshoreman'
+  s.add_development_dependency 'flores'
 end


### PR DESCRIPTION
Allows the user to configure network timeouts to Elasticsearch.
Default is the previous behavior: no timeout

Backport of #264 for Logstash 1.5.x. Fixes #260.