### PR TITLE
Use a dead letter queue to handle mapping errors.

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -151,6 +151,7 @@ module LogStash; module Outputs; class ElasticSearch;
           next
         else
           # only log what the user whitelisted
+          puts status
           @logger.info "retrying failed action with response code: #{status} (#{failure})" if !failure_type_logging_whitelist.include?(failure["type"])
           actions_to_retry << action
         end

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -4,7 +4,7 @@ module LogStash; module Outputs; class ElasticSearch;
   module Common
     attr_reader :client, :hosts
 
-    DLQ_CODES = [400]
+    DLQ_CODES = [400, 404]
     SUCCESS_CODES = [200, 201]
     CONFLICT_CODE = 409
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -141,7 +141,7 @@ module LogStash; module Outputs; class ElasticSearch;
           next
         elsif DLQ_CODES.include?(status)
           action_event = action[2]
-          @dlq_writer.write(event, config_name, id, "Could not index event to Elasticsearch. status: #{status}, action: #{action}, response: #{response}")
+          @dlq_writer.write(event, "Could not index event to Elasticsearch. status: #{status}, action: #{action}, response: #{response}")
           next
         else
           # only log what the user whitelisted

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -146,7 +146,7 @@ module LogStash; module Outputs; class ElasticSearch;
             # TODO: Change this to send a map with { :status => status, :action => action } in the future
             @dlq_writer.write(event, "Could not index event to Elasticsearch. status: #{status}, action: #{action}, response: #{response}")
           else
-            @logger.warn "Failed action.", status: status, action: action, response: response
+            @logger.warn "Could not index event to Elasticsearch.", status: status, action: action, response: response
           end
           next
         else

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -98,6 +98,16 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.multi_receive([event1])
   end
 
+  it "should retry actions with response status of 502" do
+    subject.register
+
+    mock_actions_with_response({"errors" => true, "statuses" => [502]},
+                               {"errors" => false})
+    expect(subject).to receive(:submit).with([action1]).twice.and_call_original
+
+    subject.multi_receive([event1])
+  end
+
   it "should retry an event infinitely until a non retryable status occurs" do
     expect(subject).to receive(:submit).with([action1]).exactly(6).times.and_call_original
     subject.register
@@ -107,7 +117,7 @@ describe "failures in bulk class expected behavior", :integration => true do
                                {"errors" => true, "statuses" => [429]},
                                {"errors" => true, "statuses" => [429]},
                                {"errors" => true, "statuses" => [429]},
-                               {"errors" => true, "statuses" => [500]})
+                               {"errors" => true, "statuses" => [400]})
 
     subject.multi_receive([event1])
   end
@@ -126,7 +136,7 @@ describe "failures in bulk class expected behavior", :integration => true do
                                {"errors" => true, "statuses" => [429]},
                                {"errors" => true, "statuses" => [429]},
                                {"errors" => true, "statuses" => [429]},
-                               {"errors" => true, "statuses" => [500]})
+                               {"errors" => true, "statuses" => [400]})
 
     subject.multi_receive([event1])
   end

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -8,7 +8,6 @@ describe "failures in bulk class expected behavior", :integration => true do
   let(:event2) { LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0] }, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
   let(:action2) { ["index", {:_id=>nil, :_routing=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event2] }
   let(:invalid_event) { LogStash::Event.new("geoip" => { "location" => "notlatlon" }, "@timestamp" => "2014-11-17T20:37:17.223Z") }
-  let(:retryable_codes) { [429, 502, 503, 504] }
 
   def mock_actions_with_response(*resp)
     raise ArgumentError, "Cannot mock actions until subject is registered and has a client!" unless subject.client
@@ -88,6 +87,8 @@ describe "failures in bulk class expected behavior", :integration => true do
 
     subject.multi_receive([event1, event1, event1, event2])
   end
+
+  retryable_codes = [429, 502, 503]
 
   retryable_codes.each do |code|
     it "should retry actions with response status of #{code}" do


### PR DESCRIPTION
Also retry policy has been changed. This is mostly motivated from #572 and the use of DLQ.
We now retry everything except for 400 and 409.

Fixes #572

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
