### PR TITLE
Fix handling of escaped chars in user/password for basic auth

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -496,8 +496,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     return {} unless @user && @password
 
     {
-      :user => ::URI.escape(@user, "@:"),
-      :password => ::URI.escape(@password.value, "@:")
+      :user => @user,
+      :password => @password.value
     }
   end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -26,6 +26,21 @@ describe "outputs/elasticsearch" do
       thread.kill()
     end
 
+    describe "auth setup with url encodable passwords" do
+      let(:user) { "foo@bar"}
+      let(:password) {"baz@blah" }
+      let(:options) { super.merge("user" => user, "password" => password) }
+      let(:auth_setup) { eso.send(:setup_basic_auth) }
+
+      it "should return the user verbatim" do
+        expect(auth_setup[:user]).to eql(user)
+      end
+
+      it "should return the password verbatim" do
+        expect(auth_setup[:password]).to eql(password)
+      end
+    end
+
     describe "with path" do
       it "should properly create a URI with the path" do
         expect(eso.path).to eql(options["path"])
@@ -62,7 +77,7 @@ describe "outputs/elasticsearch" do
   end
 
   # TODO(sissel): Improve this. I'm not a fan of using message expectations (expect().to receive...)
-  # especially with respect to logging to verify a failure/retry has occurred. For now, this 
+  # especially with respect to logging to verify a failure/retry has occurred. For now, this
   # should suffice, though.
   context "with timeout set" do
     let(:listener) { Flores::Random.tcp_listener }
@@ -76,9 +91,9 @@ describe "outputs/elasticsearch" do
       }
     end
     let(:eso) {LogStash::Outputs::ElasticSearch.new(options)}
-    
+
     before do
-      eso.register 
+      eso.register
 
       # Expect a timeout to be logged.
       expect(eso.logger).to receive(:warn).with("Failed to flush outgoing items",


### PR DESCRIPTION
This used to need to be escaped manually because we stuck it in the URL.
Now that it's just in the header we don't need to!

Fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/130#issuecomment-111880658