### PR TITLE
Implement HTTP redirect caching

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -103,6 +103,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # not also set this field. That will raise an error at startup
   config :path, :validate => :string
 
+  # Follow and cache HTTP redirects
+  config :cache_redirect, :validate => :boolean, :default => false
+
   # Pass a set of key value pairs as the URL query string. This query string is added
   # to every host listed in the 'hosts' configuration. If the 'hosts' list contains
   # urls that already have query strings, the one specified here will be appended.

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -36,7 +36,9 @@ module LogStash; module Outputs; class ElasticSearch;
     # * `:user` - String. The user to use for authentication.
     # * `:password` - String. The password to use for authentication.
     # * `:timeout` - Float. A duration value, in seconds, after which a socket
-    #    operation or request will be aborted if not yet successfull
+    #    operation or request will be aborted if not yet successful
+    # * `:cache_redirect` - Boolean. Determine if HTTP 302 responses will
+    #    update `:hosts`
     # * `:client_settings` - a hash; see below for keys.
     #
     # The `client_settings` key is a has that can contain other settings:
@@ -221,6 +223,7 @@ module LogStash; module Outputs; class ElasticSearch;
       adapter_options = {
         :socket_timeout => timeout,
         :request_timeout => timeout,
+        :cache_redirect => options[:cache_redirect]
       }
 
       adapter_options[:proxy] = client_settings[:proxy] if client_settings[:proxy]
@@ -251,6 +254,7 @@ module LogStash; module Outputs; class ElasticSearch;
         :sniffer_delay => options[:sniffer_delay],
         :healthcheck_path => options[:healthcheck_path],
         :absolute_healthcheck_path => options[:absolute_healthcheck_path],
+        :cache_redirect => options[:cache_redirect],
         :resurrect_delay => options[:resurrect_delay],
         :url_normalizer => self.method(:host_to_url)
       }

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -2,8 +2,6 @@ require 'manticore'
 require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch; class HttpClient;
-  DEFAULT_HEADERS = { "Content-Type" => "application/json" }
-  
   class ManticoreAdapter
     attr_reader :manticore, :logger
 
@@ -17,13 +15,19 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # We definitely don't need cookies
       options[:cookies] = false
 
-      @client_params = {:headers => DEFAULT_HEADERS.merge(options[:headers] || {})}
+      @request_options = options[:headers] ? {:headers => @options[:headers]} : {}
       
       if options[:proxy]
         options[:proxy] = manticore_proxy_hash(options[:proxy])
       end
       
-      @manticore = ::Manticore::Client.new(options)
+      @manticore = ::Manticore::Client.new(options) do |http_client_builder, request_builder|
+        if options[:cache_redirect]
+          # We'll manage redirects and cache them
+          @logger.info("Disabling Manticore redirect handling")
+          http_client_builder.disable_redirect_handling
+        end
+      end
     end
     
     # Transform the proxy option to a hash. Manticore's support for non-hash
@@ -47,7 +51,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     # @see    Transport::Base#perform_request
     #
     def perform_request(url, method, path, params={}, body=nil)
-      params = (params || {}).merge(@client_params)
+      params = (params || {}).merge @request_options
       params[:body] = body if body
 
       if url.user
@@ -72,7 +76,9 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # 404s are excluded because they are valid codes in the case of
       # template installation. We might need a better story around this later
       # but for our current purposes this is correct
-      if resp.code < 200 || resp.code > 299 && resp.code != 404
+      if resp.code == 302 && resp.headers["location"]
+        raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::RedirectError.new(resp.headers["location"])
+      elsif resp.code < 200 || resp.code > 299 && resp.code != 404
         raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(resp.code, request_uri, body, resp.body)
       end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -15,7 +15,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # We definitely don't need cookies
       options[:cookies] = false
 
-      @request_options = options[:headers] ? {:headers => @options[:headers]} : {}
+      @client_params = {:headers => DEFAULT_HEADERS.merge(options[:headers] || {})}
       
       if options[:proxy]
         options[:proxy] = manticore_proxy_hash(options[:proxy])
