### PR TITLE
Use .bytesize not .size for bulk size checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.2
+- Use byte size, not char count for bulk operation size checks
+
 ## 5.3.1
 - depends on Adressable ~> 2.3.0 to satisfy development dependency of the core ([logstash/#6204](https://github.com/elastic/logstash/issues/6204))
 

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -75,7 +75,7 @@ module LogStash; module Outputs; class ElasticSearch;
                     LogStash::Json.dump(action)
         as_json << "\n"
 
-        if (bulk_body.size + as_json.size) > TARGET_BULK_BYTES
+        if (bulk_body.bytesize + as_json.bytesize) > TARGET_BULK_BYTES
           bulk_responses << bulk_send(bulk_body)
           bulk_body = as_json
         else

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.3.1'
+  s.version         = '5.3.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency 'ftw', '~> 0.0.42'
-  s.add_development_dependency 'addressable', "~> 2.3.0" # used by FTW. V 2.5.0 is ruby 2.0 only. 
+  s.add_development_dependency 'addressable', "~> 2.3.0" # used by FTW. V 2.5.0 is ruby 2.0 only.
   s.add_development_dependency 'logstash-codec-plain'
 
   if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
This makes things more accurate when multi-byte chars are in the source.
