### PR TITLE
Change the compression feature to include gzip'ing responses and requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.0
+ - Add support to compress requests using the new `upload_compression` option.
+
 ## 7.0.0
 - introduce customization of bulk, healthcheck and sniffing paths with the behaviour:
   - if not set: the default value will be used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.1.0
- - Add support to compress requests using the new `upload_compression` option.
+ - Add support to compress requests using the new `http_compression` option.
 
 ## 7.0.0
 - introduce customization of bulk, healthcheck and sniffing paths with the behaviour:

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -202,7 +202,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
   config :validate_after_inactivity, :validate => :number, :default => 10000
 
-  # Enable or disable gzip compression on requests and responses
+  # Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
   config :http_compression, :validate => :boolean, :default => false
 
   def build_client

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -202,8 +202,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
   config :validate_after_inactivity, :validate => :number, :default => 10000
 
-  # Enable or disable gzip compression
-  config :upload_compression, :validate => :boolean, :default => false
+  # Enable or disable gzip compression on requests and responses
+  config :http_compression, :validate => :boolean, :default => false
 
   def build_client
     @client ||= ::LogStash::Outputs::ElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -67,8 +67,8 @@ require "forwardable"
 #
 # This plugin supports request and response compression. Response compression is enabled by default and 
 # for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for 
-# it to send back compressed response. For version before 5.0, `http.compression` must be set to `true` to 
-# take advantage of response compression using this plugin
+# it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` in 
+# Elasticsearch to take advantage of response compression when using this plugin
 #
 # For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 
 # setting in their Logstash config file.

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -68,7 +68,7 @@ require "forwardable"
 # This plugin supports request and response compression. Response compression is enabled by default and 
 # for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for 
 # it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` in 
-# Elasticsearch to take advantage of response compression when using this plugin
+# Elasticsearch[https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http] to take advantage of response compression when using this plugin
 #
 # For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 
 # setting in their Logstash config file.

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -62,6 +62,17 @@ require "forwardable"
 #
 # Keep in mind that a connection with keepalive enabled will
 # not reevaluate its DNS value while the keepalive is in effect.
+#
+# ==== HTTP Compression
+#
+# This plugin supports request and response compression. Response compression is enabled by default and 
+# for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for 
+# it to send back compressed response. For version before 5.0, `http.compression` must be set to `true` to 
+# take advantage of response compression using this plugin
+#
+# For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 
+# setting in their Logstash config file.
+#
 class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   declare_threadsafe!
 

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -133,7 +133,7 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def bulk_send(body_stream)
-      params = http_compression ?  {:headers => {"Accept-Encoding" => "gzip,deflate", "Content-Encoding" => "gzip"}} : {}
+      params = http_compression ? {:headers => {"Content-Encoding" => "gzip"}} : {}
       # Discard the URL 
       _, response = @pool.post(@bulk_path, params, body_stream.string)
       if !body_stream.closed?

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -7,7 +7,7 @@ module LogStash; module Outputs; class ElasticSearch;
         :pool_max => params["pool_max"],
         :pool_max_per_route => params["pool_max_per_route"],
         :check_connection_timeout => params["validate_after_inactivity"],
