### PR TITLE
Remove docker dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.1.2
 - Hide credentials in exceptions and log messages ([#482](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/482))
+- [internal] Remove dependency on longshoreman project
 
 ## 5.1.1
 - Hide user and password from the URL logged during sniffing process.

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'longshoreman'
   s.add_development_dependency 'flores'
   # Still used in some specs, we should remove this ASAP
   s.add_development_dependency 'elasticsearch'

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -1,4 +1,5 @@
 require "logstash/devutils/rspec/spec_helper"
+require "ftw"
 require 'elasticsearch'
 
 module ESHelper

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -1,30 +1,9 @@
 require "logstash/devutils/rspec/spec_helper"
-require "ftw"
-require "logstash/plugin"
-require "logstash/json"
-require "stud/try"
-require "longshoreman"
-require "logstash/outputs/elasticsearch"
 require 'elasticsearch'
-
-CONTAINER_NAME = "logstash-output-elasticsearch-#{rand(999).to_s}"
-CONTAINER_IMAGE = "elasticsearch"
-CONTAINER_TAG = "2.0"
-
-DOCKER_INTEGRATION = ENV["DOCKER_INTEGRATION"]
 
 module ESHelper
   def get_host_port
-    addr = DOCKER_INTEGRATION ? Longshoreman.new.get_host_ip : "127.0.0.1"
-    "#{addr}:#{get_port}"
-  end
-
-  def get_port
-    return 9200 unless DOCKER_INTEGRATION
-
-    container = Longshoreman::Container.new
-    container.get(CONTAINER_NAME)
-    container.rport(9200)
+    "127.0.0.1:9200"
   end
 
   def get_client
@@ -32,47 +11,6 @@ module ESHelper
   end
 end
 
-
 RSpec.configure do |config|
   config.include ESHelper
-
-  if DOCKER_INTEGRATION
-    # this :all hook gets run before every describe block that is tagged with :integration => true.
-    config.before(:all, :integration => true) do
-
-
-      # check if container exists already before creating new one.
-      begin
-        ls = Longshoreman::new
-        ls.container.get(CONTAINER_NAME)
-      rescue Docker::Error::NotFoundError
-        scriptDir = File.expand_path File.dirname(__FILE__) + '/fixtures/scripts'
-        Longshoreman.new("#{CONTAINER_IMAGE}:#{CONTAINER_TAG}", CONTAINER_NAME, {
-          'Cmd' => [ "-Des.script.inline=on", "-Des.script.indexed=on" ],
-          'HostConfig' => {
-            'Binds' => ["#{scriptDir}:/usr/share/elasticsearch/config/scripts"],
-            'PublishAllPorts' => true
-          }
-        })
-        # TODO(talevy): verify ES is running instead of static timeout
-        sleep 10
-      end
-    end
-
-    # we want to do a final cleanup after all :integration runs,
-    # but we don't want to clean up before the last block.
-    # This is a final blind check to see if the ES docker container is running and
-    # needs to be cleaned up. If no container can be found and/or docker is not
-    # running on the system, we do nothing.
-    config.after(:suite) do
-      # only cleanup docker container if system has docker and the container is running
-      begin
-        ls = Longshoreman::new
-        ls.container.get(CONTAINER_NAME)
-        ls.cleanup
-      rescue Docker::Error::NotFoundError, Excon::Errors::SocketError
-        # do nothing
-      end
-    end
-  end
 end


### PR DESCRIPTION
`longeshoreman` depends on `docker-api` which now wants to use ruby 2.0. We don't use longeshoreman anymore in our tests, so removing all together.
