### PR TITLE
introduce customization of bulk, healthcheck and sniffing paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.0.0
+- introduce customization of bulk, healthcheck and sniffing paths with the behaviour:
+  - if not set: the default value will be used
+  - if not set and path is also set: the default is appended to path
+  - if set: the set value will be used, ignoring the default and path setting
+- removes absolute_healthcheck_path and query_parameters
+
 ## 6.2.6
 - Fixed: Change how the healthcheck_path is treated: either append it to any existing path (default) or replace any existing path
   Also ensures that the healthcheck url contains no query parameters regarless of hosts urls contains them or query_params being set. #554

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -103,6 +103,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # not also set this field. That will raise an error at startup
   config :path, :validate => :string
 
+  # HTTP Path to perform the _bulk requests to
+  # this defaults to a concatenation of the path parameter and "_bulk"
+  config :bulk_path, :validate => :string
+
   # Pass a set of key value pairs as the URL query string. This query string is added
   # to every host listed in the 'hosts' configuration. If the 'hosts' list contains
   # urls that already have query strings, the one specified here will be appended.
@@ -145,6 +149,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # How long to wait, in seconds, between sniffing attempts
   config :sniffing_delay, :validate => :number, :default => 5
 
+  # HTTP Path to be used for the sniffing requests
+  # the default value is computed by concatenating the path value and "_nodes/http"
+  # if sniffing_path is set it will be used as an absolute path
+  # do not use full URL here, only paths, e.g. "/sniff/_nodes/http"
+  config :sniffing_path, :validate => :string
+
   # Set the address of a forward HTTP proxy.
   # This used to accept hashes as arguments but now only accepts
   # arguments of the URI type to prevent leaking credentials.
@@ -171,22 +181,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # which is bad.
   config :pool_max_per_route, :validate => :number, :default => 100
 
-  # When a backend is marked down a HEAD request will be sent to this path in the
-  # background to see if it has come back again before it is once again eligible
-  # to service requests. If you have custom firewall rules you may need to change this
-  # NOTE: any query parameters present in the URL or query_params config option will be removed
-  config :healthcheck_path, :validate => :string, :default => "/"
-
-  # When a `healthcheck_path` config is provided, this additional flag can be used to
-  # specify whether the healthcheck_path is appended to the existing path (default)
-  # or is treated as the absolute URL path.
-  #
-  # For example, if hosts url is "http://localhost:9200/es" and healthcheck_path is "/health",
-  # the health check url will be:
-  #
-  # * with `absolute_healthcheck_path: true`: "http://localhost:9200/es/health"
-  # * with `absolute_healthcheck_path: false`: "http://localhost:9200/health"
-  config :absolute_healthcheck_path, :validate => :boolean, :default => false
+  # HTTP Path where a HEAD request is sent when a backend is marked down
+  # the request is sent in the background to see if it has come back again
+  # before it is once again eligible to service requests.
+  # If you have custom firewall rules you may need to change this
+  config :healthcheck_path, :validate => :string
 
   # How frequently, in seconds, to wait between resurrection attempts.
   # Resurrection is the process by which backend endpoints marked 'down' are checked

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -58,6 +58,7 @@ module LogStash; module Outputs; class ElasticSearch;
       @pool = build_pool(@options)
       # mutex to prevent requests and sniffing to access the
       # connection pool at the same time
+      @bulk_path = @options[:bulk_path]
     end
     
     def build_url_template
@@ -129,8 +130,7 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def bulk_send(bulk_body)
-      # Discard the URL
-      url, response = @pool.post("_bulk", nil, bulk_body)
+      _, response = @pool.post(@bulk_path, nil, bulk_body)
       LogStash::Json.load(response.body)
     end
 
@@ -138,7 +138,6 @@ module LogStash; module Outputs; class ElasticSearch;
       @pool.close
     end
 
-    
     def calculate_property(uris, property, default, sniff_check)
       values = uris.map(&property).uniq
 
@@ -249,8 +248,8 @@ module LogStash; module Outputs; class ElasticSearch;
       pool_options = {
         :sniffing => sniffing,
         :sniffer_delay => options[:sniffer_delay],
+        :sniffing_path => options[:sniffing_path],
         :healthcheck_path => options[:healthcheck_path],
-        :absolute_healthcheck_path => options[:absolute_healthcheck_path],
         :resurrect_delay => options[:resurrect_delay],
         :url_normalizer => self.method(:host_to_url)
       }

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -79,7 +79,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       resp
     end
 
-    def format_url(url, path)
+    def format_url(url, path=nil)
 
       request_uri = url.uri
 
@@ -92,7 +92,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         # and restore it after this operation
         query = request_uri.query
         request_uri = URI.join(request_uri, relative_path)
-        request_uri.query = query
+        request_uri.query = query if query
       else
         request_uri = request_uri.clone
       end

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -13,9 +13,7 @@ module LogStash; module Outputs; class ElasticSearch;
       
       common_options = {
         :client_settings => client_settings,
-        :resurrect_delay => params["resurrect_delay"],
-        :healthcheck_path => params["healthcheck_path"],
-        :absolute_healthcheck_path => params["absolute_healthcheck_path"]
+        :resurrect_delay => params["resurrect_delay"]
       }
 
       if params["sniffing"]
@@ -26,7 +24,25 @@ module LogStash; module Outputs; class ElasticSearch;
       common_options[:timeout] = params["timeout"] if params["timeout"]
 
       if params["path"]
