### PR TITLE
Cleanup integration test use of insist + alt HTTP clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 ---
+addons:
+  apt:
+    packages:
+      - nginx
 sudo: false
 jdk: oraclejdk8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ addons:
   apt:
     packages:
       - nginx
-sudo: false
+# nginx does not like this
+# sudo: false
 jdk: oraclejdk8
 env:
 - INTEGRATION=false

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_development_dependency 'ftw', '~> 0.0.42'
-  s.add_development_dependency 'addressable', "~> 2.3.0" # used by FTW. V 2.5.0 is ruby 2.0 only.
   s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'json' # used by spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
 
@@ -35,5 +33,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'flores'
   # Still used in some specs, we should remove this ASAP
-  s.add_development_dependency 'elasticsearch'
 end

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -1,6 +1,4 @@
 require "logstash/devutils/rspec/spec_helper"
-require "ftw"
-require 'elasticsearch'
 
 module ESHelper
   def get_host_port
@@ -8,7 +6,41 @@ module ESHelper
   end
 
   def get_client
-    Elasticsearch::Client.new(:hosts => [get_host_port])
+    ::Manticore::Client.new()
+  end
+  
+  def send_request(method, location, params={})
+    url = location !~ /^https?:\/\// ? "http://#{get_host_port}/#{location}" : location
+    
+    if params[:body].is_a?(Hash)
+      params[:body] = ::LogStash::Json.dump(params[:body])
+    end
+    
+    resp = get_client.send(method, url, params)
+    resp.call # by default resp is lazy
+    resp
+  end
+  
+  def send_delete_all()
+    send_request(:delete, "/_template/*")
+    send_request(:delete, "/*")
+    send_refresh
+  end
+  
+  def send_refresh()
+    send_request(:post, "/_refresh")
+  end
+  
+  def send_json_request(*args)
+    body = send_request(*args).body
+    ::LogStash::Json.load(body)
+  rescue ::LogStash::Json::ParserError => e
+    raise "Caught a json parse error #{e} for args #{args}. Response: #{body}"
+  end
+  
+  def search_query_string(string)
+    send_refresh
+    send_json_request(:get, "/_search", query: {:q => string})
   end
 end
 

--- a/spec/fixtures/nginx_reverse_proxy.conf
+++ b/spec/fixtures/nginx_reverse_proxy.conf
@@ -1,11 +1,19 @@
 worker_processes  1;
 daemon off; # run in foreground
