### PR TITLE
Fix auth/proxy setup handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+- Fix bug where setting credentials would cause fatal errors. See https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/441
+
 ## 4.1.0
 - breaking,config: Removed obsolete config `host` and `port`. Please use the `hosts` config with the `[host:port]` syntax.
 - breaking,config: Removed obsolete config `index_type`. Please use `document_type` instead.

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -90,8 +90,9 @@ module LogStash; module Outputs; class ElasticSearch;
       adapter_options = {
         :socket_timeout => timeout,
         :request_timeout => timeout,
-        :proxy => client_settings[:proxy]
       }
+
+      adapter_options[:proxy] = client_settings[:proxy] if client_settings[:proxy]
 
       # Having this explicitly set to nil is an error
       if client_settings[:pool_max]

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '4.1.0'
+  s.version         = '4.1.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_proxy_spec.rb
+++ b/spec/unit/outputs/elasticsearch_proxy_spec.rb
@@ -42,6 +42,16 @@ describe "Proxy option" do
         end
       end
     end
+
+    context "when not specified" do
+      let(:proxy) { nil }
+      
+      it "should not send the proxy option to manticore" do
+        expect(::Manticore::Client).to have_received(:new) do |options|
+          expect(options).not_to include(:proxy)
+        end
+      end
+    end
   end
 
   describe "invalid configs" do


### PR DESCRIPTION
We were accidentally setting `:proxy => nil` when proxy was not set by the user. Manticore just doesn't like this. This fixes this by only setting the `:proxy` key when we actually have proxy configuration data to put there.

Fixes #441