-        client_settings[:path] = "/#{params["path"]}/".gsub(/\/+/, "/") # Normalize slashes
+        client_settings[:path] = dedup_slashes("/#{params["path"]}/")
+      end
+
+      common_options[:bulk_path] = if params["bulk_path"]
+         dedup_slashes("/#{params["bulk_path"]}")
+      else
+         dedup_slashes("/#{params["path"]}/_bulk")
+      end
+
+      common_options[:sniffing_path] = if params["sniffing_path"]
+         dedup_slashes("/#{params["sniffing_path"]}")
+      else
+         dedup_slashes("/#{params["path"]}/_nodes/http")
+      end
+
+      common_options[:healthcheck_path] = if params["healthcheck_path"]
+         dedup_slashes("/#{params["healthcheck_path"]}")
+      else
+         dedup_slashes("/#{params["path"]}")
       end
 
       if params["parameters"]
@@ -77,9 +93,11 @@ module LogStash; module Outputs; class ElasticSearch;
       }
       common_options.merge! update_options if params["action"] == 'update'
 
-      LogStash::Outputs::ElasticSearch::HttpClient.new(
-        common_options.merge(:hosts => hosts, :logger => logger)
-      )
+      create_http_client(common_options.merge(:hosts => hosts, :logger => logger))
+    end
+
+    def self.create_http_client(options)
+      LogStash::Outputs::ElasticSearch::HttpClient.new(options)
     end
 
     def self.setup_ssl(logger, params)
@@ -130,6 +148,11 @@ module LogStash; module Outputs; class ElasticSearch;
         :user => user,
         :password => unsafe_escaped_password
       }
+    end
+
+    private
+    def self.dedup_slashes(url)
+      url.gsub(/\/+/, "/")
     end
   end
 end; end; end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '6.2.6'
+  s.version         = '7.0.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/http_client_builder_spec.rb
+++ b/spec/unit/http_client_builder_spec.rb
@@ -1,3 +1,4 @@
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/elasticsearch"
 require "logstash/outputs/elasticsearch/http_client"
 require "logstash/outputs/elasticsearch/http_client_builder"
@@ -29,6 +30,163 @@ describe LogStash::Outputs::ElasticSearch::HttpClientBuilder do
       
       it "should escape the password" do
         expect(auth_setup[:password]).to eql("foo%40bar%23")
+      end
+    end
+  end
+
+  describe "customizing action paths" do
+    let(:hosts) { [ ::LogStash::Util::SafeURI.new("http://localhost:9200") ] }
+    let(:options) { {"hosts" => hosts } }
+    let(:logger) { double("logger") }
+    before :each do
+      [:debug, :debug?, :info?, :info, :warn].each do |level|
+        allow(logger).to receive(level)
+      end
+    end
+
+    describe "healthcheck_path" do
+
+      context "when setting bulk_path" do
+        let(:bulk_path) { "/meh" }
+        let(:options) { super.merge("bulk_path" => bulk_path) }
+
+        context "when using path" do
+          let(:options) { super.merge("path" => "/path") }
+          it "ignores the path setting" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:bulk_path]).to eq(bulk_path)
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+        context "when not using path" do
+
+          it "uses the bulk_path setting" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:bulk_path]).to eq(bulk_path)
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+      end
+
+      context "when not setting bulk_path" do
+
+        context "when using path" do
+          let(:path) { "/meh" }
+          let(:options) { super.merge("path" => path) }
+          it "sets bulk_path to path+_bulk" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:bulk_path]).to eq("#{path}/_bulk")
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+
+        context "when not using path" do
+          it "sets the bulk_path to _bulk" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:bulk_path]).to eq("/_bulk")
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+      end
+    end
+    describe "healthcheck_path" do
+      context "when setting healthcheck_path" do
+        let(:healthcheck_path) { "/meh" }
+        let(:options) { super.merge("healthcheck_path" => healthcheck_path) }
+
+        context "when using path" do
+          let(:options) { super.merge("path" => "/path") }
+          it "ignores the path setting" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:healthcheck_path]).to eq(healthcheck_path)
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+        context "when not using path" do
+
+          it "uses the healthcheck_path setting" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:healthcheck_path]).to eq(healthcheck_path)
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+      end
+
+      context "when not setting healthcheck_path" do
+
+        context "when using path" do
+          let(:path) { "/meh" }
+          let(:options) { super.merge("path" => path) }
+          it "sets healthcheck_path to path" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:healthcheck_path]).to eq(path)
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+
+        context "when not using path" do
+          it "sets the healthcheck_path to root" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:healthcheck_path]).to eq("/")
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+      end
+    end
+    describe "sniffing_path" do
+      context "when setting sniffing_path" do
+        let(:sniffing_path) { "/meh" }
+        let(:options) { super.merge("sniffing_path" => sniffing_path) }
+
+        context "when using path" do
+          let(:options) { super.merge("path" => "/path") }
+          it "ignores the path setting" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:sniffing_path]).to eq(sniffing_path)
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+        context "when not using path" do
+
+          it "uses the sniffing_path setting" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:sniffing_path]).to eq(sniffing_path)
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+      end
+
+      context "when not setting sniffing_path" do
+
+        context "when using path" do
+          let(:path) { "/meh" }
+          let(:options) { super.merge("path" => path) }
+          it "sets sniffing_path to path+_nodes/http" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:sniffing_path]).to eq("#{path}/_nodes/http")
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
+
+        context "when not using path" do
+          it "sets the sniffing_path to _nodes/http" do
+            expect(described_class).to receive(:create_http_client) do |options|
+              expect(options[:sniffing_path]).to eq("/_nodes/http")
+            end
+            described_class.build(logger, hosts, options)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This commit removes absolute_healthcheck_path and query_parameters
and introduces two new configs settings: `sniffing_path` and `bulk_path`.

The behaviour of the healthcheck, bulk and sniffing paths is now:
- if not set: the default value will be used
- if not set and path is also set: the default is appended to path
- if set: the set value will be used, ignoring the default and path values

These three settings also support query parameters, which will be
carried and included in the request to elasticsearch

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
