### PR TITLE
WIP: unhide rspec's integration tests results and give all elasticsearch p…

### DIFF
--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -102,7 +102,7 @@ describe "Update actions", :integration => true do
         'script_type' => 'inline'
       })
       subject.register
-      subject.multi_receive([LogStash::Event.new("count" => 3 )])
+      subject.multi_receive([LogStash::Event.new("counter" => 3 )])
       r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
       insist { r["_source"]["counter"] } == 4
     end

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -ex
 
+function finish {
+  last_result=$?
+  set +e
+  [[ $last_result -ne 0 ]] && cat /tmp/elasticsearch.log
+}
+trap finish EXIT
+
 setup_es() {
   download_url=$1
   curl -sL $download_url > elasticsearch.tar.gz
@@ -10,10 +17,17 @@ setup_es() {
 }
 
 start_es() {
-  es_args=$1
+  es_args=$@
   elasticsearch/bin/elasticsearch $es_args > /tmp/elasticsearch.log &
-  sleep 10
-  curl http://localhost:9200 && echo "ES is up!" || cat /tmp/elasticsearch.log
+  count=120
+  echo "Waiting for elasticsearch to respond..."
+  while ! curl --silent localhost:9200 && [[ $count -ne 0 ]]; do
+    count=$(( $count - 1 ))
+    [[ $count -eq 0 ]] && return 1
+    sleep 1
+  done
+  echo "Elasticsearch is Up !"
+  return 0
 }
 
 if [[ "$INTEGRATION" != "true" ]]; then
@@ -22,10 +36,10 @@ else
   if [[ "$ES_VERSION" == 5.* ]]; then
     setup_es https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
     start_es -Ees.script.inline=true -Ees.script.indexed=true -Ees.script.file=true
-    bundle exec rspec -fd spec --tag integration --tag version_5x || cat /tmp/elasticsearch.log
+    bundle exec rspec -fd spec --tag integration --tag version_5x
   else
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
-    bundle exec rspec -fd spec --tag integration --tag ~version_5x || cat /tmp/elasticsearch.log
+    bundle exec rspec -fd spec --tag integration --tag ~version_5x
   fi
 fi


### PR DESCRIPTION
…arameters

This PR restore real results of travis-ci integration tests and add a retry loop for waiting elasticsearch to start.

Unfortunately this PR reveal regressions happened in the past : 
* "counter" was renamed to "count" (https://github.com/logstash-plugins/logstash-output-elasticsearch/commit/06a47535111881b2bc6c9dbd3908e664e4852476#diff-ddabedb092be2147e979248f9e1a228cR105)
* incompatible features with elasticsearch 1.7 : 
  * part of scripting update (not yet precisely identified)
  * bool query does not support filter (https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/spec/integration/outputs/templates_spec.rb#L78)
