### PR TITLE
Add plugin level required to support sending content-type headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.2.2
+ - Docs: Add requirement to use version 6.2.5 or higher to support sending Content-Type headers.
+
 ## 7.2.1
  - Expose a `#post` method in the http client class to be use by other modules
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -10,6 +10,16 @@ require "thread" # for safe queueing
 require "uri" # for escaping user input
 require "forwardable"
 
+# .Compatibility Note
+# [NOTE]
+# ================================================================================
+# Starting with Elasticsearch 5.3, there's an {ref}modules-http.html[HTTP setting]
+# called `http.content_type.required`. If this option is set to `true`, and you
+# are using Logstash 2.4 through 5.2, you need to update the Elasticsearch output
+# plugin to version 6.2.5 or higher.
+# 
+# ================================================================================
+#
 # This plugin is the recommended method of storing logs in Elasticsearch.
 # If you plan on using the Kibana web interface, you'll want to use this output.
 #

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.2.1'
+  s.version         = '7.2.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adds compatibility note requested in https://github.com/elastic/logstash/issues/6718

@acchen97 Please review. 