+error_log /dev/stderr;
 
 events {
   worker_connections 1024;
 }
 
 http {
+  access_log /dev/stdout;
+  client_body_temp_path /tmp/nginx/client_body;
+  proxy_temp_path /tmp/nginx/proxy_body;
+	fastcgi_temp_path /tmp/nginx/fastcgi;
+  uwsgi_temp_path /tmp/nginx/uwsgi;
+  scgi_temp_path /tmp/nginx/scgi;
+
   server {
     listen 9900 default_server;
     ssl on;
@@ -13,7 +21,11 @@ http {
     ssl_certificate_key server.key;
     client_max_body_size 200m;
 
+    client_body_temp_path /tmp/nginx/client_body;
+
     location / {
+      client_body_temp_path /tmp/nginx/client_body;
+
       proxy_pass http://localhost:9200;
       auth_basic "Restricted Content";
       auth_basic_user_file htpasswd;

--- a/spec/fixtures/nginx_reverse_proxy.conf
+++ b/spec/fixtures/nginx_reverse_proxy.conf
@@ -7,12 +7,6 @@ events {
 }
 
 http {
-  access_log /dev/stdout;
-  client_body_temp_path /tmp/nginx/client_body;
-  proxy_temp_path /tmp/nginx/proxy_body;
-	fastcgi_temp_path /tmp/nginx/fastcgi;
-  uwsgi_temp_path /tmp/nginx/uwsgi;
-  scgi_temp_path /tmp/nginx/scgi;
 
   server {
     listen 9900 default_server;
@@ -21,11 +15,7 @@ http {
     ssl_certificate_key server.key;
     client_max_body_size 200m;
 
-    client_body_temp_path /tmp/nginx/client_body;
-
     location / {
-      client_body_temp_path /tmp/nginx/client_body;
-
       proxy_pass http://localhost:9200;
       auth_basic "Restricted Content";
       auth_basic_user_file htpasswd;

--- a/spec/fixtures/users.txt
+++ b/spec/fixtures/users.txt
@@ -1,0 +1,2 @@
+simpleuser:abc123
+fancyuser:ab%12#

--- a/spec/integration/outputs/create_spec.rb
+++ b/spec/integration/outputs/create_spec.rb
@@ -18,12 +18,7 @@ describe "client create actions", :integration => true do
   end
 
   before :each do
-    @es = get_client
-    # Delete all templates first.
-    # Clean ES of data before we start.
-    @es.indices.delete_template(:name => "*")
-    # This can fail if there are no indexes, ignore failure.
-    @es.indices.delete(:index => "*") rescue nil
+    send_delete_all
   end
 
   context "when action => create" do
@@ -31,12 +26,9 @@ describe "client create actions", :integration => true do
       subject = get_es_output("create", "id123")
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-      @es.indices.refresh
-      # Wait or fail until everything's indexed.
-      Stud::try(3.times) do
-        r = @es.search
-        insist { r["hits"]["total"] } == 1
-      end
+      send_refresh
+      r = search_query_string("*")
+      expect(r["hits"]["total"]).to eq(1)
     end
 
     it "should allow default (internal) version" do

--- a/spec/integration/outputs/delete_spec.rb
+++ b/spec/integration/outputs/delete_spec.rb
@@ -5,15 +5,8 @@ require "logstash/outputs/elasticsearch"
 describe "Versioned delete", :integration => true, :version_greater_than_equal_to_2x => true do
   require "logstash/outputs/elasticsearch"
 
-  let(:es) { get_client }
-
   before :each do
-    # Delete all templates first.
-    # Clean ES of data before we start.
-    es.indices.delete_template(:name => "*")
-    # This can fail if there are no indexes, ignore failure.
-    es.indices.delete(:index => "*") rescue nil
-    es.indices.refresh
+    send_delete_all
   end
 
   context "when delete only" do
@@ -39,12 +32,12 @@ describe "Versioned delete", :integration => true, :version_greater_than_equal_t
     it "should ignore non-monotonic external version updates" do
       id = "ev2"
       subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "index", "message" => "foo", "my_version" => 99)])
-      r = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+      r = send_json_request(:get, "/logstash-delete/logs/#{id}")
       expect(r['_version']).to eq(99)
       expect(r['_source']['message']).to eq('foo')
 
       subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "delete", "message" => "foo", "my_version" => 98)])
-      r2 = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+      r2 = send_json_request(:get, "/logstash-delete/logs/#{id}")
       expect(r2['_version']).to eq(99)
       expect(r2['_source']['message']).to eq('foo')
     end
@@ -52,12 +45,12 @@ describe "Versioned delete", :integration => true, :version_greater_than_equal_t
     it "should commit monotonic external version updates" do
       id = "ev3"
       subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "index", "message" => "foo", "my_version" => 99)])
-      r = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+      r = send_json_request(:get, "/logstash-delete/logs/#{id}")
       expect(r['_version']).to eq(99)
       expect(r['_source']['message']).to eq('foo')
 
       subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "delete", "message" => "foo", "my_version" => 100)])
-      expect { es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+      expect(send_request(:get, "/logstash-delete/logs/#{id}").code).to eq(404)
     end
   end
 end

--- a/spec/integration/outputs/index_version_spec.rb
+++ b/spec/integration/outputs/index_version_spec.rb
@@ -5,15 +5,8 @@ require "logstash/outputs/elasticsearch"
 describe "Versioned indexing", :integration => true, :version_greater_than_equal_to_2x => true do
   require "logstash/outputs/elasticsearch"
 
-  let(:es) { get_client }
-
   before :each do
-    # Delete all templates first.
-    # Clean ES of data before we start.
-    es.indices.delete_template(:name => "*")
-    # This can fail if there are no indexes, ignore failure.
-    es.indices.delete(:index => "*") rescue nil
-    es.indices.refresh
+    send_delete_all
   end
 
   context "when index only" do
@@ -38,11 +31,11 @@ describe "Versioned indexing", :integration => true, :version_greater_than_equal
 
       it "should default to ES version" do
         subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => 'logs', :id => "123", :refresh => true)
+        r = send_json_request(:get, "/logstash-index/logs/123")
         expect(r["_version"]).to eq(1)
         expect(r["_source"]["message"]).to eq('foo')
         subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foobar")])
-        r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => "123", :refresh => true)
+        r2 = send_json_request(:get, "/logstash-index/logs/123")
         expect(r2["_version"]).to eq(2)
         expect(r2["_source"]["message"]).to eq('foobar')
       end  
@@ -66,7 +59,7 @@ describe "Versioned indexing", :integration => true, :version_greater_than_equal
       it "should respect the external version" do
         id = "ev1"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        r = send_json_request(:get, "/logstash-index/logs/#{id}")
         expect(r["_version"]).to eq(99)
         expect(r["_source"]["message"]).to eq('foo')
       end
