### PR TITLE
Add "version" to 5.x template

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
@@ -1,5 +1,6 @@
 {
   "template" : "logstash-*",
+  "version" : 20160915,
   "settings" : {
     "index.refresh_interval" : "5s"
   },

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
@@ -1,6 +1,6 @@
 {
   "template" : "logstash-*",
-  "version" : 20160915,
+  "version" : 50001,
   "settings" : {
     "index.refresh_interval" : "5s"
   },

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -48,7 +48,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
       end
     end
     context "elasticsearch 5.x" do
-      it "chooses the 2x template" do
+      it "chooses the 5x template" do
         expect(described_class.default_template_path("5")).to match(/elasticsearch-template-es5x.json/)
       end
     end


### PR DESCRIPTION
This adds a version value of today's date (`20160915`) as the version. Any change to the template should increase the version number (change to that date), thus making it easier to detect changes.

As this is the first release of 5.x, it really is somewhat moot, but any future release may also choose to build in variable for the 5.x change so that the file only needs to be loaded _if_ the version actually needs to be replaced.

Closes #477 