### PR TITLE
ensure query params are kept in manticore_adapter

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -79,6 +79,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         # First, we make sure the path is relative so URI.join does
         # the right thing
         relative_path = path && path.start_with?("/") ? path[1..-1] : path
+        # because URI.join obliterates the query parameter, we need to save it
+        # and restore it after this operation
         query = request_uri.query
         request_uri = URI.join(request_uri, relative_path)
         request_uri.query = query


### PR DESCRIPTION
a bug was found where manticore_adapter will remove the query parameters from the URI.

This PR extracts the url formatting from the manticore_adapter class, adds a few tests that show the problem, and fixes it.