### PR TITLE
change url handling of health check requests

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -173,14 +173,21 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # When a backend is marked down a HEAD request will be sent to this path in the
   # background to see if it has come back again before it is once again eligible
-  # to service requests. If you have custom firewall rules you may need to change
-  # this
+  # to service requests. If you have custom firewall rules you may need to change this
+  # NOTE: any query parameters present in the URL or query_params config option will be removed
   config :healthcheck_path, :validate => :string, :default => "/"
-  # When a `healthcheck_path` config is provided, this additional flag can be used to 
-  # specify whether it is an absolute URI or a relative path. 
-  # If this flag is true, `healthcheck_path` is expected to be a fully formed URL 
-  # with any basic auth credentials provided in the URL itself.
+
+  # When a `healthcheck_path` config is provided, this additional flag can be used to
+  # specify whether the healthcheck_path is appended to the existing path (default)
+  # or is treated as the absolute URL path.
+  #
+  # For example, if hosts url is "http://localhost:9200/es" and healthcheck_path is "/health",
+  # the health check url will be:
+  #
+  # * with `absolute_healthcheck_path: true`: "http://localhost:9200/es/health"
+  # * with `absolute_healthcheck_path: false`: "http://localhost:9200/health"
   config :absolute_healthcheck_path, :validate => :boolean, :default => false
+
   # How frequently, in seconds, to wait between resurrection attempts.
   # Resurrection is the process by which backend endpoints marked 'down' are checked
   # to see if they have come back to life

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -231,10 +231,10 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       @state_mutex.synchronize { @url_info.select {|url,meta| meta[:state] != :alive } }.each do |url,meta|
         begin
           path = healthcheck_path
-          healthcheck_url = url
+          healthcheck_url = LogStash::Util::SafeURI.new(url.uri.clone)
+          healthcheck_url.query = nil
           if @absolute_healthcheck_path
-            healthcheck_url = ::LogStash::Util::SafeURI.new(healthcheck_path)
-            path = ROOT_URI_PATH
+            healthcheck_url.path = ROOT_URI_PATH
           end
           logger.info("Running health check to see if an Elasticsearch connection is working",
                         :healthcheck_url => healthcheck_url, :path => path)


### PR DESCRIPTION
This commit makes `absolute_healthcheck_path` change how the healthcheck_path is treated: either append it to any existing path (default) or replace any existing path

Also ensures that the healthcheck url contains no query parameters regarless of hosts urls contains them or query_params being set

depends on https://github.com/elastic/logstash/pull/6645