### PR TITLE
Disable fielddata use for analyzed strings

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -11,7 +11,8 @@
           "match" : "message",
           "match_mapping_type" : "string",
           "mapping" : {
-            "type" : "string", "index" : "analyzed", "omit_norms" : true
+            "type" : "string", "index" : "analyzed", "omit_norms" : true,
+            "fielddata" : { "format" : "disabled" }
           }
         }
       }, {
@@ -20,6 +21,7 @@
           "match_mapping_type" : "string",
           "mapping" : {
             "type" : "string", "index" : "analyzed", "omit_norms" : true,
+            "fielddata" : { "format" : "disabled" },
             "fields" : {
               "raw" : {"type": "string", "index" : "not_analyzed", "doc_values" : true, "ignore_above" : 256}
             }


### PR DESCRIPTION
By default, users should not be sorting, aggregating, or scripting against the analyzed string variant of fields. Instead, users should do those things against the `.raw` multifield variant.

This _will_ prevent the use of `significant_terms` aggregation against the associated field, which will be undesirable in rare cases. Given the rarity of that need, I would much rather have those users manually enable fielddata explicitly for the field (it is dynamically updatable!).

Closes #308