### PR TITLE
Break up large bulk requests into multiple requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.0
+- Bulk operations will now target 20MB chunks at a time to reduce heap usage
+
 ## 5.2.0
 - Change default lang for scripts to be painless, inline with ES 5.0. Earlier there was no default.
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -17,20 +17,20 @@ require "uri" # for escaping user input
 # yet far easier to administer and work with. When using the HTTP protocol one may upgrade Elasticsearch versions without having
 # to upgrade Logstash in lock-step. For those still wishing to use the node or transport protocols please see
 # the <<plugins-outputs-elasticsearch_java,elasticsearch_java output plugin>>.
-#
+# 
 # You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
 #
 # ==== Template management for Elasticsearch 5.x
-# Index template for this version (Logstash 5.0) has been changed to reflect Elasticsearch's mapping changes in version 5.0. 
-# Most importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match ES default 
+# Index template for this version (Logstash 5.0) has been changed to reflect Elasticsearch's mapping changes in version 5.0.
+# Most importantly, the subfield for string multi-fields has changed from `.raw` to `.keyword` to match ES default
 # behavior.
 #
 # ** Users installing ES 5.x and LS 5.x **
 # This change will not affect you and you will continue to use the ES defaults.
 #
 # ** Users upgrading from LS 2.x to LS 5.x with ES 5.x **
-# LS will not force upgrade the template, if `logstash` template already exists. This means you will still use 
-# `.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after 
+# LS will not force upgrade the template, if `logstash` template already exists. This means you will still use
+# `.raw` for sub-fields coming from 2.x. If you choose to use the new template, you will have to reindex your data after
 # the new template is installed.
 #
 # ==== Retry Policy
@@ -47,6 +47,10 @@ require "uri" # for escaping user input
 #
 # NOTE: 409 exceptions are no longer retried. Please set a higher `retry_on_conflict` value if you experience 409 exceptions.
 # It is more performant for Elasticsearch to retry these exceptions than this plugin.
+#
+# ==== Batch Sizes ====
+# This plugin attempts to send batches of events as a single request. However, if
+# a request exceeds 20MB we will break it up until multiple batch requests. If a single document exceeds 20MB it will be sent as a single request.
 #
 # ==== DNS Caching
 #
@@ -146,7 +150,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # a timeout occurs, the request will be retried.
   config :timeout, :validate => :number, :default => 60
 
-  # Set the Elasticsearch errors in the whitelist that you don't want to log. 
+  # Set the Elasticsearch errors in the whitelist that you don't want to log.
   # A useful example is when you want to skip all 409 errors
   # which are `document_already_exists_exception`.
   config :failure_type_logging_whitelist, :validate => :array, :default => []
@@ -173,7 +177,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # Resurrection is the process by which backend endpoints marked 'down' are checked
   # to see if they have come back to life
   config :resurrect_delay, :validate => :number, :default => 5
-  
+
   # How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
   # You may want to set this lower, if you get connection errors regularly
   # Quoting the Apache commons docs (this client is based Apache Commmons):

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -81,7 +81,7 @@ module LogStash; module Outputs; class ElasticSearch
       # If you specify a number larger than the batch size of your pipeline it will have no effect,
       # save for the case where a filter increases the size of an inflight batch by outputting
       # events.
-      mod.config :flush_size, :validate => :number, :default => 500
+      mod.config :flush_size, :validate => :number, :deprecate => "This setting is no longer necessary as we now try to restrict bulk requests to sane sizes. See the 'Batch Sizes' section of the docs. If you think you still need to restrict payloads based on the number, not size, of events, please open a ticket."
 
       # The amount of time since last flush before a flush is forced.
       #

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -45,7 +45,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # but for our current purposes this is correct
       if resp.code < 200 || resp.code > 299 && resp.code != 404
         safe_url = ::LogStash::Outputs::ElasticSearch::SafeURL.without_credentials(url)
-        raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(resp.code, safe_url + path, body)
+        raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(resp.code, safe_url + path, resp.body)
       end
 
       resp

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency 'ftw', '~> 0.0.42'
+  s.add_development_dependency 'addressable', "~> 2.4.0" # used by FTW. V 2.5.0 is ruby 2.0 only. 
   s.add_development_dependency 'logstash-codec-plain'
 
   if RUBY_PLATFORM == 'java'

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.2.0'
+  s.version         = '5.3.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -1,21 +1,21 @@
 require_relative "../../../spec/es_spec_helper"
