### PR TITLE
Properly decode passwords when setting auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.3
+- Fixed a bug introduced in 6.2.2 where passwords needing escapes were not actually sent to ES properly
+  encoded. 
+
 ## 6.2.2
 - Fixed a bug that forced users to URL encode the `password` option.
   If you are currently manually escaping your passwords upgrading to this version

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -1,4 +1,5 @@
 require 'manticore'
+require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch; class HttpClient;
   class ManticoreAdapter
@@ -48,7 +49,13 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       params[:body] = body if body
 
       if url.user
-        params[:auth] = { :user => url.user, :password => url.password, :eager => true }
+        params[:auth] = { 
+          :user => url.user,
+          # We have to unescape the password here since manticore won't do it
+          # for us unless its part of the URL
+          :password => CGI.unescape(url.password), 
+          :eager => true 
+        }
       end
 
       request_uri = format_url(url, path)


### PR DESCRIPTION
6.2.2 broke passwords that need URL escaping completely. This fixes that PR by properly decoding the passwords before setting auth header.