### PR TITLE
Set ssl options regardless of :ssl true or false

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -59,8 +59,14 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def self.setup_ssl(logger, params)
-      return {} if params["ssl"].nil?
-      return {:ssl => {:enabled => false}} if params["ssl"] == false
+
+      if params["ssl"].nil?
+        ssl_options = {:enabled => nil}
+      elsif params["ssl"] == false
+        ssl_options = {:enabled => false}
+      else
+        ssl_options = {:enabled => true}
+      end
 
       cacert, truststore, truststore_password, keystore, keystore_password =
         params.values_at('cacert', 'truststore', 'truststore_password', 'keystore', 'keystore_password')
@@ -68,8 +74,6 @@ module LogStash; module Outputs; class ElasticSearch;
       if cacert && truststore
         raise(LogStash::ConfigurationError, "Use either \"cacert\" or \"truststore\" when configuring the CA certificate") if truststore
       end
-
-      ssl_options = {:enabled => true}
 
       if cacert
         ssl_options[:ca_file] = cacert

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -199,5 +199,20 @@ describe "outputs/elasticsearch" do
       let(:options) { {"hosts" => "https://localhost"} }
       include_examples("an encrypted client connection")
     end
+
+    context "With an https host and ssl settings" do
+      let(:options) { {"hosts" => "https://localhost", "ssl_certificate_verification" => false} }
+      subject do
+        next LogStash::Outputs::ElasticSearch.new(options)
+      end
+      context "without ssl enabled" do
+        it "sets ssl options" do
+          expect(::Elasticsearch::Client).to receive(:new) do |args|
+            expect(args[:ssl]).to include(:verify => false)
+          end
+          subject.register
+        end
+      end
+    end
   end
 end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -208,6 +208,7 @@ describe "outputs/elasticsearch" do
       context "without ssl enabled" do
         it "sets ssl options" do
           expect(::Elasticsearch::Client).to receive(:new) do |args|
+            expect(args[:ssl]).to be(Hash)
             expect(args[:ssl]).to include(:verify => false)
           end
           subject.register

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -208,7 +208,7 @@ describe "outputs/elasticsearch" do
       context "without ssl enabled" do
         it "sets ssl options" do
           expect(::Elasticsearch::Client).to receive(:new) do |args|
-            expect(args[:ssl]).to be(Hash)
+            expect(args[:ssl]).to be_a(Hash)
             expect(args[:ssl]).to include(:verify => false)
           end
           subject.register


### PR DESCRIPTION
instead of only formatting ssl options if :ssl => true, always do it.

This allows ssl settings to be used if :ssl is set to false but the URL passed in the hosts array uses the https schema (i.e. `https://..`)

fixes #388 