+require "logstash/outputs/elasticsearch"
 
 shared_examples "an indexer" do
+    let(:event) { LogStash::Event.new("message" => "Hello World!", "type" => type) }
     let(:index) { 10.times.collect { rand(10).to_s }.join("") }
     let(:type) { 10.times.collect { rand(10).to_s }.join("") }
     let(:event_count) { 10000 + rand(500) }
-    let(:flush_size) { rand(200) + 1 }
     let(:config) { "not implemented" }
+    let(:events) { event_count.times.map { event }.to_a }
     subject { LogStash::Outputs::ElasticSearch.new(config) }
 
     before do
       subject.register
-      event_count.times do
-        subject.multi_receive([LogStash::Event.new("message" => "Hello World!", "type" => type)])
-      end
     end
 
     it "ships events" do
+      subject.multi_receive(events)
       index_url = "http://#{get_host_port}/#{index}"
 
       ftw = FTW::Agent.new
@@ -42,13 +42,57 @@ shared_examples "an indexer" do
     end
 end
 
+describe "TARGET_BULK_BYTES", :integration => true do
+  let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
+  let(:event_count) { 1000 }
+  let(:events) { event_count.times.map { event }.to_a }
+  let(:config) {
+      {
+        "hosts" => get_host_port,
+        "index" => index
+      }
+  }
+  let(:index) { 10.times.collect { rand(10).to_s }.join("") }
+  let(:type) { 10.times.collect { rand(10).to_s }.join("") }
+  subject { LogStash::Outputs::ElasticSearch.new(config) }
+
+
+  before do
+    subject.register
+    allow(subject.client).to receive(:bulk_send).with(any_args).and_call_original
+    subject.multi_receive(events)
+  end
+
+  describe "batches that are too large for one" do
+    let(:event) { LogStash::Event.new("message" => "a " * (((target_bulk_bytes/2) / event_count)+1)) }
+
+    it "should send in two batches" do
+      expect(subject.client).to have_received(:bulk_send).twice do |payload|
+        expect(payload.size).to be <= target_bulk_bytes
+      end
+    end
+
+    describe "batches that fit in one" do
+      # Normally you'd want to generate a request that's just 1 byte below the limit, but it's
+      # impossible to know how many bytes an event will serialize as with bulk proto overhead
+      let(:event) { LogStash::Event.new("message" => "a") }
+
+      it "should send in one batch" do
+        expect(subject.client).to have_received(:bulk_send).once do |payload|
+          expect(payload.size).to be <= target_bulk_bytes
+        end
+      end
+    end
+  end
+end
+
+
 describe "an indexer with custom index_type", :integration => true do
   it_behaves_like "an indexer" do
     let(:config) {
       {
         "hosts" => get_host_port,
-        "index" => index,
-        "flush_size" => flush_size
+        "index" => index
       }
     }
   end
@@ -60,8 +104,7 @@ describe "an indexer with no type value set (default to logs)", :integration => 
     let(:config) {
       {
         "hosts" => get_host_port,
-        "index" => index,
-        "flush_size" => flush_size
+        "index" => index
       }
     }
   end

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -4,7 +4,6 @@ shared_examples "a parent indexer" do
     let(:index) { 10.times.collect { rand(10).to_s }.join("") }
     let(:type) { 10.times.collect { rand(10).to_s }.join("") }
     let(:event_count) { 10000 + rand(500) }
-    let(:flush_size) { rand(200) + 1 }
     let(:parent) { "not_implemented" }
     let(:config) { "not_implemented" }
     subject { LogStash::Outputs::ElasticSearch.new(config) }
@@ -17,7 +16,7 @@ shared_examples "a parent indexer" do
       ftw.put!("#{index_url}", :body => mapping.to_json)
       pdoc = { "foo" => "bar" }
       ftw.put!("#{index_url}/#{type}_parent/test", :body => pdoc.to_json)
-      
+
       subject.register
       subject.multi_receive(event_count.times.map { LogStash::Event.new("link_to" => "test", "message" => "Hello World!", "type" => type) })
     end
@@ -49,7 +48,6 @@ describe "(http protocol) index events with static parent", :integration => true
       {
         "hosts" => get_host_port,
         "index" => index,
-        "flush_size" => flush_size,
         "parent" => parent
       }
     }
