### PR TITLE
Use the correct Content-Type header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 jdk: oraclejdk8
 env:
 - INTEGRATION=false
-- INTEGRATION=true ES_VERSION=1.7.5
-- INTEGRATION=true ES_VERSION=2.3.4
-- INTEGRATION=true ES_VERSION=5.1.1
+- INTEGRATION=true ES_VERSION=1.7.5 TEST_DEBUG=true
+- INTEGRATION=true ES_VERSION=2.3.4 TEST_DEBUG=true
+- INTEGRATION=true ES_VERSION=5.1.1 TEST_DEBUG=true
 language: ruby
 cache: bundler
 rvm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.2.5
+- Send the Content-Type: application/json header that proper ES clients should send
+
 ## 6.2.4
 - Fix bug where using escaped characters in the password field would attempt to show a warning but instead crash.
   The warning was also not necessary since escaped characters never worked there before.

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -2,6 +2,8 @@ require 'manticore'
 require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch; class HttpClient;
+  DEFAULT_HEADERS = { "Content-Type" => "application/json" }
+  
   class ManticoreAdapter
     attr_reader :manticore, :logger
 
@@ -15,7 +17,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # We definitely don't need cookies
       options[:cookies] = false
 
-      @request_options = options[:headers] ? {:headers => @options[:headers]} : {}
+      @client_params = {:headers => DEFAULT_HEADERS.merge(options[:headers] || {})}
       
       if options[:proxy]
         options[:proxy] = manticore_proxy_hash(options[:proxy])
@@ -45,7 +47,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     # @see    Transport::Base#perform_request
     #
     def perform_request(url, method, path, params={}, body=nil)
-      params = (params || {}).merge @request_options
+      params = (params || {}).merge(@client_params)
       params[:body] = body if body
 
       if url.user

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '6.2.4'
+  s.version         = '6.2.5'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -44,7 +44,7 @@ describe "TARGET_BULK_BYTES", :integration => true do
   end
 end
 
-describe "indexing" do
+describe "indexing", :integration => true do
   let(:event) { LogStash::Event.new("message" => "Hello World!", "type" => type) }
   let(:index) { 10.times.collect { rand(10).to_s }.join("") }
   let(:type) { 10.times.collect { rand(10).to_s }.join("") }
@@ -82,6 +82,13 @@ describe "indexing" do
         expect(doc["_index"]).to eq(index)
       end
     end
+    
+    it "sets the correct content-type header" do
+      expect(subject.client.pool.adapter.client).to receive(:send).
+        with(anything, anything, {:headers => {"Content-Type" => "application/json"}, :body => anything}).
+        and_call_original
+      subject.multi_receive(events)
+    end
   end
 
   describe "an indexer with custom index_type", :integration => true do
@@ -105,7 +112,7 @@ describe "indexing" do
     it_behaves_like("an indexer")
   end
 
-  describe "a secured indexer", :integration => true do
+  describe "a secured indexer", :secure_integration => true do
     let(:user) { "simpleuser" }
     let(:password) { "abc123" }
     let(:cacert) { "spec/fixtures/server.crt" }

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -28,6 +28,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
       allow(resp).to receive(:code).and_return(200)
       expect(subject.manticore).to receive(:get).
         with(noauth_uri, {
+          :headers => {"Content-Type" => "application/json"},
           :auth => {
             :user => user,
             :password => password,

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -50,16 +50,16 @@ else
     setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     start_es -Escript.inline=true -Escript.stored=true -Escript.file=true
     # Run all tests which are for versions > 5 but don't run ones tagged < 5.x. Include ingest, new template
-    bundle exec rspec -fd --tag ~secured_integration --tag integration --tag version_greater_than_equal_to_5x --tag ~version_less_than_5x $spec_path
+    bundle exec rspec -fd --tag ~secure_integration --tag integration --tag version_greater_than_equal_to_5x --tag ~version_less_than_5x $spec_path
   elif [[ "$ES_VERSION" == 2.* ]]; then
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Run all tests which are for versions < 5 but don't run ones tagged 5.x and above. Skip ingest, new template
-    bundle exec rspec -fd --tag ~secured_integration --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x $spec_path
+    bundle exec rspec -fd --tag ~secure_integration --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x $spec_path
   else
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Still have to support ES versions < 2.x so run tests for those.
-    bundle exec rspec -fd --tag ~secured_integration --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x $spec_path
+    bundle exec rspec -fd --tag ~secure_integration --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x $spec_path
   fi
 fi

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -50,16 +50,16 @@ else
     setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     start_es -Escript.inline=true -Escript.stored=true -Escript.file=true
     # Run all tests which are for versions > 5 but don't run ones tagged < 5.x. Include ingest, new template
-    bundle exec rspec -fd --tag integration --tag version_greater_than_equal_to_5x --tag ~version_less_than_5x $spec_path
+    bundle exec rspec -fd --tag ~secured_integration --tag integration --tag version_greater_than_equal_to_5x --tag ~version_less_than_5x $spec_path
   elif [[ "$ES_VERSION" == 2.* ]]; then
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Run all tests which are for versions < 5 but don't run ones tagged 5.x and above. Skip ingest, new template
-    bundle exec rspec -fd --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x $spec_path
+    bundle exec rspec -fd --tag ~secured_integration --tag integration --tag version_less_than_5x --tag ~version_greater_than_equal_to_5x $spec_path
   else
     setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
     start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
     # Still have to support ES versions < 2.x so run tests for those.
-    bundle exec rspec -fd --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x $spec_path
+    bundle exec rspec -fd --tag ~secured_integration --tag integration --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x $spec_path
   fi
 fi


### PR DESCRIPTION
When we switched away from using the 'elasticsearch' gem to using our own internal implementation we didn't port this behavior. Official clients should send the correct content-type header.

This patch also adds an extra rspec scope for integration tests requiring SSL so that tests will pass again on travis. Those tests broke a couple commits ago and that wasn't detected because at the time travis-ci was broken even though they passed locally with nginx started.