### PR TITLE
Perform healthchecks at startup using state machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.0
+- Perform healthcheck against hosts right after startup / sniffing
+
 ## 5.3.5
 - Docs: Remove mention of using the elasticsearch_java output plugin because it is no longer supported
 

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -31,7 +31,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     def perform_request(url, method, path, params={}, body=nil)
       params = (params || {}).merge @request_options
       params[:body] = body if body
-      url_and_path = (url + path).to_s # Convert URI object to string
+      # Convert URI object to string
+      url_and_path = path ? (url + path).to_s  : url.to_s
 
       resp = @manticore.send(method.downcase, url_and_path, params)
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -64,10 +64,6 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       @stopping = false
       
       update_urls(initial_urls)
-      # Perform initial healthcheck to determine which URLs are alive
-      # We do this here because we don't want error messages on API actions unless
-      # this fails
-      healthcheck! 
       
       start_resurrectionist
       start_sniffer if @sniffing
@@ -285,6 +281,12 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           logger.info("Elasticsearch pool URLs updated", :changes => safe_state_changes(state_changes))
         end
       end
+      
+      # Run an inline healthcheck anytime URLs are updated
+      # This guarantees that during startup / post-startup
+      # sniffing we don't have idle periods waiting for the
+      # periodic sniffer to allow new hosts to come online
+      healthcheck! 
     end
     
     def safe_state_changes(state_changes)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '5.3.5'
+  s.version         = '5.4.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_proxy_spec.rb
+++ b/spec/unit/outputs/elasticsearch_proxy_spec.rb
@@ -1,6 +1,7 @@
 require_relative "../../../spec/es_spec_helper"
 require 'stud/temporary'
 require "logstash/outputs/elasticsearch"
+require 'manticore/client'
 
 describe "Proxy option" do
   let(:settings) {
@@ -14,7 +15,7 @@ describe "Proxy option" do
   }
 
   before do
-    allow(::Manticore::Client).to receive(:new).with(any_args)
+    allow(::Manticore::Client).to receive(:new).with(any_args).and_call_original
   end
 
   describe "valid configs" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -285,7 +285,7 @@ describe "outputs/elasticsearch" do
     subject(:eso) { LogStash::Outputs::ElasticSearch.new("validate_after_inactivity" => validate_after_inactivity) }
 
     before do
-      allow(::Manticore::Client).to receive(:new).with(any_args)
+      allow(::Manticore::Client).to receive(:new).with(any_args).and_call_original
       subject.register
     end
 


### PR DESCRIPTION
Refactored the pool.rb URL status to be more state-machine like.
URLs start as 'unknown' then after a healtcheck transition to 'alive'.

This was the cleanest way to fix #507