### PR TITLE
No longer require escaping of 'password' option for special chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ Gemfile.lock
 *~
 .ruby-version
 elasticsearch.tar.gz
-elasticsearch/
+/elasticsearch/*
 lumberjack.key
 target/
 vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.2.2
+- Fixed a bug that forced users to URL encode the `password` option.
+  If you are currently manually escaping your passwords upgrading to this version
+  will break authentication. You should unescape your password if you have implemented
+  this workaround as it will otherwise be doubly encoded.
+  URL escaping is STILL required for passwords inline with URLs in the `hosts` option. 
+
 ## 6.2.1
 - When an HTTP error is encountered, log the response body instead of the request.
   The request body will still be logged at debug level.

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -87,6 +87,8 @@ module LogStash; module Outputs; class ElasticSearch
       #     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
       # It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
       # to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
+      # 
+      # Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
       mod.config :hosts, :validate => :uri, :default => [::LogStash::Util::SafeURI.new("//127.0.0.1")], :list => true
 
       # This plugin uses the bulk index API for improved indexing performance.

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module LogStash; module Outputs; class ElasticSearch;
   module HttpClientBuilder
     def self.build(logger, hosts, params)
@@ -119,11 +121,28 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def self.setup_basic_auth(logger, params)
       user, password = params["user"], params["password"]
-      return {} unless user && password
+      unsafe_password = password && password.value
+      unsafe_escaped_password = unsafe_password ? CGI.escape(unsafe_password) : nil
+      
+      # TODO: Remove this when we release LS6.0.0
+      if unsafe_password =~ /%[0-9A-Fa-f]{2}/
+        m <<-EOM
+        The Elasticsearch output was provided a password that looks like it includes URL encoded characters.
+        Previous versions of this plugin had a bug that required a workaround where users needed to manually
+        URL encode special characters in the password field. Given this, URL encoded strings will 
+        be doubly escaped making authentication fail. This may not apply to you.
+        If your password just happens to include string parts that simply look 
+        like URL encoded strings like '%2F' but are in fact just a part of your 
+        password then you can safely ignore this message. 
+        EOM
+        @logger.warn(m)
+      end
+      
+      return {} unless user && unsafe_escaped_password
 
       {
         :user => user,
-        :password => password.value
+        :password => unsafe_escaped_password
       }
     end
   end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '6.2.1'
+  s.version         = '6.2.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/http_client_builder_spec.rb
+++ b/spec/unit/http_client_builder_spec.rb
@@ -6,7 +6,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClientBuilder do
   describe "auth setup with url encodable passwords" do
     let(:klass) { LogStash::Outputs::ElasticSearch::HttpClientBuilder }
     let(:user) { "foo@bar"}
-    let(:password) {"baz@blah" }
+    let(:password) {"bazblah" }
     let(:password_secured) do
       secured = double("password")
       allow(secured).to receive(:value).and_return(password)
@@ -22,6 +22,14 @@ describe LogStash::Outputs::ElasticSearch::HttpClientBuilder do
 
     it "should return the password verbatim" do
       expect(auth_setup[:password]).to eql(password)
+    end
+    
+    context "passwords that need escaping" do
+      let(:password) { "foo@bar#" }
+      
+      it "should escape the password" do
+        expect(auth_setup[:password]).to eql("foo%40bar%23")
+      end
     end
   end
 end


### PR DESCRIPTION
There was a regression at some point where the `password` option required URL escaping. This fixes that issue by escaping the option for you.