### PR TITLE
No longer explicitly support or test ES 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## 4.1.1
-
 - Fix bug where setting credentials would cause fatal errors. See https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/441
 
 ## 4.1.0

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -67,7 +67,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # - delete: deletes a document by id (An id is required for this action)
   # - create: indexes a document, fails if a document by that id already exists in the index.
   # - update: updates a document by id. Update has a special case where you can upsert -- update a
-  #   document if not already present. See the `upsert` option
+  #   document if not already present. See the `upsert` option. NOTE: This does not work and is not supported
+  #   in Elasticsearch 1.x. Please upgrade to ES 2.x or greater to use this feature with Logstash!
   # - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   #   would use the foo field for the action
   #

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -214,7 +214,7 @@ module LogStash; module Outputs; class ElasticSearch;
           sleep_interval = sleep_for_interval(sleep_interval)
           retry unless @stopping.true?
         else
-          @logger.error("Got a bad response code from server, but this code is not considered retryable. Request will be dropped", :code => e.code)
+          @logger.error("Got a bad response code from server, but this code is not considered retryable. Request will be dropped", :code => e.response_code)
         end
       rescue => e
         # Stuff that should never happen

--- a/spec/integration/outputs/routing_spec.rb
+++ b/spec/integration/outputs/routing_spec.rb
@@ -12,7 +12,7 @@ shared_examples "a routing indexer" do
     before do
       subject.register
       event_count.times do
-        subject.multi_receive([LogStash::Event.new("message" => "Hello World!", "type" => type)])
+        subject.multi_receive([LogStash::Event.new("message" => "test", "type" => type)])
       end
     end
 
@@ -26,6 +26,7 @@ shared_examples "a routing indexer" do
       # Wait until all events are available.
       Stud::try(10.times) do
         data = ""
+
         response = ftw.get!("#{index_url}/_count?q=*&routing=#{routing}")
         response.read_body { |chunk| data << chunk }
         result = LogStash::Json.load(data)

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -75,9 +75,7 @@ describe "index template expected behavior", :integration => true do
   end
 
   it "make [geoip][location] a geo_point" do
-    results = @es.search(:body => { "query" => { "bool" => { "must" => { "match_all" => {} }, "filter" => { "geo_distance" => { "distance" => "1000km", "geoip.location" => { "lat" => 0.5, "lon" => 0.5 } } } } } })
-    insist { results["hits"]["total"] } == 1
-    insist { results["hits"]["hits"][0]["_source"]["geoip"]["location"] } == [ 0.0, 0.0 ]
+    expect(@es.indices.get_template(name: "logstash")["logstash"]["mappings"]["_default_"]["properties"]["geoip"]["properties"]["location"]["type"]).to eq("geo_point")
   end
 
   it "aggregate .raw results correctly " do

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../../spec/es_spec_helper"
 
-describe "Update actions", :integration => true do
+describe "Update actions", :integration => true, :version_2x_plus => true do
   require "logstash/outputs/elasticsearch"
 
   def get_es_output( options={} )

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -18,7 +18,7 @@ setup_es() {
 
 start_es() {
   es_args=$@
-  elasticsearch/bin/elasticsearch $es_args > /tmp/elasticsearch.log &
+  elasticsearch/bin/elasticsearch $es_args > /tmp/elasticsearch.log 2>/dev/null &
   count=120
   echo "Waiting for elasticsearch to respond..."
   while ! curl --silent localhost:9200 && [[ $count -ne 0 ]]; do
@@ -36,10 +36,14 @@ else
   if [[ "$ES_VERSION" == 5.* ]]; then
     setup_es https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
     start_es -Ees.script.inline=true -Ees.script.indexed=true -Ees.script.file=true
-    bundle exec rspec -fd spec --tag integration --tag version_5x
-  else
+    bundle exec rspec -fd spec --tag integration --tag version_5x --tag integration_2x_plus
+  elif [[ "$ES_VERSION" == 2.* ]]; then
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     bundle exec rspec -fd spec --tag integration --tag ~version_5x
+  else
+    setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
+    start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
+    bundle exec rspec -fd spec --tag integration --tag ~version_5x --tag ~version_2x_plus
   fi
 fi


### PR DESCRIPTION
The JSON parsing is too messed update for update queries to work, and some ES1.x queries we use in tests don't work like their 5x equivalents and vice versa.