### PR TITLE
Add support for external version numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+*.swp
 *.gem
 Gemfile.lock
 .bundle
 .idea
 *~
 .ruby-version
+elasticsearch.tar.gz
+elasticsearch/
+lumberjack.key
+target/
+vendor/

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -61,6 +61,15 @@ module LogStash; module Outputs; class ElasticSearch
       # Elasticsearch with the same ID.
       mod.config :document_id, :validate => :string
 
+      # The version to use for indexing.
+      # See https://www.elastic.co/blog/elasticsearch-versioning-support.
+      mod.config :version, :validate => :string
+      
+      # The version_type to use for indexing.
+      # See https://www.elastic.co/blog/elasticsearch-versioning-support.
+      # See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
+      mod.config :version_type, :validate => ["internal", 'external', "external_gt", "external_gte", "force"]
+
       # A routing override to be applied to all processed events.
       # This can be dynamic using the `%{foo}` syntax.
       mod.config :routing, :validate => :string

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ftw', '~> 0.0.42'
   s.add_development_dependency 'addressable', "~> 2.3.0" # used by FTW. V 2.5.0 is ruby 2.0 only.
   s.add_development_dependency 'logstash-codec-plain'
+  s.add_development_dependency 'json' # used by spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
 
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM

--- a/spec/integration/outputs/create_spec.rb
+++ b/spec/integration/outputs/create_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../../spec/es_spec_helper"
 describe "client create actions", :integration => true do
   require "logstash/outputs/elasticsearch"
 
-  def get_es_output(action, id)
+  def get_es_output(action, id, version=nil, version_type=nil)
     settings = {
       "manage_template" => true,
       "index" => "logstash-create",
@@ -12,6 +12,8 @@ describe "client create actions", :integration => true do
       "action" => action
     }
     settings['document_id'] = id
+    settings['version'] = version if version
+    settings['version_type'] = version_type if version_type
     LogStash::Outputs::ElasticSearch.new(settings)
   end
 
@@ -35,6 +37,31 @@ describe "client create actions", :integration => true do
         r = @es.search
         insist { r["hits"]["total"] } == 1
       end
+    end
+
+    it "should allow default (internal) version" do
+      subject = get_es_output("create", "id123", 43)
+      subject.register
+    end
+
+    it "should allow internal version" do
+      subject = get_es_output("create", "id123", 43, "internal")
+      subject.register
+    end
+
+    it "should not allow external version" do
+      subject = get_es_output("create", "id123", 43, "external")
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+
+    it "should not allow external_gt version" do
+      subject = get_es_output("create", "id123", 43, "external_gt")
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+
+    it "should not allow external_gte version" do
+      subject = get_es_output("create", "id123", 43, "external_gte")
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
   end
 end

