### PR TITLE
Add stale connection check / Bump to 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
+## 5.1.0
+- Add check_connection_timeout parameter (default 10m)
+- Set default timeout to 60s
+
 ## 5.0.0
-- Breaking Change: Index template for 5.0 has been changed to reflect Elasticsearch's mapping changes. Most importantly, 
+- Breaking Change: Index template for 5.0 has been changed to reflect Elasticsearch's mapping changes. Most importantly,
 the subfield for string multi-fields has changed from `.raw` to `.keyword` to match ES default behavior. ([#386](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/386))
 
 **Users installing ES 5.x and LS 5.x**
 This change will not affect you and you will continue to use the ES defaults.
 
 **Users upgrading from LS 2.x to LS 5.x with ES 5.x**
-LS will not force upgrade the template, if `logstash` template already exists. This means you will still use 
-`.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after 
+LS will not force upgrade the template, if `logstash` template already exists. This means you will still use
+`.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after
 the new template is installed.
 
 ## 4.1.3

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -177,7 +177,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
   # You may want to set this lower, if you get connection errors regularly
   # Quoting the Apache commons docs (this client is based Apache Commmons):
-  # 'Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps detect connections that have become stale (half-closed) while kept inactive in the pool.'
+  # 'Defines period of inactivity in milliseconds after which persistent connections must
+  # be re-validated prior to being leased to the consumer. Non-positive value passed to
+  # this method disables connection validation. This check helps detect connections that
+  # have become stale (half-closed) while kept inactive in the pool.'
   # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
   config :validate_after_inactivity, :validate => :number, :default => 10000
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -173,6 +173,13 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # Resurrection is the process by which backend endpoints marked 'down' are checked
   # to see if they have come back to life
   config :resurrect_delay, :validate => :number, :default => 5
+  
+  # How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
+  # You may want to set this lower, if you get connection errors regularly
+  # Quoting the Apache commons docs (this client is based Apache Commmons):
+  # 'Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps detect connections that have become stale (half-closed) while kept inactive in the pool.'
+  # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
+  config :validate_after_inactivity, :validate => :number, :default => 10000
 
   def build_client
     @client = ::LogStash::Outputs::ElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -99,6 +99,8 @@ module LogStash; module Outputs; class ElasticSearch;
 
       adapter_options[:proxy] = client_settings[:proxy] if client_settings[:proxy]
 
+      adapter_options[:check_connection_timeout] = client_settings[:check_connection_timeout] if client_settings[:check_connection_timeout]
+
       # Having this explicitly set to nil is an error
       if client_settings[:pool_max]
         adapter_options[:pool_max] = client_settings[:pool_max]

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -4,6 +4,7 @@ module LogStash; module Outputs; class ElasticSearch;
       client_settings = {
         :pool_max => params["pool_max"],
         :pool_max_per_route => params["pool_max_per_route"],
+        :check_connection_timeout => params["validate_after_inactivity"]
       }
 
       common_options = {

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.0.0'
+  s.version         = '5.1.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -279,4 +279,20 @@ describe "outputs/elasticsearch" do
       end
     end
   end
+
+  describe "stale connection check" do
+    let(:validate_after_inactivity) { 123 }
+    subject(:eso) { LogStash::Outputs::ElasticSearch.new("validate_after_inactivity" => validate_after_inactivity) }
+
+    before do
+      allow(::Manticore::Client).to receive(:new).with(any_args)
+      subject.register
+    end
+
+    it "should set the correct http client option for 'validate_after_inactivity" do
+      expect(::Manticore::Client).to have_received(:new) do |options|
+        expect(options[:check_connection_timeout]).to eq(validate_after_inactivity)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add 'check_connection_timeout' parameter and bump to 5.1.0

This also releases the new timeout defaults

Fixes #468 