### PR TITLE
ensure event interpolation does not pollute event data

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -31,7 +31,7 @@ module LogStash; module Outputs; class ElasticSearch;
     # Convert the event into a 3-tuple of action, params, and event
     def event_action_tuple(event)
       params = event_action_params(event)
-      action = event.sprintf(@action)
+      action = safe_event_sprintf(event, @action)
       [action, params, event]
     end
 
@@ -139,23 +139,23 @@ module LogStash; module Outputs; class ElasticSearch;
       type = get_event_type(event)
 
       params = {
-        :_id => @document_id ? event.sprintf(@document_id) : nil,
-        :_index => event.sprintf(@index),
+        :_id => @document_id ? safe_event_sprintf(event, @document_id) : nil,
+        :_index => safe_event_sprintf(event, @index),
         :_type => type,
-        :_routing => @routing ? event.sprintf(@routing) : nil
+        :_routing => @routing ? safe_event_sprintf(event, @routing) : nil
       }
 
       if @pipeline
-        params[:pipeline] = event.sprintf(@pipeline)
+        params[:pipeline] = safe_event_sprintf(event, @pipeline)
       end
 
      if @parent
-        params[:parent] = event.sprintf(@parent)
+        params[:parent] = safe_event_sprintf(event, @parent)
       end
 
       if @action == 'update'
-        params[:_upsert] = LogStash::Json.load(event.sprintf(@upsert)) if @upsert != ""
-        params[:_script] = event.sprintf(@script) if @script != ""
+        params[:_upsert] = LogStash::Json.load(safe_event_sprintf(event, @upsert)) if @upsert != ""
+        params[:_script] = safe_event_sprintf(event, @script) if @script != ""
         params[:_retry_on_conflict] = @retry_on_conflict
       end
 
@@ -166,7 +166,7 @@ module LogStash; module Outputs; class ElasticSearch;
     def get_event_type(event)
       # Set the 'type' value for the index.
       type = if @document_type
-               event.sprintf(@document_type)
+               safe_event_sprintf(event, @document_type)
              else
                event.get("type") || "logs"
              end
@@ -238,6 +238,11 @@ module LogStash; module Outputs; class ElasticSearch;
         sleep_interval = sleep_for_interval(sleep_interval)
         retry unless @stopping.true?
       end
+    end
+
+    def safe_event_sprintf(event, expression)
+      result = event.sprintf(expression)
+      result.match(/%{/) ? nil : result
     end
   end
 end; end; end

--- a/spec/unit/outputs/elasticsearch/common_spec.rb
+++ b/spec/unit/outputs/elasticsearch/common_spec.rb
@@ -1,0 +1,25 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/elasticsearch/common"
+require "java"
+
+describe LogStash::Outputs::ElasticSearch::Common do
+  let(:including_class) { Class.new { extend LogStash::Outputs::ElasticSearch::Common } }
+  let(:event_data) { {} }
+  let(:event) { ::LogStash::Event.new(event_data) }
+
+  describe "safe_event_sprintf" do
+    context "with valid references" do
+      let(:event_data) { { "id" => "hello" } }
+      it "includes the value of the field reference" do
+        expect(including_class.safe_event_sprintf(event, "%{id}")).to eql("hello")
+      end
+    end
+
+    context "with invalid references" do
+      let(:event_data) { {} }
+      it "sets the param value to nil" do
+        expect(including_class.safe_event_sprintf(event, "%{id}")).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
eventually we could change Event#sprintf so it never leaks a field reference, but that can break existing setups, so I'm including a safer (slower) sprintf that checks if the result of sprintf contains a field reference, and returns `nil`

solves #518 
