### PR TITLE
bump manticore minimum version due to obj leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.3
+ - Bump minimum manticore version to 0.5.4 which fixes a memory leak (#392)
+
 ## 2.5.2
  - Fix bug with update document with doc_as_upsert and scripting (#364, #359)
  - Make error messages more verbose and easier to parse by humans

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '2.5.2'
+  s.version         = '2.5.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM
-    s.add_runtime_dependency "manticore", '>= 0.5.2', '< 1.0.0'
+    s.add_runtime_dependency "manticore", '>= 0.5.4', '< 1.0.0'
   end
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
see more in https://github.com/cheald/manticore/issues/45

fixes #392