@@ -62,10 +60,8 @@ describe "(http_protocol) index events with fieldref in parent value", :integrat
       {
         "hosts" => get_host_port,
         "index" => index,
-        "flush_size" => flush_size,
         "parent" => "%{link_to}"
       }
     }
   end
 end
-

--- a/spec/integration/outputs/routing_spec.rb
+++ b/spec/integration/outputs/routing_spec.rb
@@ -4,7 +4,6 @@ shared_examples "a routing indexer" do
     let(:index) { 10.times.collect { rand(10).to_s }.join("") }
     let(:type) { 10.times.collect { rand(10).to_s }.join("") }
     let(:event_count) { 10000 + rand(500) }
-    let(:flush_size) { rand(200) + 1 }
     let(:routing) { "not_implemented" }
     let(:config) { "not_implemented" }
     subject { LogStash::Outputs::ElasticSearch.new(config) }
@@ -43,7 +42,6 @@ describe "(http protocol) index events with static routing", :integration => tru
       {
         "hosts" => get_host_port,
         "index" => index,
-        "flush_size" => flush_size,
         "routing" => routing
       }
     }
@@ -57,10 +55,8 @@ describe "(http_protocol) index events with fieldref in routing value", :integra
       {
         "hosts" => get_host_port,
         "index" => index,
-        "flush_size" => flush_size,
         "routing" => "%{message}"
       }
     }
   end
 end
-

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -3,7 +3,7 @@ require "logstash/outputs/elasticsearch/http_client"
 require "java"
 
 describe LogStash::Outputs::ElasticSearch::HttpClient do
-  let(:base_options) { {:hosts => ["127.0.0.1"], :logger => Cabin::Channel.get }}
+  let(:base_options) { {:hosts => ["127.0.0.1"], :logger => Cabin::Channel.get} }
 
   describe "Host/URL Parsing" do
     subject { described_class.new(base_options) }

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -10,9 +10,12 @@ trap finish EXIT
 
 setup_es() {
   download_url=$1
-  curl -sL $download_url > elasticsearch.tar.gz
-  mkdir elasticsearch
-  tar -xzf elasticsearch.tar.gz --strip-components=1 -C ./elasticsearch/.
+  if [[ ! -d elasticsearch ]]; then
+    curl -sL $download_url > elasticsearch.tar.gz
+    mkdir elasticsearch
+    tar -xzf elasticsearch.tar.gz --strip-components=1 -C ./elasticsearch/.
+  fi
+  rm -f elasticsearch/config/scripts || true
   ln -sn ../../spec/fixtures/scripts elasticsearch/config/.
 }
 
@@ -33,20 +36,25 @@ start_es() {
 if [[ "$INTEGRATION" != "true" ]]; then
   bundle exec rspec -fd spec
 else
+  if [ "$1" -eq "" ]; then
+    spec_path="spec"
+  else
+    spec_path="$1"
+  fi
   if [[ "$ES_VERSION" == 5.* ]]; then
     setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     start_es -Escript.inline=true -Escript.stored=true -Escript.file=true
     # Run all tests which are for versions > 5 but don't run ones tagged < 5.x. Include ingest, new template
-    bundle exec rspec -fd spec --tag integration --tag version_greater_than_equal_to_5x --tag ~version_less_than_5x
+    bundle exec rspec -fd --tag integration --tag version_greater_than_equal_to_5x --tag ~version_less_than_5x $spec_path
   elif [[ "$ES_VERSION" == 2.* ]]; then
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Run all tests which are for versions < 5 but don't run ones tagged 5.x and above. Skip ingest, new template
-    bundle exec rspec -fd spec --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x
+    bundle exec rspec -fd --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x $spec_path
   else
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Still have to support ES versions < 2.x so run tests for those.
-    bundle exec rspec -fd spec --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x
+    bundle exec rspec -fd --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x $spec_path
   fi
 fi


### PR DESCRIPTION
This PR changes the HTTP Client to try as best as it can to restrict bulk requests to 20MB or less. If a single document is larger than this it will be sent alone in a separate request.

This PR also changes the flush_size to be effectively infinite. If users have explicitly set the `flush_size` it will still work until that option is made obsolete.

Fixes #164, #284, #382, #453, #499
