### PR TITLE
Fix bug with update action with doc_as_upsert and scripting, fixes #364, fixes #359

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.5.1
  - Fix bug where SSL would sometimes not be enabled
+ - Fix bug with update document with doc_as_upsert and scripting
 
 ## 2.5.0
  - Host settings now are more robust to bad input

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -203,10 +203,13 @@ module LogStash; module Outputs; class ElasticSearch;
         # Use the event as a hash from your script with variable name defined
         # by script_var_name (default: "event")
         # Ex: event["@timestamp"]
-        source = { 'script' => {'params' => { @options[:script_var_name] => source }} }
+        source_orig = source
+        source = { 'script' => {'params' => { @options[:script_var_name] => source_orig }} }
         if @options[:scripted_upsert]
           source['scripted_upsert'] = true
           source['upsert'] = {}
+        elsif @options[:doc_as_upsert]
+          source['upsert'] = source_orig
         else
           source['upsert'] = args.delete(:_upsert) if args[:_upsert]
         end


### PR DESCRIPTION
This PR fixes #364 . So now you can do : 
```
output {
  elasticsearch {
    action => "update"
    doc_as_upsert => true
    script => "ctx._source.count += 1"
    script_lang => "groovy"
    script_type => "inline"
    document_type => "my_type"
    index => "my_index"
    hosts => ["localhost:9200"]
    document_id => "%{id}"
  }
}
```
cc @andrewvc 
Thanks