### PR TITLE
elasticsearch api expects source to be wrapped in data field

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -44,7 +44,7 @@ module LogStash; module Outputs; class ElasticSearch;
         args, source = update_action_builder(args, source) if action == 'update'
 
         if source && action != 'delete'
-          next [ { action => args }, source ]
+          next [ { action => args.merge({ :data => source }) } ]
         else
           next { action => args }
         end


### PR DESCRIPTION
This is to fix bug discussed at https://github.com/elastic/logstash/issues/4796

When source document contains field named "data", the bulk request is not generated correctly.