-        :upload_compression => params["upload_compression"]
+        :http_compression => params["http_compression"]
       }
       
       client_settings[:proxy] = params["proxy"] if params["proxy"]

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.0.0'
+  s.version         = '7.1.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -1,0 +1,66 @@
+require_relative "../../../spec/es_spec_helper"
+require "logstash/outputs/elasticsearch"
+require "stringio"
+require "gzip"
+
+RSpec::Matchers.define :a_valid_gzip_encoded_string do
+  match { |data|
+    expect { Zlib::GzipReader.new(StringIO.new(data)).read }.not_to raise_error
+  }
+end
+
+describe "indexing with upload compression", :integration => true, :version_greater_than_equal_to_5x => true do
+  let(:event) { LogStash::Event.new("message" => "Hello World!", "type" => type) }
+  let(:index) { 10.times.collect { rand(10).to_s }.join("") }
+  let(:type) { 10.times.collect { rand(10).to_s }.join("") }
+  let(:event_count) { 10000 + rand(500) }
+  let(:events) { event_count.times.map { event }.to_a }
+  let(:config) {
+    {
+      "hosts" => get_host_port,
+      "index" => index,
+      "upload_compression" => true
+    }
+  }
+  subject { LogStash::Outputs::ElasticSearch.new(config) }
+
+  let(:es_url) { "http://#{get_host_port}" }
+  let(:index_url) {"#{es_url}/#{index}"}
+  let(:http_client_options) { {} }
+  let(:http_client) do
+    Manticore::Client.new(http_client_options)
+  end
+
+  before do
+    subject.register
+  end
+  
+  shared_examples "an indexer" do
+    it "ships events" do
+      subject.multi_receive(events)
+
+      http_client.post("#{es_url}/_refresh").call
+
+      response = http_client.get("#{index_url}/_count?q=*")
+      result = LogStash::Json.load(response.body)
+      cur_count = result["count"]
+      expect(cur_count).to eq(event_count)
+
+      response = http_client.get("#{index_url}/_search?q=*&size=1000")
+      result = LogStash::Json.load(response.body)
+      result["hits"]["hits"].each do |doc|
+        expect(doc["_type"]).to eq(type)
+        expect(doc["_index"]).to eq(index)
+      end
+    end
+  end
+
+  it "sets the correct content-encoding header and body is compressed" do
+    expect(subject.client.pool.adapter.client).to receive(:send).
+      with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
+      and_call_original
+    subject.multi_receive(events)
+  end
+
+  it_behaves_like("an indexer")
+end

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -19,7 +19,7 @@ describe "indexing with upload compression", :integration => true, :version_grea
     {
       "hosts" => get_host_port,
       "index" => index,
-      "upload_compression" => true
+      "http_compression" => true
     }
   }
   subject { LogStash::Outputs::ElasticSearch.new(config) }
@@ -57,7 +57,7 @@ describe "indexing with upload compression", :integration => true, :version_grea
 
   it "sets the correct content-encoding header and body is compressed" do
     expect(subject.client.pool.adapter.client).to receive(:send).
-      with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
+      with(anything, anything, {:headers=>{"Accept-Encoding" => "gzip,deflate", "Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
       and_call_original
     subject.multi_receive(events)
   end

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :a_valid_gzip_encoded_string do
   }
 end
 
-describe "indexing with upload compression", :integration => true, :version_greater_than_equal_to_5x => true do
+describe "indexing with http_compression turned on", :integration => true, :version_greater_than_equal_to_5x => true do
   let(:event) { LogStash::Event.new("message" => "Hello World!", "type" => type) }
   let(:index) { 10.times.collect { rand(10).to_s }.join("") }
   let(:type) { 10.times.collect { rand(10).to_s }.join("") }
@@ -57,7 +57,7 @@ describe "indexing with upload compression", :integration => true, :version_grea
 
   it "sets the correct content-encoding header and body is compressed" do
     expect(subject.client.pool.adapter.client).to receive(:send).
-      with(anything, anything, {:headers=>{"Accept-Encoding" => "gzip,deflate", "Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
+      with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
       and_call_original
     subject.multi_receive(events)
   end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -1,13 +1,5 @@
 require_relative "../../../spec/es_spec_helper"
 require "logstash/outputs/elasticsearch"
-require "stringio"
-require "gzip"
-
-RSpec::Matchers.define :a_valid_gzip_encoded_string do
-  match { |data|
-    expect { Zlib::GzipReader.new(StringIO.new(data)).read }.not_to raise_error
-  }
-end 
 
 describe "TARGET_BULK_BYTES", :integration => true do
   let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
@@ -118,22 +110,6 @@ describe "indexing", :integration => true do
       }
     }
     it_behaves_like("an indexer")
-  end
-
-  describe "with upload compression turned on" do
-    let(:config) {
-      {
-        "hosts" => get_host_port,
-        "index" => index,
-        "upload_compression" => true
-      }
-      it "sets the correct content-encoding header and body is compressed" do
-        expect(subject.client.pool.adapter.client).to receive(:send).
-          with(anything, anything, {:headers => {"Content-Encoding" => "gzip"}, :body => a_valid_gzip_encoded_string}).
-          and_call_original
-        subject.multi_receive(events)
-      end
-    }
   end
 
   describe "a secured indexer", :secure_integration => true do


### PR DESCRIPTION
This PR:
* Adds `http_compression` to enable compressing both the request and response.
* Response compression is handled automatically by HTTPCommons, but the correct headers (`Accept-Encoding`) needs to be sent.
* Adds a new file for compressed indexing tests. The previous test attempt was borked
* Bumps version

Follow up from #559