### PR TITLE
Implement HTTP redirect caching

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -103,6 +103,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # not also set this field. That will raise an error at startup
   config :path, :validate => :string
 
+  # Follow and cache HTTP redirects
+  config :cache_redirect, :validate => :boolean, :default => false
+
   # Pass a set of key value pairs as the URL query string. This query string is added
   # to every host listed in the 'hosts' configuration. If the 'hosts' list contains
   # urls that already have query strings, the one specified here will be appended.

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -36,7 +36,9 @@ module LogStash; module Outputs; class ElasticSearch;
     # * `:user` - String. The user to use for authentication.
     # * `:password` - String. The password to use for authentication.
     # * `:timeout` - Float. A duration value, in seconds, after which a socket
-    #    operation or request will be aborted if not yet successfull
+    #    operation or request will be aborted if not yet successful
+    # * `:cache_redirect` - Boolean. Determine if HTTP 302 responses will
+    #    update `:hosts`
     # * `:client_settings` - a hash; see below for keys.
     #
     # The `client_settings` key is a has that can contain other settings:
@@ -221,6 +223,7 @@ module LogStash; module Outputs; class ElasticSearch;
       adapter_options = {
         :socket_timeout => timeout,
         :request_timeout => timeout,
+        :cache_redirect => options[:cache_redirect]
       }
 
       adapter_options[:proxy] = client_settings[:proxy] if client_settings[:proxy]
@@ -251,6 +254,7 @@ module LogStash; module Outputs; class ElasticSearch;
         :sniffer_delay => options[:sniffer_delay],
         :healthcheck_path => options[:healthcheck_path],
         :absolute_healthcheck_path => options[:absolute_healthcheck_path],
+        :cache_redirect => options[:cache_redirect],
         :resurrect_delay => options[:resurrect_delay],
         :url_normalizer => self.method(:host_to_url)
       }

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -23,7 +23,13 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         options[:proxy] = manticore_proxy_hash(options[:proxy])
       end
       
-      @manticore = ::Manticore::Client.new(options)
+      @manticore = ::Manticore::Client.new(options) do |http_client_builder, request_builder|
+        if options[:cache_redirect]
+           # We'll manage redirects and cache them
+           @logger.info("Disabling Manticore redirect handling")
+           http_client_builder.disable_redirect_handling
+        end
+      end
     end
     
     # Transform the proxy option to a hash. Manticore's support for non-hash
@@ -72,7 +78,9 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # 404s are excluded because they are valid codes in the case of
       # template installation. We might need a better story around this later
       # but for our current purposes this is correct
-      if resp.code < 200 || resp.code > 299 && resp.code != 404
+      if resp.code == 302 && resp.headers["location"]
+        raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::RedirectError.new(resp.headers["location"])
+      elsif resp.code < 200 || resp.code > 299 && resp.code != 404
         raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(resp.code, request_uri, body, resp.body)
       end
 

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -15,7 +15,8 @@ module LogStash; module Outputs; class ElasticSearch;
         :client_settings => client_settings,
         :resurrect_delay => params["resurrect_delay"],
         :healthcheck_path => params["healthcheck_path"],
-        :absolute_healthcheck_path => params["absolute_healthcheck_path"]
+        :absolute_healthcheck_path => params["absolute_healthcheck_path"],
+        :cache_redirect => params["cache_redirect"]
       }
 
       if params["sniffing"]


### PR DESCRIPTION
Hi. I opened a topic on discuss.elastic.co about a week ago asking for feedback on interest in adding the ability to cache HTTP redirects in filebeat about a week ago. I had planned on discussing adding the feature to this plugin as well. However, as I got no feedback on the original topic, I'm going to go ahead and submit the PR. I've completed a CLA as rayharris-ibm/harrisra@us.ibm.com. And here is the link to the discuss topic:

https://discuss.elastic.co/t/add-ability-to-cache-http-redirects-in-elasticsearch-output/73901