### PR TITLE
Make error messages more verbose and easier to parse by humans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.2
+ - Make error messages more verbose and easier to parse by humans
+
 ## 2.5.1
  - Fix bug where SSL would sometimes not be enabled
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Contributors:
 * Dmitry Koprov (dkoprov)
 * Graham Bleach (bleach)
 * Hao Chen (haoch)
+* Ivan Babrou (bobrik)
 * James Turnbull (jamtur01)
 * John E. Vincent (lusis)
 * Jordan Sissel (jordansissel)

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -107,12 +107,13 @@ module LogStash; module Outputs; class ElasticSearch;
       bulk_response["items"].each_with_index do |response,idx|
         action_type, action_props = response.first
         status = action_props["status"]
+        error  = action_props["error"]
         action = actions[idx]
 
         if SUCCESS_CODES.include?(status)
           next
         elsif RETRYABLE_CODES.include?(status)
-          @logger.warn "retrying failed action with response code: #{status}"
+          @logger.warn "retrying failed action with response code: #{status} (#{error})"
           actions_to_retry << action
         else
           @logger.warn "Failed action. ", status: status, action: action, response: response
@@ -166,9 +167,9 @@ module LogStash; module Outputs; class ElasticSearch;
       @logger.error(
         "Attempted to send a bulk request to Elasticsearch configured at '#{@client.client_options[:hosts]}',"+
           " but Elasticsearch appears to be unreachable or down!",
-        :client_config => @client.client_options,
         :error_message => e.message,
-        :class => e.class.name
+        :class => e.class.name,
+        :client_config => @client.client_options,
       )
       @logger.debug("Failed actions for last bad bulk request!", :actions => actions)
 
@@ -181,10 +182,10 @@ module LogStash; module Outputs; class ElasticSearch;
         "Attempted to send a bulk request to Elasticsearch configured at '#{@client.client_options[:hosts]}'," +
           " but an error occurred and it failed! Are you sure you can reach elasticsearch from this machine using " +
           "the configuration provided?",
-        :client_config => @client.client_options,
         :error_message => e.message,
         :error_class => e.class.name,
-        :backtrace => e.backtrace
+        :backtrace => e.backtrace,
+        :client_config => @client.client_options,
       )
 
       @logger.debug("Failed actions for last bad bulk request!", :actions => actions)


### PR DESCRIPTION
It wasn't obvious why nginx logs report 200 OK, but logstash complains about error code 429.

Error messages looked kind of messy and hard to understand, I moved important things up front. I'm still curious what this tells me:

```
:message=>"es:9200 failed to respond", :class=>"Manticore::ClientProtocolException"
```