### PR TITLE
ES 1.x gets the ES 2.x template

### DIFF
--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -30,7 +30,8 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.default_template_path(es_major_version)
-      default_template_name = "elasticsearch-template-es#{es_major_version}x.json"
+      es_major_version == "1" ? template_version = "2" : template_version = es_major_version
+      default_template_name = "elasticsearch-template-es#{template_version}x.json"
       ::File.expand_path(default_template_name, ::File.dirname(__FILE__))
     end
 

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -30,7 +30,7 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.default_template_path(es_major_version)
-      es_major_version == "1" ? template_version = "2" : template_version = es_major_version
+      template_version = es_major_version == "1" ? "2" : es_major_version
       default_template_name = "elasticsearch-template-es#{template_version}x.json"
       ::File.expand_path(default_template_name, ::File.dirname(__FILE__))
     end

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -6,9 +6,18 @@ require "json"
 describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
   describe ".get_es_major_version" do
+    let(:es_1x_version) { '{ "number" : "1.7.0", "build_hash" : "929b9739cae115e73c346cb5f9a6f24ba735a743", "build_timestamp" : "2015-07-16T14:31:07Z", "build_snapshot" : false, "lucene_version" : "4.10.4" }' }
     let(:es_2x_version) { '{ "number" : "2.3.4", "build_hash" : "e455fd0c13dceca8dbbdbb1665d068ae55dabe3f", "build_timestamp" : "2016-06-30T11:24:31Z", "build_snapshot" : false, "lucene_version" : "5.5.0" }' }
     let(:es_5x_version) { '{ "number" : "5.0.0-alpha4", "build_hash" : "b0da471", "build_date" : "2016-06-22T12:33:48.164Z", "build_snapshot" : false, "lucene_version" : "6.1.0" }' }
     let(:client) { double("client") }
+    context "elasticsearch 1.x" do
+      before(:each) do
+        allow(client).to receive(:get_version).and_return(JSON.parse(es_1x_version))
+      end
+      it "detects major version is 1" do
+        expect(described_class.get_es_major_version(client)).to eq("1")
+      end
+    end
     context "elasticsearch 2.x" do
       before(:each) do
         allow(client).to receive(:get_version).and_return(JSON.parse(es_2x_version))
@@ -28,6 +37,11 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
   end
 
   describe ".default_template_path" do
+    context "elasticsearch 1.x" do
+      it "chooses the 2x template" do
+        expect(described_class.default_template_path("1")).to match(/elasticsearch-template-es2x.json/)
+      end
+    end
     context "elasticsearch 2.x" do
       it "chooses the 2x template" do
         expect(described_class.default_template_path("2")).to match(/elasticsearch-template-es2x.json/)


### PR DESCRIPTION
This is the current default behavior anyway

fixes #456 