### PR TITLE
Make it more clear when bulk actions are being retried.

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -82,8 +82,7 @@ module LogStash; module Outputs; class ElasticSearch;
         begin
           submit_actions = submit(submit_actions)
           if submit_actions && submit_actions.size > 0
-            @logger.error("Retrying individual actions")
-            submit_actions.each {|action| @logger.error("Action", action) }
+            @logger.info("Retrying individual bulk actions that failed or were rejected by the previous bulk request.", :count => submit_actions.size)
           end
         rescue => e
           @logger.error("Encountered an unexpected error submitting a bulk request! Will retry.",


### PR DESCRIPTION
Fixes #515 by removing the accidentally-unhelpful log message that was
smply logging "Action" with no context.