### PR TITLE
Fix sniffing spec to sleep for the proper amount of time.

### DIFF
--- a/spec/unit/outputs/elasticsearch/protocol_spec.rb
+++ b/spec/unit/outputs/elasticsearch/protocol_spec.rb
@@ -24,7 +24,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
       end
 
       it "should periodically sniff the client" do
-        sleep 2
+        sleep 1.5
         expect(transport).to have_received(:reload_connections!)
       end
     end


### PR DESCRIPTION
It sniffs once per second, so sleeping for 2s put it right on the boundary.
This should make our travis tests pass consistently