### PR TITLE
use path_match instead of match in the message_field field template

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es2x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es2x.json
@@ -8,7 +8,7 @@
       "_all" : {"enabled" : true, "omit_norms" : true},
       "dynamic_templates" : [ {
         "message_field" : {
-          "match" : "message",
+          "path_match" : "message",
           "match_mapping_type" : "string",
           "mapping" : {
             "type" : "string", "index" : "analyzed", "omit_norms" : true,

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
@@ -9,7 +9,7 @@
       "_all" : {"enabled" : true, "norms" : false},
       "dynamic_templates" : [ {
         "message_field" : {
-          "match" : "message",
+          "path_match" : "message",
           "match_mapping_type" : "string",
           "mapping" : {
             "type" : "string", "index" : "analyzed", "norms" : false,


### PR DESCRIPTION
this prevents fields like "message.error" or "other.message" to also not get a .raw field.
By using path_match, only "message" will not have a .raw

