### PR TITLE
Expose a `#get` method on the http_client to allow custom calls

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -143,6 +143,11 @@ module LogStash; module Outputs; class ElasticSearch;
       LogStash::Json.load(response.body)
     end
 
+    def get(path)
+      url, response = @pool.get(path, nil)
+      LogStash::Json.load(response.body)
+    end
+
     def close
       @pool.close
     end

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -121,6 +121,20 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     end
   end
 
+  describe "get" do
+    subject { described_class.new(base_options) }
+    let(:body) { "foobar" }
+    let(:path) { "/hello-id" }
+    let(:get_response) {
+      double("response", :body => LogStash::Json::dump( { "body" => body }))
+    }
+
+    it "returns the hash response" do
+      expect(subject.pool).to receive(:get).with(path, nil).and_return([nil, get_response])
+      expect(subject.get(path)["body"]).to eq(body)
+    end
+  end
+
   describe "join_bulk_responses" do
     subject { described_class.new(base_options) }
 


### PR DESCRIPTION
This is really handy when you use the elasticsearch output to create the
right client with the right ssl options but you want to make a custom
call to the back.