### PR TITLE
Add retry_on_conflict configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,6 @@
-# 2.6.0
- - Changed the default template in this version to be compatible 
-   with Elasticsearch 5.0 due to new changes in mappings. This version contains 
-   the new default template. You _can_ still use this version of Logstash by 
-   manually specifying your own template, or disabling template management.
-
-# 2.5.5
-  - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.5.4
-  - New dependency requirements for logstash-core for the 5.0 release
-## 2.5.3
- - Bump minimum manticore version to 0.5.4 which fixes a memory leak (#392)
-
+## 2.6.1
+ - Add 'retry_on_conflict' configuration option which should have been here from the beginning
+ 
 ## 2.5.2
  - Fix bug with update document with doc_as_upsert and scripting (#364, #359)
  - Make error messages more verbose and easier to parse by humans

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -138,6 +138,7 @@ module LogStash; module Outputs; class ElasticSearch;
       if @action == 'update'
         params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @upsert != ""
         params[:_script] = event.sprintf(@script) if @script != ""
+        params[:_retry_on_conflict] = @retry_on_conflict
       end
       params
     end

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -151,6 +151,11 @@ module LogStash; module Outputs; class ElasticSearch
       # DEPRECATED This setting no longer does anything. If you need to change the number of retries in flight
       # try increasing the total number of workers to better handle this.
       mod.config :retry_max_items, :validate => :number, :default => 500, :deprecated => true
+
+      # The number of times Elasticsearch should internally retry an update/upserted document
+      # See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
+      # for more info
+      mod.config :retry_on_conflict, :validate => :number, :default => 1
     end
   end
 end end end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '2.6.0'
+  s.version         = '2.6.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "Output events to elasticsearch"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -200,4 +200,28 @@ describe "outputs/elasticsearch" do
       include_examples("an encrypted client connection")
     end
   end
+
+  describe "retry_on_conflict" do
+    let(:num_retries) { 123 }
+    let(:event) { LogStash::Event.new("message" => "blah") }
+    subject(:eso) {LogStash::Outputs::ElasticSearch.new(options.merge('retry_on_conflict' => num_retries))}
+
+    context "with a regular index" do
+      let(:options) { {"action" => "index"} }
+
+      it "should interpolate the requested action value when creating an event_action_tuple" do
+        action, params, event_data = eso.event_action_tuple(event)
+        expect(params).not_to include({:_retry_on_conflict => num_retries})
+      end
+    end
+
+    context "using a plain update" do
+      let(:options) { {"action" => "update", "retry_on_conflict" => num_retries} }
+
+      it "should interpolate the requested action value when creating an event_action_tuple" do
+        action, params, event_data = eso.event_action_tuple(event)
+        expect(params).to include({:_retry_on_conflict => num_retries})
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/408 by adding a `retry_on_conflict` operation. This only makes sense for update operations of course.