### PR TITLE
adding time unit to documentation.

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -128,7 +128,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # Note, this is NOT a SOCKS proxy, but a plain HTTP proxy
   config :proxy
 
-  # Set the timeout for network operations and requests sent Elasticsearch. If
+  # Set the timeout, in seconds, for network operations and requests sent Elasticsearch. If
   # a timeout occurs, the request will be retried.
   config :timeout, :validate => :number
 


### PR DESCRIPTION
https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/lib/logstash/outputs/elasticsearch/http_client.rb#L71-L72

>     # * `:timeout` - Float. A duration value, in seconds, after which a socket
>     #    operation or request will be aborted if not yet successfull