### PR TITLE
Switch from beta to 5.1.1 for 5.x integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 - INTEGRATION=false
 - INTEGRATION=true ES_VERSION=1.7.5
 - INTEGRATION=true ES_VERSION=2.3.4
-- INTEGRATION=true ES_VERSION=5.0.0-beta1
+- INTEGRATION=true ES_VERSION=5.1.1
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
There's no reason to test against a beta anymore.