### PR TITLE
source = { 'doc' => source }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.3
+ - Fix bug with update document. (#356)
+
 ## 2.4.2
  - Make flush_size actually cap the batch size in LS 2.2+
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -16,7 +16,7 @@ require "uri" # for escaping user input
 # We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,
 # yet far easier to administer and work with. When using the HTTP protocol one may upgrade Elasticsearch versions without having
 # to upgrade Logstash in lock-step. For those still wishing to use the node or transport protocols please see
-# the https://www.elastic.co/guide/en/logstash/2.0/plugins-outputs-elasticsearch_java.html[logstash-output-elasticsearch_java] plugin.
+# the <<plugins-outputs-elasticsearch_java,elasticsearch_java output plugin>>.
 #
 # You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
 #

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -170,7 +170,6 @@ module LogStash; module Outputs; class ElasticSearch;
         end
         source['script']['lang'] = @options[:script_lang] if @options[:script_lang] != ''
       else
-        source = { 'doc' => source }
         if @options[:doc_as_upsert]
           source['doc_as_upsert'] = true
         else

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -170,6 +170,10 @@ module LogStash; module Outputs; class ElasticSearch;
         end
         source['script']['lang'] = @options[:script_lang] if @options[:script_lang] != ''
       else
+        if not source.has_key?("doc")
+          source = { 'doc' => source }
+
+        end
         if @options[:doc_as_upsert]
           source['doc_as_upsert'] = true
         else

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '2.4.2'
+  s.version         = '2.4.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -40,7 +40,7 @@ describe "Update actions", :integration => true do
     it "should not create new document" do
       subject = get_es_output({ 'document_id' => "456" } )
       subject.register
-      subject.receive(LogStash::Event.new("message" => "sample message here"))
+      subject.receive(LogStash::Event.new("doc" => '{"message":"sample message here"}'))
       subject.flush
       expect {@es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)}.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
     end
@@ -48,7 +48,7 @@ describe "Update actions", :integration => true do
     it "should update existing document" do
       subject = get_es_output({ 'document_id' => "123" })
       subject.register
-      subject.receive(LogStash::Event.new("doc" => '{"message":"updated message here"'))
+      subject.receive(LogStash::Event.new("doc" => '{"message":"updated message here"}'))
       subject.flush
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
       insist { r["_source"]["message"] } == 'updated message here'

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -48,7 +48,7 @@ describe "Update actions", :integration => true do
     it "should update existing document" do
       subject = get_es_output({ 'document_id' => "123" })
       subject.register
-      subject.receive(LogStash::Event.new("message" => "updated message here"))
+      subject.receive(LogStash::Event.new("doc" => '{"message":"updated message here"'))
       subject.flush
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
       insist { r["_source"]["message"] } == 'updated message here'


### PR DESCRIPTION
It is hack.
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html

From docs:
{ "update" : {"_id" : "1", "_type" : "type1", "_index" : "index1"} }
{ "doc" : {"field2" : "value2"} }

If use explicit add "doc" it will be like this:
{ "update" : {"_id" : "1", "_type" : "type1", "_index" : "index1"} }
{{"doc":  "doc" : {"field2" : "value2"} }}