### PR TITLE
Remove mention of elasticsearch_java output plugin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.5
+- Docs: Remove mention of using the elasticsearch_java output plugin because it is no longer supported
+
 ## 5.3.4
 - Add `sprintf` or event dependent configuration when specifying ingest pipeline
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -15,8 +15,7 @@ require "uri" # for escaping user input
 # This output only speaks the HTTP protocol. HTTP is the preferred protocol for interacting with Elasticsearch as of Logstash 2.0.
 # We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,
 # yet far easier to administer and work with. When using the HTTP protocol one may upgrade Elasticsearch versions without having
-# to upgrade Logstash in lock-step. For those still wishing to use the node or transport protocols please see
-# the <<plugins-outputs-elasticsearch_java,elasticsearch_java output plugin>>.
+# to upgrade Logstash in lock-step. 
 # 
 # You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
 #

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.3.4'
+  s.version         = '5.3.5'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
elasticsearch_java output is no longer supported in 5.0, so I'm removing it from the doc.

