### PR TITLE
Fixes a bug whereby http errors would not sleep for max_retry_interval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
 language: ruby
 cache: bundler
 rvm:
-  - jruby-19mode
+  - jruby-1.7.23
 script: bundle exec rspec spec && bundle exec rspec spec --tag integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.2
+ - Fix bug where max_retry_interval was not respected for HTTP error codes
+
 ## 2.3.1
  - Bump manticore dependenvy to 0.5.2
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -77,7 +77,7 @@ module LogStash; module Outputs; class ElasticSearch;
       # Initially we submit the full list of actions
       submit_actions = actions
 
-      while submit_actions && submit_actions.length
+      while submit_actions && submit_actions.length > 0
         return if !submit_actions || submit_actions.empty? # If everything's a success we move along
         # We retry with whatever is didn't succeed
         begin
@@ -88,6 +88,8 @@ module LogStash; module Outputs; class ElasticSearch;
                        :class => e.class.name,
                        :backtrace => e.backtrace)
         end
+
+        sleep @retry_max_interval if submit_actions && submit_actions.length > 0
       end
     end
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '2.3.1'
+  s.version         = '2.3.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"


### PR DESCRIPTION
This fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/326
by correctly sleeping between retries for HTTP error codes, not just connection errors.

It also fixes a defensive array length check