@@ -51,7 +51,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     # @see    Transport::Base#perform_request
     #
     def perform_request(url, method, path, params={}, body=nil)
-      params = (params || {}).merge @request_options
+      params = (params || {}).merge(@client_params)
       params[:body] = body if body
 
       if url.user

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -27,14 +27,26 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         "Elasticsearch Unreachable: [#{@url}][#{original_error.class}] #{original_error.message}"
       end
     end
+    class RedirectError < Error
+      attr_reader :location
 
-    attr_reader :logger, :adapter, :sniffing, :sniffer_delay, :resurrect_delay, :healthcheck_path, :absolute_healthcheck_path
+      def initialize(location)
+        @location = location
+      end
+
+      def message
+        "Elasticsearch returned an HTTP redirect to #{@location}"
+      end
+    end
+
+    attr_reader :logger, :adapter, :sniffing, :sniffer_delay, :resurrect_delay, :healthcheck_path, :absolute_healthcheck_path, :cache_redirect
 
     ROOT_URI_PATH = '/'.freeze
 
     DEFAULT_OPTIONS = {
       :healthcheck_path => ROOT_URI_PATH,
       :absolute_healthcheck_path => false,
+      :cache_redirect => false,
       :scheme => 'http',
       :resurrect_delay => 5,
       :sniffing => false,
@@ -51,6 +63,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       DEFAULT_OPTIONS.merge(options).tap do |merged|
         @healthcheck_path = merged[:healthcheck_path]
         @absolute_healthcheck_path = merged[:absolute_healthcheck_path]
+        @cache_redirect = merged[:cache_redirect]
         @resurrect_delay = merged[:resurrect_delay]
         @sniffing = merged[:sniffing]
         @sniffer_delay = merged[:sniffer_delay]
@@ -242,6 +255,15 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           # If no exception was raised it must have succeeded!
           logger.warn("Restored connection to ES instance", :url => healthcheck_url.sanitized)
           @state_mutex.synchronize { meta[:state] = :alive }
+        rescue RedirectError => e
+          if @cache_redirect
+            logger.info("Caching HTTP redirect: #{e.location}")
+            redirect = LogStash::Util::SafeURI.new(e.location)
+            update_urls([redirect])
+          else
+            logger.error("Received a redirect but redirect caching is disabled: #{e.location}")
+            raise e
+          end
         rescue HostUnreachableError, BadResponseCodeError => e
           logger.warn("Attempted to resurrect connection to dead ES instance, but got an error.", url: url.sanitized, error_type: e.class, error: e.message)
         end
@@ -356,6 +378,9 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     rescue BadResponseCodeError => e
       # These aren't discarded from the pool because these are often very transient
       # errors
+      raise e
+    rescue RedirectError => e
+      logger.warn("Received unexpected HTTP redirect")
       raise e
     rescue => e
       logger.warn("UNEXPECTED POOL ERROR", :e => e)

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -15,7 +15,8 @@ module LogStash; module Outputs; class ElasticSearch;
         :client_settings => client_settings,
         :resurrect_delay => params["resurrect_delay"],
         :healthcheck_path => params["healthcheck_path"],
-        :absolute_healthcheck_path => params["absolute_healthcheck_path"]
+        :absolute_healthcheck_path => params["absolute_healthcheck_path"],
+        :cache_redirect => params["cache_redirect"]
       }
 
       if params["sniffing"]


### PR DESCRIPTION
Hi. I opened a topic on discuss.elastic.co about a week ago asking for feedback on interest in adding the ability to cache HTTP redirects in filebeat about a week ago. I had planned on discussing adding the feature to this plugin as well. However, as I got no feedback on the original topic, I'm going to go ahead and submit the PR. I've completed a CLA as rayharris-ibm/harrisra@us.ibm.com. And here is the link to the discuss topic:

https://discuss.elastic.co/t/add-ability-to-cache-http-redirects-in-elasticsearch-output/73901