### PR TITLE
Add `sprintf` or event dependent configuration when specifying ingest pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.4
+- Add `sprintf` or event dependent configuration when specifying ingest pipeline
+
 ## 5.3.3
 - Hide user/password in connection pool
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -146,7 +146,7 @@ module LogStash; module Outputs; class ElasticSearch;
       }
 
       if @pipeline
-        params[:pipeline] = @pipeline
+        params[:pipeline] = event.sprintf(@pipeline)
       end
 
      if @parent

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -137,7 +137,8 @@ module LogStash; module Outputs; class ElasticSearch
       # for more info
       mod.config :retry_on_conflict, :validate => :number, :default => 1
 
-      # Set which ingest pipeline you wish to execute for an event
+      # Set which ingest pipeline you wish to execute for an event. You can also use event dependent configuration
+      # here like `pipeline => "%{INGEST_PIPELINE}"`
       mod.config :pipeline, :validate => :string, :default => nil
     end
   end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.3.3'
+  s.version         = '5.3.4'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Previously, ingest pipeline config was not setup to use
event dependent configuration, but now it is.