### PR TITLE
Clean logstash elasticsearch template

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -84,9 +84,9 @@
           "dynamic": true,
           "properties" : {
             "ip": { "type": "ip", "doc_values" : true },
-            "location" : { "type" : "geo_point", "doc_values" : true },
-            "latitude" : { "type" : "float", "doc_values" : true },
-            "longitude" : { "type" : "float", "doc_values" : true }
+            "location" : { "type" : "geo_point" },
+            "latitude" : { "type" : "float" },
+            "longitude" : { "type" : "float" }
           }
         }
       }


### PR DESCRIPTION
Since doc_values are already defined it is not required to defined again at the field type declaration.