### PR TITLE
BREAKING CHANGE! New default template for ES 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 2.5.4
+# 5.0.0
+  - BREAKING CHANGE!  The default template in this version is _only_ compatible 
+    with Elasticsearch 5.0 due to new changes in mappings. This version contains 
+    the new default template. You _can_ still use this version of Logstash by 
+    manually specifying your own template, or disabling template management.
+
+## 2.5.4
   - New dependency requirements for logstash-core for the 5.0 release
 ## 2.5.3
  - Bump minimum manticore version to 0.5.4 which fixes a memory leak (#392)

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -32,7 +32,6 @@
         "@timestamp": { "type": "date" },
         "@version": { "type": "string", "index": "not_analyzed" },
         "geoip"  : {
-          "type" : "object",
           "dynamic": true,
           "properties" : {
             "ip": { "type": "ip" },

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -5,30 +5,32 @@
   },
   "mappings" : {
     "_default_" : {
+      "_all" : {"enabled" : true, "omit_norms" : true},
       "dynamic_templates" : [ {
         "message_field" : {
           "match" : "message",
-          "match_mapping_type" : "text",
+          "match_mapping_type" : "string",
           "mapping" : {
-            "type" : "text", 
-            "norms" : false }
+            "type" : "string", "index" : "analyzed", "omit_norms" : true,
+            "fielddata" : { "format" : "disabled" }
           }
-        }, {
-        "text_fields" : {
+        }
+      }, {
+        "string_fields" : {
           "match" : "*",
-          "match_mapping_type" : "text",
+          "match_mapping_type" : "string",
           "mapping" : {
-            "type" : "text", 
-            "norms" : false,
+            "type" : "string", "index" : "analyzed", "omit_norms" : true,
+            "fielddata" : { "format" : "disabled" },
             "fields" : {
-              "raw" : { "type": "keyword", "ignore_above" : 256}
+              "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
             }
           }
         }
       } ],
       "properties" : {
         "@timestamp": { "type": "date" },
-        "@version": { "type": "keyword" },
+        "@version": { "type": "string", "index": "not_analyzed" },
         "geoip"  : {
           "type" : "object",
           "dynamic": true,

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
@@ -5,88 +5,38 @@
   },
   "mappings" : {
     "_default_" : {
-      "_all" : {"enabled" : true, "omit_norms" : true},
       "dynamic_templates" : [ {
         "message_field" : {
           "match" : "message",
-          "match_mapping_type" : "string",
+          "match_mapping_type" : "text",
           "mapping" : {
-            "type" : "string", "index" : "analyzed", "omit_norms" : true,
-            "fielddata" : { "format" : "disabled" }
+            "type" : "text", 
+            "norms" : false }
           }
-        }
-      }, {
-        "string_fields" : {
+        }, {
+        "text_fields" : {
           "match" : "*",
-          "match_mapping_type" : "string",
+          "match_mapping_type" : "text",
           "mapping" : {
-            "type" : "string", "index" : "analyzed", "omit_norms" : true,
-            "fielddata" : { "format" : "disabled" },
+            "type" : "text", 
+            "norms" : false,
             "fields" : {
-              "raw" : {"type": "string", "index" : "not_analyzed", "doc_values" : true, "ignore_above" : 256}
+              "raw" : { "type": "keyword", "ignore_above" : 256}
             }
           }
         }
-      }, {
-        "float_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "float",
-          "mapping" : { "type" : "float", "doc_values" : true }
-        }
-      }, {
-        "double_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "double",
-          "mapping" : { "type" : "double", "doc_values" : true }
-        }
-      }, {
-        "byte_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "byte",
-          "mapping" : { "type" : "byte", "doc_values" : true }
-        }
-      }, {
-        "short_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "short",
-          "mapping" : { "type" : "short", "doc_values" : true }
-        }
-      }, {
-        "integer_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "integer",
-          "mapping" : { "type" : "integer", "doc_values" : true }
-        }
-      }, {
-        "long_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "long",
-          "mapping" : { "type" : "long", "doc_values" : true }
-        }
-      }, {
-        "date_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "date",
-          "mapping" : { "type" : "date", "doc_values" : true }
-        }
-      }, {
-        "geo_point_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "geo_point",
-          "mapping" : { "type" : "geo_point", "doc_values" : true }
-        }
       } ],
       "properties" : {
-        "@timestamp": { "type": "date", "doc_values" : true },
-        "@version": { "type": "string", "index": "not_analyzed", "doc_values" : true },
+        "@timestamp": { "type": "date" },
+        "@version": { "type": "keyword" },
         "geoip"  : {
           "type" : "object",
           "dynamic": true,
           "properties" : {
-            "ip": { "type": "ip", "doc_values" : true },
-            "location" : { "type" : "geo_point", "doc_values" : true },
-            "latitude" : { "type" : "float", "doc_values" : true },
-            "longitude" : { "type" : "float", "doc_values" : true }
+            "ip": { "type": "ip" },
+            "location" : { "type" : "geo_point" },
+            "latitude" : { "type" : "float" },
+            "longitude" : { "type" : "float" }
           }
         }
       }

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.0.0'
+  s.version         = '5.0.0.alpha1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '2.5.4'
+  s.version         = '3.0.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '3.0.0'
+  s.version         = '5.0.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -73,7 +73,7 @@ describe "index template expected behavior", :integration => true do
   end
 
   it "make [geoip][location] a geo_point" do
-    results = @es.search(:body => { "filter" => { "geo_distance" => { "distance" => "1000km", "geoip.location" => { "lat" => 0.5, "lon" => 0.5 } } } })
+    results = @es.search(:body => { "query" => { "bool" => { "must" => { "match_all" => {} }, "filter" => { "geo_distance" => { "distance" => "1000km", "geoip.location" => { "lat" => 0.5, "lon" => 0.5 } } } } } })
     insist { results["hits"]["total"] } == 1
     insist { results["hits"]["hits"][0]["_source"]["geoip"]["location"] } == [ 0.0, 0.0 ]
   end


### PR DESCRIPTION
Do not use this with older versions of Elasticsearch.  It will not work.

This template has been tested with the alpha1 release of Elasticsearch 5.0.0

fixes #386