### PR TITLE
allow specifying headers to add to all requests

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -128,6 +128,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # a timeout occurs, the request will be retried.
   config :timeout, :validate => :number
 
+  # Additional headers to add to all requests.
+  # Should be an array of hashes in the form
+  # `{ 'X-My-Header-Here': 'val123', ... }`
+  config :headers, :validate => :hash
+
   def build_client
     @client = ::LogStash::Outputs::ElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)
   end

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -104,12 +104,14 @@ module LogStash; module Outputs; class ElasticSearch;
       hosts = options[:hosts] || ["127.0.0.1"]
       client_settings = options[:client_settings] || {}
       timeout = options[:timeout] || 0
+      headers = options[:headers] || {}
 
       host_ssl_opt = client_settings[:ssl].nil? ? nil : client_settings[:ssl][:enabled]
       urls = hosts.map {|host| host_to_url(host, host_ssl_opt, client_settings[:path])}
 
       @client_options = {
         :hosts => urls,
+        :headers => headers,
         :ssl => client_settings[:ssl],
         :transport_options => {
           :socket_timeout => timeout,
@@ -121,7 +123,8 @@ module LogStash; module Outputs; class ElasticSearch;
 
       if options[:user] && options[:password] then
         token = Base64.strict_encode64(options[:user] + ":" + options[:password])
-        @client_options[:headers] = { "Authorization" => "Basic #{token}" }
+        auth_header = { "Authorization" => "Basic #{token}" }
+        @client_options[:headers].merge! auth_header
       end
 
       @logger.debug? && @logger.debug("Elasticsearch HTTP client options", client_options)

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -16,6 +16,7 @@ module LogStash; module Outputs; class ElasticSearch;
       client_settings.merge! setup_ssl(logger, params)
       client_settings.merge! setup_proxy(logger, params)
       common_options.merge! setup_basic_auth(logger, params)
+      common_options.merge! setup_headers(logger, params)
 
       # Update API setup
       raise( Logstash::ConfigurationError,
@@ -101,6 +102,12 @@ module LogStash; module Outputs; class ElasticSearch;
         :user => user,
         :password => password.value
       }
+    end
+
+    def self.setup_headers(logger, params)
+      return {} unless params["headers"]
+
+      params["headers"]
     end
   end
 end; end; end


### PR DESCRIPTION
Allows additional headers to be specified and added to the http client. 

e.g.

```
elasticsearch {
  ...
  headers => {
    "X-My-Header" => "value123"
    "X-My-Second-Header" => "abcdef"
  }
}
```