### PR TITLE
let ES 5.x handle unanalyzed dynamically mapped strings

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
@@ -15,19 +15,7 @@
             "fielddata" : { "format" : "disabled" }
           }
         }
-      }, {
-        "string_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "string",
-          "mapping" : {
-            "type" : "string", "index" : "analyzed", "omit_norms" : true,
-            "fielddata" : { "format" : "disabled" },
-            "fields" : {
-              "raw" : {"type": "string", "index" : "not_analyzed", "ignore_above" : 256}
-            }
-          }
-        }
-      } ],
+      }],
       "properties" : {
         "@timestamp": { "type": "date" },
         "@version": { "type": "string", "index": "not_analyzed" },


### PR DESCRIPTION
All string fields in ES (as of https://github.com/elastic/elasticsearch/pull/17188) will have a special dynamic mapping defined. They will be associated with the `text` type and have an unanalyzed multi-field `keyword`.

Historically, Logstash has used the `.raw` multi-field for a similar mapping strategy. Now that this is the default in ES, there is no reason to stray away from the ES defaults.

This PR attempts to keep consistency between the new string-types and default multi-field naming.