### PR TITLE
Improved .travis.yml to support multiple ES versions + use better formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 sudo: false
-before_install:
-  - openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost"   -keyout /tmp/localhost.key -out /tmp/localhost.crt
-  - curl -s https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.0.0/elasticsearch-2.0.0.tar.gz  > elasticsearch.tar.gz
-  - mkdir elasticsearch && tar -xzf elasticsearch.tar.gz --strip-components=1 -C ./elasticsearch/.
-  - ln -sn ../../spec/fixtures/scripts elasticsearch/config/.
-  - cd elasticsearch && bin/elasticsearch -Des.script.inline=on -Des.script.indexed=on &
-  - sleep 10 && curl http://localhost:9200
+env:
+  - INTEGRATION=false
+  - INTEGRATION=true ES_VERSION=2.2.0
+  - INTEGRATION=true ES_VERSION=1.7.5
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: bundle exec rspec spec && bundle exec rspec spec --tag integration
+  - jruby-1.7.24
+script: ./travis-run.sh

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+if [[ "$INTEGRATION" != "true" ]]; then
+  bundle exec rspec -fd spec
+else
+  openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost"   -keyout /tmp/localhost.key -out /tmp/localhost.crt
+  curl -sL https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz > elasticsearch.tar.gz
+  mkdir elasticsearch
+  tar -xzf elasticsearch.tar.gz --strip-components=1 -C ./elasticsearch/.
+  ln -sn ../../spec/fixtures/scripts elasticsearch/config/.
+  elasticsearch/bin/elasticsearch -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on > /tmp/elasticsearch.log &
+  sleep 10
+  curl http://localhost:9200 && echo "ES is up!" || cat /tmp/elasticsearch.log
+  bundle exec rspec -fd spec --tag integration || cat /tmp/elasticsearch.log
+fi


### PR DESCRIPTION
The .travis.yml file should support multiple ES versions, this fixes this. It also cleans up the output to be more legible and no longer interleaves the background ES process logs with the rspec logs. It will barf out the background logs in the event of an error.