### PR TITLE
Breaking: Pass tests for ES 5.0.0-beta1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 - INTEGRATION=false
 - INTEGRATION=true ES_VERSION=1.7.5
 - INTEGRATION=true ES_VERSION=2.3.4
-- INTEGRATION=true ES_VERSION=5.0.0-alpha5
+- INTEGRATION=true ES_VERSION=5.0.0-beta1
 language: ruby
 cache: bundler
 rvm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.0
+- Change default lang for scripts to be painless, inline with ES 5.0. Earlier there was no default.
+
 ## 5.1.2
 - Hide credentials in exceptions and log messages ([#482](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/482))
 - [internal] Remove dependency on longshoreman project

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -114,8 +114,8 @@ module LogStash; module Outputs; class ElasticSearch
       #  file    : "script" contains the name of script stored in elasticseach's config directory
       mod.config :script_type, :validate => ["inline", 'indexed', "file"], :default => ["inline"]
 
-      # Set the language of the used script
-      mod.config :script_lang, :validate => :string, :default => ""
+      # Set the language of the used script. If not set, this defaults to painless in ES 5.0
+      mod.config :script_lang, :validate => :string, :default => "painless"
 
       # Set variable name passed to script (scripted update)
       mod.config :script_var_name, :validate => :string, :default => "event"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.1.2'
+  s.version         = '5.2.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/create_spec.rb
+++ b/spec/integration/outputs/create_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../../spec/es_spec_helper"
 describe "client create actions", :integration => true do
   require "logstash/outputs/elasticsearch"
 
-  def get_es_output(action, id = nil)
+  def get_es_output(action, id)
     settings = {
       "manage_template" => true,
       "index" => "logstash-create",
@@ -11,7 +11,7 @@ describe "client create actions", :integration => true do
       "hosts" => get_host_port(),
       "action" => action
     }
-    settings['document_id'] = id unless id.nil?
+    settings['document_id'] = id
     LogStash::Outputs::ElasticSearch.new(settings)
   end
 
@@ -27,18 +27,6 @@ describe "client create actions", :integration => true do
   context "when action => create" do
     it "should create new documents with or without id" do
       subject = get_es_output("create", "id123")
-      subject.register
-      subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-      @es.indices.refresh
-      # Wait or fail until everything's indexed.
-      Stud::try(3.times) do
-        r = @es.search
-        insist { r["hits"]["total"] } == 1
-      end
-    end
-
-    it "should create new documents without id" do
-      subject = get_es_output("create")
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
       @es.indices.refresh

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -33,7 +33,7 @@ shared_examples "a parent indexer" do
       Stud::try(10.times) do
         query = { "query" => { "has_parent" => { "type" => "#{type}_parent", "query" => { "match" => { "foo" => "bar" } } } } }
         data = ""
-        response = ftw.post!("#{index_url}/_count?q=*", :body => query.to_json)
+        response = ftw.post!("#{index_url}/_count", :body => query.to_json)
         response.read_body { |chunk| data << chunk }
         result = LogStash::Json.load(data)
         cur_count = result["count"]

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -9,7 +9,8 @@ describe "Update actions", :integration => true, :version_greater_than_equal_to_
       "index" => "logstash-update",
       "template_overwrite" => true,
       "hosts" => get_host_port(),
-      "action" => "update"
+      "action" => "update",
+      "script_lang" => "groovy"
     }
     LogStash::Outputs::ElasticSearch.new(settings.merge!(options))
   end
@@ -166,6 +167,7 @@ describe "Update actions", :integration => true, :version_greater_than_equal_to_
         subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_upsert', 'scripted_upsert' => true, 'script_type' => 'file' })
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 1)])
+        @es.indices.refresh
         r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
         insist { r["_source"]["counter"] } == 1
       end

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -44,7 +44,7 @@ else
     # Run all tests which are for versions < 5 but don't run ones tagged 5.x and above. Skip ingest, new template
     bundle exec rspec -fd spec --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x
   else
-    setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
+    setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Still have to support ES versions < 2.x so run tests for those.
     bundle exec rspec -fd spec --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -34,7 +34,7 @@ if [[ "$INTEGRATION" != "true" ]]; then
   bundle exec rspec -fd spec
 else
   if [[ "$ES_VERSION" == 5.* ]]; then
-    setup_es https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
+    setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     start_es -Escript.inline=true -Escript.stored=true -Escript.file=true
     # Run all tests which are for versions > 5 but don't run ones tagged < 5.x. Include ingest, new template
     bundle exec rspec -fd spec --tag integration --tag version_greater_than_equal_to_5x --tag ~version_less_than_5x
@@ -44,7 +44,7 @@ else
     # Run all tests which are for versions < 5 but don't run ones tagged 5.x and above. Skip ingest, new template
     bundle exec rspec -fd spec --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x
   else
-    setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+    setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Still have to support ES versions < 2.x so run tests for those.
     bundle exec rspec -fd spec --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x


### PR DESCRIPTION
Breaking change to set lang to painless by default mirroring ES
Groovy related tests still pass

Removed one test in create_spec because it does not make sense
as ES is mandating passing of id with op_type=create

For the scripting tests, passing groovy manually to make tests work

Fixes #488