### PR TITLE
Depends on Addressable 2.3.X instead of 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.1
+- depends on Adressable ~> 2.3.0 to satisfy development dependency of the core ([logstash/#6204](https://github.com/elastic/logstash/issues/6204))
+
 ## 5.3.0
 - Bulk operations will now target 20MB chunks at a time to reduce heap usage
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.3.0'
+  s.version         = '5.3.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency 'ftw', '~> 0.0.42'
-  s.add_development_dependency 'addressable', "~> 2.4.0" # used by FTW. V 2.5.0 is ruby 2.0 only. 
+  s.add_development_dependency 'addressable', "~> 2.3.0" # used by FTW. V 2.5.0 is ruby 2.0 only. 
   s.add_development_dependency 'logstash-codec-plain'
 
   if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
Some development dependencies of the core require to use 2.3.X and wont
work with 2.4