### PR TITLE
Hide user and password from the url.

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -6,12 +6,12 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
       def initialize(response_code, url, body)
         @response_code = response_code
-        @url = url
+        @url = ::LogStash::Outputs::ElasticSearch::SafeURL.without_credentials(url)
         @body = body
       end
 
       def message
-        "Got response code '#{response_code}' contact Elasticsrearch at URL '#{@url}'"
+        "Got response code '#{response_code}' contact Elasticsearch at URL '#{@url}'"
       end
     end
     class HostUnreachableError < Error;
@@ -19,7 +19,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
       def initialize(original_error, url)
         @original_error = original_error
-        @url = url
+        @url = ::LogStash::Outputs::ElasticSearch::SafeURL.without_credentials(url)
       end
 
       def message

--- a/lib/logstash/outputs/elasticsearch/safe_url.rb
+++ b/lib/logstash/outputs/elasticsearch/safe_url.rb
@@ -3,6 +3,9 @@ module LogStash; module Outputs; class ElasticSearch;
     PLACEHOLDER = "~hidden~".freeze
 
     module_function
+
+    # Takes a URI object and returns a copy of it with any user or password
+    # information replaced with a placeholder `~hidden~`.
     def without_credentials(url)
       url.dup.tap do |u|
         u.user = PLACEHOLDER if u.user

--- a/lib/logstash/outputs/elasticsearch/safe_url.rb
+++ b/lib/logstash/outputs/elasticsearch/safe_url.rb
@@ -1,0 +1,11 @@
+module LogStash; module Outputs; class ElasticSearch;
+  module SafeURL
+    module_function
+    def without_credentials(url)
+      url.dup.tap do |u|
+        u.user = "~hidden~" if u.user
+        u.password = "~hidden~" if u.password
+      end
+    end
+  end
+end end end

--- a/lib/logstash/outputs/elasticsearch/safe_url.rb
+++ b/lib/logstash/outputs/elasticsearch/safe_url.rb
@@ -1,10 +1,12 @@
 module LogStash; module Outputs; class ElasticSearch;
   module SafeURL
+    PLACEHOLDER = "~hidden~".freeze
+
     module_function
     def without_credentials(url)
       url.dup.tap do |u|
-        u.user = "~hidden~" if u.user
-        u.password = "~hidden~" if u.password
+        u.user = PLACEHOLDER if u.user
+        u.password = PLACEHOLDER if u.password
       end
     end
   end

--- a/spec/unit/safe_url_spec.rb
+++ b/spec/unit/safe_url_spec.rb
@@ -2,6 +2,8 @@ require "logstash/outputs/elasticsearch/safe_url"
 require "uri"
 
 describe ::LogStash::Outputs::ElasticSearch::SafeURL do
+  let(:placeholder) { ::LogStash::Outputs::ElasticSearch::SafeURL::PLACEHOLDER }
+
   context "#without_credentials" do
     subject { described_class.without_credentials(url) }
 
@@ -27,16 +29,16 @@ describe ::LogStash::Outputs::ElasticSearch::SafeURL do
       it_behaves_like "returning a new object"
       
       it "should hide the user" do
-        expect(subject.user).to be == "~hidden~"
+        expect(subject.user).to be == placeholder
       end
 
       it "should hide the password" do
-        expect(subject.user).to be == "~hidden~"
+        expect(subject.user).to be == placeholder
       end
 
       context "#to_s" do
         it "should not contain credentials" do
-          expect(subject.to_s).to be == "https://~hidden~:~hidden~@example.com/"
+          expect(subject.to_s).to be == "https://#{placeholder}:#{placeholder}@example.com/"
         end
       end
     end

--- a/spec/unit/safe_url_spec.rb
+++ b/spec/unit/safe_url_spec.rb
@@ -1,0 +1,44 @@
+require "logstash/outputs/elasticsearch/safe_url"
+require "uri"
+
+describe ::LogStash::Outputs::ElasticSearch::SafeURL do
+  context "#without_credentials" do
+    subject { described_class.without_credentials(url) }
+
+    shared_examples_for "returning a new object" do
+      it "should return a new url object" do
+        expect(subject.object_id).not_to be == url.object_id
+      end
+    end
+
+    context "when given a url without credentials" do
+      let(:url) { URI.parse("https://example.com/") }
+
+      it_behaves_like "returning a new object"
+
+      it "should return the same url" do
+        expect(subject).to be == url
+      end
+    end
+
+    context "when url contains credentials" do
+      let(:url) { URI.parse("https://user:pass@example.com/") }
+
+      it_behaves_like "returning a new object"
+      
+      it "should hide the user" do
+        expect(subject.user).to be == "~hidden~"
+      end
+
+      it "should hide the password" do
+        expect(subject.user).to be == "~hidden~"
+      end
+
+      context "#to_s" do
+        it "should not contain credentials" do
+          expect(subject.to_s).to be == "https://~hidden~:~hidden~@example.com/"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, a 403 error would log this:

> Got response code '403' contact Elasticsrearch at URL 'http://foo:bar@localhost:9200/'

This caused a leak in credentials.