@@ -74,12 +67,12 @@ describe "Versioned indexing", :integration => true, :version_greater_than_equal
       it "should ignore non-monotonic external version updates" do
         id = "ev2"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        r = send_json_request(:get, "/logstash-index/logs/#{id}")
         expect(r["_version"]).to eq(99)
         expect(r["_source"]["message"]).to eq('foo')
 
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "98", "message" => "foo")])
-        r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        r2 = send_json_request(:get, "/logstash-index/logs/#{id}")
         expect(r2["_version"]).to eq(99)
         expect(r2["_source"]["message"]).to eq('foo')
       end
@@ -87,12 +80,12 @@ describe "Versioned indexing", :integration => true, :version_greater_than_equal
       it "should commit monotonic external version updates" do
         id = "ev3"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        r = send_json_request(:get, "/logstash-index/logs/#{id}")
         expect(r["_version"]).to eq(99)
         expect(r["_source"]["message"]).to eq('foo')
 
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "100", "message" => "foo")])
-        r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+        r2 = send_json_request(:get, "/logstash-index/logs/#{id}")
         expect(r2["_version"]).to eq(100)
         expect(r2["_source"]["message"]).to eq('foo')
       end

--- a/spec/integration/outputs/pipeline_spec.rb
+++ b/spec/integration/outputs/pipeline_spec.rb
@@ -10,7 +10,6 @@ describe "Ingest pipeline execution behavior", :integration => true, :version_gr
     next LogStash::Outputs::ElasticSearch.new(settings)
   end
 
