### PR TITLE
add ability to specify pipeline param to index event with an ingest pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.7.0
+ - Add `pipeline` configuration option for setting an ingest pipeline to run upon indexing
+
 ## 2.6.2
  - Fix bug where update index actions would not work with events with 'data' field
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -134,12 +134,20 @@ module LogStash; module Outputs; class ElasticSearch;
         :_routing => @routing ? event.sprintf(@routing) : nil
       }
 
-      params[:parent] = event.sprintf(@parent) if @parent
+      if @pipeline
+        params[:pipeline] = @pipeline
+      end
+
+     if @parent
+        params[:parent] = event.sprintf(@parent)
+      end
+
       if @action == 'update'
         params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @upsert != ""
         params[:_script] = event.sprintf(@script) if @script != ""
         params[:_retry_on_conflict] = @retry_on_conflict
       end
+
       params
     end
 

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -156,6 +156,9 @@ module LogStash; module Outputs; class ElasticSearch
       # See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
       # for more info
       mod.config :retry_on_conflict, :validate => :number, :default => 1
+
+      # Set which ingest pipeline you wish to execute for an event
+      mod.config :pipeline, :validate => :string, :default => nil
     end
   end
 end end end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '2.6.2'
+  s.version         = '2.7.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/pipeline_spec.rb
+++ b/spec/integration/outputs/pipeline_spec.rb
@@ -1,0 +1,55 @@
+require_relative "../../../spec/es_spec_helper"
+
+describe "Ingest pipeline execution behavior", :integration => true do
+  subject! do
+    require "logstash/outputs/elasticsearch"
+    settings = {
+      "hosts" => "#{get_host_port()}"
+    }
+    next LogStash::Outputs::ElasticSearch.new(settings)
+  end
+
+  before :each do
+    # Delete all templates first.
+    require "elasticsearch"
+
+    # Clean ES of data before we start.
+    @es = get_client
+    @es.indices.delete_template(:name => "*")
+
+    # This can fail if there are no indexes, ignore failure.
+    @es.indices.delete(:index => "*") rescue nil
+
+    # TODO(talevy): make these comments real
+    # PUT a new ingest pipeline definition into ES
+    # {
+    #   "description": "test pipeline that inserts a field",
+    #   "processors" : [
+    #     {
+    #       "set" : {
+    #         "ingest_field": "foo"
+    #       }
+    #     }
+    #   ]
+    # }
+
+    subject.register
+    subject.receive(LogStash::Event.new("magic_field" => "magic"))
+    subject.flush
+    @es.indices.refresh
+
+    # Wait or fail until everything's indexed.
+    Stud::try(20.times) do
+      r = @es.search
+      insist { r["hits"]["total"] } == 1
+    end
+  end
+
+  # TODO(talevy): only run this when ENV['ES_VERSION'] ~= 5.*
+  it "indexes using the proper pipeline" do
+    results = @es.search(:q => "magic_field:\"magic\"")
+    insist { results["hits"]["total"] } == 1
+    insist { results["hits"]["hits"][0]["_source"]["magic_field"] } == "magic"
+    insist { results["hits"]["hits"][0]["_source"]["ingest_field"] } == "foo"
+  end
+end


### PR DESCRIPTION
example usage:
```
output {
  elasticsearch {
    pipeline => "my-ingest-pipeline-name"
  }
}
```

Closes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/410