### PR TITLE
Make host obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.1
+ - Made host config obsolete.
+
 ## 2.1.0
  - New setting: timeout. This lets you control the behavior of a slow/stuck
    request to Elasticsearch that could be, for example, caused by network,

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -111,6 +111,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   config :hosts, :validate => :array
 
+  config :host, :obsolete => "Please use the 'hosts' setting instead. You can specify multiple entries separated by comma in 'host:port' format."
+
   # The port setting is obsolete.  Please use the 'hosts' setting instead.
   # Hosts entries can be in "host:port" format.
   config :port, :obsolete => "Please use the 'hosts' setting instead. Hosts entries can be in 'host:port' format."

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '2.1.1'
+  s.version         = '2.1.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"


### PR DESCRIPTION
`host` was removed in 2.0 and replaced by `hosts` setting. Making this `obsolete` so users can get feedback when they start LS with their current config