--- a/spec/integration/outputs/delete_spec.rb
+++ b/spec/integration/outputs/delete_spec.rb
@@ -1,0 +1,63 @@
+require_relative "../../../spec/es_spec_helper"
+require "logstash/outputs/elasticsearch"
+
+
+describe "Versioned delete", :integration => true, :version_greater_than_equal_to_2x => true do
+  require "logstash/outputs/elasticsearch"
+
+  let(:es) { get_client }
+
+  before :each do
+    # Delete all templates first.
+    # Clean ES of data before we start.
+    es.indices.delete_template(:name => "*")
+    # This can fail if there are no indexes, ignore failure.
+    es.indices.delete(:index => "*") rescue nil
+    es.indices.refresh
+  end
+
+  context "when delete only" do
+    subject { LogStash::Outputs::ElasticSearch.new(settings) }
+
+    before do
+      subject.register
+    end
+
+    let(:settings) do
+      {
+        "manage_template" => true,
+        "index" => "logstash-delete",
+        "template_overwrite" => true,
+        "hosts" => get_host_port(),
+        "document_id" => "%{my_id}",
+        "version" => "%{my_version}",
+        "version_type" => "external",
+        "action" => "%{my_action}"
+      }
+    end
+
+    it "should ignore non-monotonic external version updates" do
+      id = "ev2"
+      subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "index", "message" => "foo", "my_version" => 99)])
+      r = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+      expect(r['_version']).to eq(99)
+      expect(r['_source']['message']).to eq('foo')
+
+      subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "delete", "message" => "foo", "my_version" => 98)])
+      r2 = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+      expect(r2['_version']).to eq(99)
+      expect(r2['_source']['message']).to eq('foo')
+    end
+
+    it "should commit monotonic external version updates" do
+      id = "ev3"
+      subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "index", "message" => "foo", "my_version" => 99)])
+      r = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+      expect(r['_version']).to eq(99)
+      expect(r['_source']['message']).to eq('foo')
+
+      subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "delete", "message" => "foo", "my_version" => 100)])
+      expect { es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+  end
+end

--- a/spec/integration/outputs/index_version_spec.rb
+++ b/spec/integration/outputs/index_version_spec.rb
@@ -1,0 +1,101 @@
+require_relative "../../../spec/es_spec_helper"
+require "logstash/outputs/elasticsearch"
+
+
+describe "Versioned indexing", :integration => true, :version_greater_than_equal_to_2x => true do
+  require "logstash/outputs/elasticsearch"
+
+  let(:es) { get_client }
+
+  before :each do
+    # Delete all templates first.
+    # Clean ES of data before we start.
+    es.indices.delete_template(:name => "*")
+    # This can fail if there are no indexes, ignore failure.
+    es.indices.delete(:index => "*") rescue nil
+    es.indices.refresh
+  end
+
+  context "when index only" do
+    subject { LogStash::Outputs::ElasticSearch.new(settings) }
+
+    before do
+      subject.register
+    end
+
+    describe "unversioned output" do
+      let(:settings) do
+        {
+          "manage_template" => true,
+          "index" => "logstash-index",
+          "template_overwrite" => true,
+          "hosts" => get_host_port(),
+          "action" => "index",
+          "script_lang" => "groovy",
+          "document_id" => "%{my_id}"
+        }
+      end
+
+      it "should default to ES version" do
+        subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foo")])
+        r = es.get(:index => 'logstash-index', :type => 'logs', :id => "123", :refresh => true)
+        expect(r["_version"]).to eq(1)
+        expect(r["_source"]["message"]).to eq('foo')
+        subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foobar")])
+        r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => "123", :refresh => true)
+        expect(r2["_version"]).to eq(2)
+        expect(r2["_source"]["message"]).to eq('foobar')
+      end  
+    end
+
+    describe "versioned output" do
+      let(:settings) do 
+        {
+          "manage_template" => true,
+          "index" => "logstash-index",
+          "template_overwrite" => true,
+          "hosts" => get_host_port(),
+          "action" => "index",
+          "script_lang" => "groovy",
+          "document_id" => "%{my_id}",
+          "version" => "%{my_version}",
+          "version_type" => "external",
+        }
+      end
+
+      it "should respect the external version" do
+        id = "ev1"
+        subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
+        r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        expect(r["_version"]).to eq(99)
+        expect(r["_source"]["message"]).to eq('foo')
+      end
+
+      it "should ignore non-monotonic external version updates" do
+        id = "ev2"
+        subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
+        r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        expect(r["_version"]).to eq(99)
+        expect(r["_source"]["message"]).to eq('foo')
+
+        subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "98", "message" => "foo")])
+        r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        expect(r2["_version"]).to eq(99)
+        expect(r2["_source"]["message"]).to eq('foo')
+      end
+
+      it "should commit monotonic external version updates" do
+        id = "ev3"
+        subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
+        r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        expect(r["_version"]).to eq(99)
+        expect(r["_source"]["message"]).to eq('foo')
+
+        subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "100", "message" => "foo")])
+        r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        expect(r2["_version"]).to eq(100)
+        expect(r2["_source"]["message"]).to eq('foo')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'm just pushing an initial commit so I can see the tests run in TravisCI.

For some reason, I'm unable to run the tests locally. They fail with this error:

```
$ bundle exec rspec
The signal EXIT is in use by the JVM and will not work correctly on this platform
bundler: failed to load command: rspec (/home/john/repos/baz/logstash-output-elasticsearch/vendor/bundle/jruby/1.9/bin/rspec)
RuntimeError: 

        you might need to reinstall the gem which depends on the missing jar or in case there is Jars.lock then resolve the jars with `lock_jars` command

no such file to load -- org/apache/logging/log4j/log4j-core/2.6.2/log4j-core-2.6.2 (LoadError)
... (stacktrace) ...
```
