### PR TITLE
Allow URI paths to work correctly when no 'path' option set.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -79,7 +79,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # HTTP Path at which the Elasticsearch server lives. Use this if you must run Elasticsearch behind a proxy that remaps
   # the root path for the Elasticsearch HTTP API lives.
-  config :path, :validate => :string, :default => "/"
+  # Note that if you use paths as components of URLs in the 'hosts' field you may
+  # not also set this field. That will raise an error at startup
+  config :path, :validate => :string
 
   # Enable SSL/TLS secured communication to Elasticsearch cluster. Leaving this unspecified will use whatever scheme
   # is specified in the URLs listed in 'hosts'. If no explicit protocol is specified plain HTTP will be used.

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -10,7 +10,11 @@ module LogStash; module Outputs; class ElasticSearch;
       }
 
       common_options[:timeout] = params["timeout"] if params["timeout"]
-      client_settings[:path] = "/#{params["path"]}/".gsub(/\/+/, "/") # Normalize slashes
+
+      if params["path"]
+        client_settings[:path] = "/#{params["path"]}/".gsub(/\/+/, "/") # Normalize slashes
+      end
+
       logger.debug? && logger.debug("Normalizing http path", :path => params["path"], :normalized => client_settings[:path])
 
       client_settings.merge! setup_ssl(logger, params)


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

This fixes a bug where the default setting of 'path' would break all instances
of paths in 'hosts' URIs. The code would think the user had manually set 'path'.
This removes the default setting for 'path' and adds tests for these cases.