### PR TITLE
add a few metrics to the plugin

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -227,6 +227,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   config :http_compression, :validate => :boolean, :default => false
 
   def build_client
+    params["metric"] = metric
     @client ||= ::LogStash::Outputs::ElasticSearch::HttpClientBuilder.build(@logger, @hosts, params)
   end
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -165,6 +165,7 @@ module LogStash; module Outputs; class ElasticSearch;
         @bulk_request_metrics.increment(:with_errors)
       else
         @bulk_request_metrics.increment(:successes)
+        @document_level_metrics.increment(:successes, actions.size)
         return
       end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -45,6 +45,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     def initialize(logger, adapter, initial_urls=[], options={})
       @logger = logger
       @adapter = adapter
+      @metric = options[:metric]
       @initial_urls = initial_urls
       
       raise ArgumentError, "No URL Normalizer specified!" unless options[:url_normalizer]
@@ -161,8 +162,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     # Sniffs and returns the results. Does not update internal URLs!
     def check_sniff
       _, url_meta, resp = perform_request(:get, @sniffing_path)
+      @metric.increment(:sniff_requests)
       parsed = LogStash::Json.load(resp.body)
-      
       nodes = parsed['nodes']
       if !nodes || nodes.empty?
         @logger.warn("Sniff returned no nodes! Will not update hosts.")

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -14,6 +14,7 @@ module LogStash; module Outputs; class ElasticSearch;
       
       common_options = {
         :client_settings => client_settings,
+        :metric => params["metric"],
         :resurrect_delay => params["resurrect_delay"]
       }
 

--- a/spec/integration/outputs/metrics_spec.rb
+++ b/spec/integration/outputs/metrics_spec.rb
@@ -1,0 +1,70 @@
+require_relative "../../../spec/es_spec_helper"
+
+describe "metrics", :integration => true do
+  subject! do
+    require "logstash/outputs/elasticsearch"
+    settings = {
+      "manage_template" => false,
+      "hosts" => "#{get_host_port()}"
+    }
+    plugin = LogStash::Outputs::ElasticSearch.new(settings)
+  end
+
+  let(:metric) { subject.metric }
+  let(:bulk_request_metrics) { subject.instance_variable_get(:@bulk_request_metrics) }
+  let(:document_level_metrics) { subject.instance_variable_get(:@document_level_metrics) }
+
+  before :each do
+    require "elasticsearch"
+
+    # Clean ES of data before we start.
+    @es = get_client
+    @es.indices.delete_template(:name => "*")
+
+    # This can fail if there are no indexes, ignore failure.
+    @es.indices.delete(:index => "*") rescue nil
+    #@es.indices.refresh
+    subject.register
+  end
+
+  context "after a succesful bulk insert" do
+    let(:bulk) { [
+      LogStash::Event.new("message" => "sample message here"),
+      LogStash::Event.new("somemessage" => { "message" => "sample nested message here" }),
+      LogStash::Event.new("somevalue" => 100),
+      LogStash::Event.new("somevalue" => 10),
+      LogStash::Event.new("somevalue" => 1),
+      LogStash::Event.new("country" => "us"),
+      LogStash::Event.new("country" => "at"),
+      LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0 ] })
+    ]}
+
+    it "increases successful bulk request metric" do
+      expect(bulk_request_metrics).to receive(:increment).with(:successes).once
+      subject.multi_receive(bulk)
+    end
+
+    it "increases number of successful inserted documents" do
+      expect(document_level_metrics).to receive(:increment).with(:successes, bulk.size).once
+      subject.multi_receive(bulk)
+    end
+  end
+
+  context "after a bulk insert that generates errors" do
+    let(:bulk) { [
+      LogStash::Event.new("message" => "sample message here"),
+      LogStash::Event.new("message" => { "message" => "sample nested message here" }),
+    ]}
+    it "increases bulk request with error metric" do
+      expect(bulk_request_metrics).to receive(:increment).with(:with_errors).once
+      expect(bulk_request_metrics).to_not receive(:increment).with(:successes)
+      subject.multi_receive(bulk)
+    end
+
+    it "increases number of successful and non retryable documents" do
+      expect(document_level_metrics).to receive(:increment).with(:non_retryable_failures).once
+      expect(document_level_metrics).to receive(:increment).with(:successes).once
+      subject.multi_receive(bulk)
+    end
+  end
+end

--- a/spec/integration/outputs/sniffer_spec.rb
+++ b/spec/integration/outputs/sniffer_spec.rb
@@ -7,7 +7,13 @@ describe "pool sniffer", :integration => true do
   let(:logger) { Cabin::Channel.get }
   let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger) }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://#{get_host_port}")] }
-  let(:options) { {:resurrect_delay => 2, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
+  let(:options) do
+    {
+      :resurrect_delay => 2, # Shorten the delay a bit to speed up tests
+      :url_normalizer => proc {|u| u},
+      :metric => ::LogStash::Instrument::NullMetric.new(:dummy).namespace(:alsodummy)
+    }
+  end
 
   subject { LogStash::Outputs::ElasticSearch::HttpClient::Pool.new(logger, adapter, initial_urls, options) }
 

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -7,7 +7,8 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
   let(:base_options) do
     opts = {
       :hosts => [::LogStash::Util::SafeURI.new("127.0.0.1")],
-      :logger => Cabin::Channel.get
+      :logger => Cabin::Channel.get,
+      :metric => ::LogStash::Instrument::NamespacedNullMetric.new(:dummy_metric)
     }
 
     if !ssl.nil? # Shortcut to set this


### PR DESCRIPTION
~~- number of sniffing requests performed~~
~~- number of bulk_requests measured before right before executing the
request~~
~~- number of concurrent bulk_requests~~
~~- number of bulk retries~~

metrics calculated:

```ruby
{
  "bulk_requests": {
     "responses": {  # counts per top level status code returned in the bulk response
       "200": 346300,
       "201": 712,
       "404": 61,
       "429": 36
       # other status codes ...
     },
     "successes": 346819,  # successful bulk requests with no errors (sum of 200 and 201 minus partial_successes)
     "failures": 23,         # no http response from ES. will be retried. see point 1 above for causes
     "partial_successes": 134,  # bulk request successful (status 20X) but contains errors
     "drops": 5,   # bulk request dropped
  },
  "documents": {
       "successes": 173409500,
       "retryable_failures": 450,
       "non_retryable_failures": 12
  },
  "sniffing_count": 621
}
```


this is the context of https://github.com/elastic/logstash/issues/6831