-  let(:ftw_client) { FTW::Agent.new }
   let(:ingest_url) { "http://#{get_host_port()}/_ingest/pipeline/apache-logs" }
   let(:apache_logs_pipeline) { '
     {
@@ -27,48 +26,33 @@ describe "Ingest pipeline execution behavior", :integration => true, :version_gr
   }
 
   before :each do
-    # Delete all templates first.
-    require "elasticsearch"
-
-    # Clean ES of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
-
-    # This can fail if there are no indexes, ignore failure.
-    @es.indices.delete(:index => "*") rescue nil
+    send_delete_all
 
     # delete existing ingest pipeline
-    req = ftw_client.delete(ingest_url)
-    ftw_client.execute(req)
+    send_request(:delete, ingest_url)
 
     # register pipeline
-    req = ftw_client.put(ingest_url, :body => apache_logs_pipeline)
-    ftw_client.execute(req)
-
-    #TODO: Use esclient
-    #@es.ingest.put_pipeline :id => 'apache_pipeline', :body => pipeline_defintion
+    send_request(:put, ingest_url, :body => apache_logs_pipeline)
 
     subject.register
     subject.multi_receive([LogStash::Event.new("message" => '183.60.215.50 - - [01/Jun/2015:18:00:00 +0000] "GET /scripts/netcat-webserver HTTP/1.1" 200 182 "-" "Mozilla/5.0 (compatible; EasouSpider; +http://www.easou.com/search/spider.html)"')])
-    @es.indices.refresh
+    send_refresh
 
-    #Wait or fail until everything's indexed.
-    Stud::try(20.times) do
-      r = @es.search
-      insist { r["hits"]["total"] } == 1
-    end
+    r = search_query_string("*")
+    expect(r["hits"]["total"]).to eq(1)
   end
 
   it "indexes using the proper pipeline" do
-    results = @es.search(:index => 'logstash-*', :q => "message:\"netcat\"")
-    insist { results["hits"]["total"] } == 1
-    insist { results["hits"]["hits"][0]["_source"]["response"] } == "200"
-    insist { results["hits"]["hits"][0]["_source"]["bytes"] } == "182"
-    insist { results["hits"]["hits"][0]["_source"]["verb"] } == "GET"
-    insist { results["hits"]["hits"][0]["_source"]["request"] } == "/scripts/netcat-webserver"
-    insist { results["hits"]["hits"][0]["_source"]["auth"] } == "-"
-    insist { results["hits"]["hits"][0]["_source"]["ident"] } == "-"
-    insist { results["hits"]["hits"][0]["_source"]["clientip"] } == "183.60.215.50"
-    insist { results["hits"]["hits"][0]["_source"]["junkfieldaaaa"] } == nil
+    results = send_json_request(:post, "/logstash-*/_search", :query => {:q => "message:\"netcat\""})
+    
+    expect(results["hits"]["total"]).to eq(1)
+    expect(results["hits"]["hits"][0]["_source"]["response"]).to eq("200")
+    expect(results["hits"]["hits"][0]["_source"]["bytes"]).to eq("182")
+    expect(results["hits"]["hits"][0]["_source"]["verb"]).to eq("GET")
+    expect(results["hits"]["hits"][0]["_source"]["request"]).to eq("/scripts/netcat-webserver")
+    expect(results["hits"]["hits"][0]["_source"]["auth"]).to eq("-")
+    expect(results["hits"]["hits"][0]["_source"]["ident"]).to eq("-")
+    expect(results["hits"]["hits"][0]["_source"]["clientip"]).to eq("183.60.215.50")
+    expect(results["hits"]["hits"][0]["_source"]["junkfieldaaaa"]).to eq(nil)
   end
 end

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -39,15 +39,8 @@ describe "failures in bulk class expected behavior", :integration => true do
   end
 
   before :each do
-    # Delete all templates first.
-    require "elasticsearch"
     allow(Stud).to receive(:stoppable_sleep)
-
-    # Clean ES of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
-    @es.indices.delete(:index => "*")
-    @es.indices.refresh
+    send_delete_all
   end
 
   after :each do
@@ -137,8 +130,8 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.multi_receive([invalid_event])
     subject.close
 
-    @es.indices.refresh
-    r = @es.search
+    send_delete_all
+    r = search_query_string("*")
     expect(r["hits"]["total"]).to eql(0)
   end
 
@@ -148,8 +141,7 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.register
     subject.multi_receive([event1])
     subject.close
-    @es.indices.refresh
-    r = @es.search
+    r = search_query_string("*")
     expect(r["hits"]["total"]).to eql(1)
   end
 
@@ -158,8 +150,7 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.multi_receive([invalid_event, event1])
     subject.close
 
-    @es.indices.refresh
-    r = @es.search
+    r = search_query_string("*")
     expect(r["hits"]["total"]).to eql(1)
   end
 end

--- a/spec/integration/outputs/routing_spec.rb
+++ b/spec/integration/outputs/routing_spec.rb
@@ -17,20 +17,14 @@ shared_examples "a routing indexer" do
 
 
     it "ships events" do
-      index_url = "http://#{get_host_port()}/#{index}"
-
-      ftw = FTW::Agent.new
-      ftw.post!("#{index_url}/_refresh")
+      send_refresh
 
       # Wait until all events are available.
       Stud::try(10.times) do
-        data = ""
-
-        response = ftw.get!("#{index_url}/_count?q=*&routing=#{routing}")
-        response.read_body { |chunk| data << chunk }
-        result = LogStash::Json.load(data)
-        cur_count = result["count"]
-        insist { cur_count } == event_count
+        response = send_json_request(:get, "#{index}/_count", :query => {routing: routing})
+        
+        cur_count = response["count"]
+        expect(cur_count).to eq(event_count)
       end
     end
 end

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -12,15 +12,8 @@ describe "index template expected behavior", :integration => true, :version_less
   end
 
   before :each do
-    # Delete all templates first.
-    require "elasticsearch"
-
     # Clean ES of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
-
-    # This can fail if there are no indexes, ignore failure.
-    @es.indices.delete(:index => "*") rescue nil
+    send_delete_all
 
     subject.register
 
@@ -35,57 +28,54 @@ describe "index template expected behavior", :integration => true, :version_less
       LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0 ] })
     ])
 
-    @es.indices.refresh
-
     # Wait or fail until everything's indexed.
-    Stud::try(20.times) do
-      r = @es.search
-      insist { r["hits"]["total"] } == 8
-    end
+    r = search_query_string("*")
+    expect(r["hits"]["total"]).to eq(8)
   end
 
   it "permits phrase searching on string fields" do
-    results = @es.search(:q => "message:\"sample message\"")
-    insist { results["hits"]["total"] } == 1
-    insist { results["hits"]["hits"][0]["_source"]["message"] } == "sample message here"
+    results = search_query_string("message:\"sample message\"")
+    expect(results["hits"]["total"]).to eq(1)
+    expect(results["hits"]["hits"][0]["_source"]["message"]).to eq("sample message here")
   end
 
   it "numbers dynamically map to a numeric type and permit range queries" do
-    results = @es.search(:q => "somevalue:[5 TO 105]")
-    insist { results["hits"]["total"] } == 2
+    results = search_query_string("somevalue:[5 TO 105]")
+    expect(results["hits"]["total"]).to eq(2)
 
     values = results["hits"]["hits"].collect { |r| r["_source"]["somevalue"] }
