### PR TITLE
Expose a `#post` method on the http client until we have a more reusable in the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.2.1
+ - Expose a `#post` method in the http client class to be use by other modules
+
 ## 7.2.0
  - Support 6.0.0-alpha1 version of Elasticsearch by adding a separate 6x template
  - Note: This version is backwards compatible w.r.t. config, but for ES 6.0.0, `_all` has been

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -148,6 +148,11 @@ module LogStash; module Outputs; class ElasticSearch;
       LogStash::Json.load(response.body)
     end
 
+    def post(path, params = {}, body_string)
+      url, response = @pool.post(path, params, body_string)
+      LogStash::Json.load(response.body)
+    end
+
     def close
       @pool.close
     end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.2.0'
+  s.version         = '7.2.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Xpack is using the ES output http client to make all the connections to the backend and make sure we have the same SSL support, but it needs to be able to make raw request to ES.