### PR TITLE
Typo in documentation Dnetworkaddress spelled Dnetwordaddress

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -41,7 +41,7 @@ require "uri" # for escaping user input
 # a global setting for the JVM.
 #
 # As an example, to set your DNS TTL to 1 second you would set
-# the `LS_JAVA_OPTS` environment variable to `-Dnetwordaddress.cache.ttl=1`.
+# the `LS_JAVA_OPTS` environment variable to `-Dnetworkaddress.cache.ttl=1`.
 #
 # Keep in mind that a connection with keepalive enabled will
 # not reevaluate its DNS value while the keepalive is in effect.


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

sample code block says `Dnetwordaddress.cache.ttl` instead of `Dnetworkaddress.cache.ttl`. Copying and pasting leads to lots of troubleshooting since the two words are incredibly close to each other.