-    insist { values }.include?(10)
-    insist { values }.include?(100)
-    reject { values }.include?(1)
+    expect(values).to include(10)
+    expect(values).to include(100)
+    expect(values).not_to include(1)
   end
 
   it "does not create .raw field for the message field" do
-    results = @es.search(:q => "message.raw:\"sample message here\"")
-    insist { results["hits"]["total"] } == 0
+    results = search_query_string("message.raw:\"sample message here\"")
+    expect(results["hits"]["total"]).to eq(0)
   end
 
   it "creates .raw field for nested message fields" do
-    results = @es.search(:q => "somemessage.message.raw:\"sample nested message here\"")
-    insist { results["hits"]["total"] } == 1
+    results = search_query_string("somemessage.message.raw:\"sample nested message here\"")
+    expect(results["hits"]["total"]).to eq(1)
   end
 
   it "creates .raw field from any string field which is not_analyzed" do
-    results = @es.search(:q => "country.raw:\"us\"")
-    insist { results["hits"]["total"] } == 1
-    insist { results["hits"]["hits"][0]["_source"]["country"] } == "us"
+    results = search_query_string("country.raw:\"us\"")
+    expect(results["hits"]["total"]).to eq(1)
+    expect(results["hits"]["hits"][0]["_source"]["country"]).to eq("us")
 
     # partial or terms should not work.
-    results = @es.search(:q => "country.raw:\"u\"")
-    insist { results["hits"]["total"] } == 0
+    results = search_query_string("country.raw:\"u\"")
+    expect(results["hits"]["total"]).to eq(0)
   end
 
   it "make [geoip][location] a geo_point" do
-    expect(@es.indices.get_template(name: "logstash")["logstash"]["mappings"]["_default_"]["properties"]["geoip"]["properties"]["location"]["type"]).to eq("geo_point")
+    tmpl = send_json_request("/_template/logstash")
+    expect(tmpl["logstash"]["mappings"]["_default_"]["properties"]["geoip"]["properties"]["location"]["type"]).to eq("geo_point")
   end
 
   it "aggregate .raw results correctly " do
-    results = @es.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.raw" } } } })["aggregations"]["my_agg"]
+    results = send_json_request(:get, "/_search", :body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.raw" } } } })["aggregations"]["my_agg"]
     terms = results["buckets"].collect { |b| b["key"] }
 
     insist { terms }.include?("us")
@@ -94,5 +84,3 @@ describe "index template expected behavior", :integration => true, :version_less
     insist { terms }.include?("at")
   end
 end
-
-

--- a/start_nginx.sh
+++ b/start_nginx.sh
@@ -5,4 +5,4 @@ if [ ! -f spec/fixtures/server.key ] || [ ! -f spec/fixtures/server.crt ]; then
 	openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout spec/fixtures/server.key -out spec/fixtures/server.crt -days 365 -subj /CN=localhost
 fi
 
-/usr/bin/env nginx -c $(pwd)/spec/fixtures/nginx_reverse_proxy.conf
+sudo -u www-data /usr/bin/env nginx -c $(pwd)/spec/fixtures/nginx_reverse_proxy.conf

--- a/start_nginx.sh
+++ b/start_nginx.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
+mkdir -p /tmp/nginx
 
 if [ ! -f spec/fixtures/server.key ] || [ ! -f spec/fixtures/server.crt ]; then
 	openssl req -x509 -batch -nodes -newkey rsa:2048 -keyout spec/fixtures/server.key -out spec/fixtures/server.crt -days 365 -subj /CN=localhost
 fi
 
-nginx -c $(pwd)/spec/fixtures/nginx_reverse_proxy.conf
+/usr/bin/env nginx -c $(pwd)/spec/fixtures/nginx_reverse_proxy.conf

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -34,6 +34,9 @@ start_es() {
 }
 
 start_nginx() {
+  nginx=`which nginx`
+  echo "nginx Path: $nginx"
+
   status_command='curl -k --silent --output /dev/stderr --write-out "%{http_code}" https://simpleuser:abc123@localhost:9900'
 
   status=$($status_command | tr -d '"')
@@ -52,6 +55,7 @@ start_nginx() {
     echo "nginx started successfully!"
   else
     echo "NGINX could not be started successfully"
+    ps aux | grep [n]ginx
     curl -k -i https://simpleuser:abc123@localhost:9900
     exit 1
   fi


### PR DESCRIPTION
Removes dev dependency on 'elasticsearch' and 'ftw' gems.
Adds new helpers for testing against ES directly using Manticore.
Converts all legacy `insist` tests to standard `expect`.