### PR TITLE
update templates to be more strict on `message` match

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es2x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es2x.json
@@ -8,7 +8,7 @@
       "_all" : {"enabled" : true, "omit_norms" : true},
       "dynamic_templates" : [ {
         "message_field" : {
-          "match" : "message",
+          "path_match" : "message",
           "match_mapping_type" : "string",
           "mapping" : {
             "type" : "string", "index" : "analyzed", "omit_norms" : true,

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
@@ -12,8 +12,8 @@
           "path_match" : "message",
           "match_mapping_type" : "string",
           "mapping" : {
-            "type" : "string", "index" : "analyzed", "norms" : false,
-            "fielddata" : { "format" : "disabled" }
+            "type" : "text",
+            "norms" : false
           }
         }
       }, {

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
@@ -9,7 +9,7 @@
       "_all" : {"enabled" : true, "norms" : false},
       "dynamic_templates" : [ {
         "message_field" : {
-          "match" : "message",
+          "path_match" : "message",
           "match_mapping_type" : "string",
           "mapping" : {
             "type" : "string", "index" : "analyzed", "norms" : false,


### PR DESCRIPTION
Currently, all fields named `message` are mapped to be excluded
from the `.keyword` and `.raw`. This is rather strict, and need only
be applied to the top-level `message` field. All nested `**.*.message`
fields should be treated like any old field.