### PR TITLE
Reject default password of 'changeme'

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -15,6 +15,10 @@ module LogStash; module Outputs; class ElasticSearch;
     VERSION_TYPES_PERMITTING_CONFLICT = ["external", "external_gt", "external_gte"]
 
     def register
+      if @password && @password.value == "changeme"
+        raise LogStash::ConfigurationError, "The password 'changeme' is an indication you should actually change this password before accessing Elasticsearch. To resolve this, you must change the password for the configured user to something other than 'changeme'."
+      end
+
       @stopping = Concurrent::AtomicBoolean.new(false)
       setup_hosts # properly sets @hosts
       build_client

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -441,4 +441,21 @@ describe "outputs/elasticsearch" do
       end
     end
   end
+
+  context "for safety" do
+    context "when the password is 'changeme'" do
+      let(:config) do
+        {
+          "user" => "elastic",
+          "password" => "changeme"
+        }
+      end
+
+      subject { LogStash::Outputs::ElasticSearch.new(config) }
+
+      it "the configuration should be rejected" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /changeme/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Safety first!

The intent of this is to force users to actually change the default
password often given to users by administrators. Further, x-pack
has a default password of 'changeme' and so this now requires users to
change this password in Elasticsearch before Logstash will run.