### PR TITLE
support sniffing_path customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.3.0
+- Add support for customizing sniffing_path with absolute_sniffing_path
+
 ## 6.2.6
 - Fixed: Change how the healthcheck_path is treated: either append it to any existing path (default) or replace any existing path
   Also ensures that the healthcheck url contains no query parameters regarless of hosts urls contains them or query_params being set. #554

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -188,6 +188,24 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # * with `absolute_healthcheck_path: false`: "http://localhost:9200/health"
   config :absolute_healthcheck_path, :validate => :boolean, :default => false
 
+  # If sniffing is enabled, this plugin will periodically execute a request
+  # to one of the nodes to retrieve the list of other nodes eligible to receive
+  # bulk requests. By default this path is `_nodes/http` but if you need to set
+  # it to something else, this is the place
+  # NOTE: any query parameters present in the URL or query_params config option will be removed
+  config :sniffing_path, :validate => :string, :default => "_nodes/http"
+
+  # When a `sniffing_path` config is provided, this additional flag can be used to
+  # specify whether this sniffing_path is appended to the existing path (default)
+  # or is treated as the absolute URL path.
+  #
+  # For example, if hosts url is "http://localhost:9200/es" and sniffing_path is "/_sniffing",
+  # the sniffing request will be sent to:
+  #
+  # * with `absolute_sniffing_path: true`: "http://localhost:9200/es/_sniffing"
+  # * with `absolute_sniffing_path: false`: "http://localhost:9200/_sniffing"
+  config :absolute_sniffing_path, :validate => :boolean, :default => false
+
   # How frequently, in seconds, to wait between resurrection attempts.
   # Resurrection is the process by which backend endpoints marked 'down' are checked
   # to see if they have come back to life

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -251,6 +251,8 @@ module LogStash; module Outputs; class ElasticSearch;
         :sniffer_delay => options[:sniffer_delay],
         :healthcheck_path => options[:healthcheck_path],
         :absolute_healthcheck_path => options[:absolute_healthcheck_path],
+        :sniffing_path => options[:sniffing_path],
+        :absolute_sniffing_path => options[:absolute_sniffing_path],
         :resurrect_delay => options[:resurrect_delay],
         :url_normalizer => self.method(:host_to_url)
       }

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -15,7 +15,9 @@ module LogStash; module Outputs; class ElasticSearch;
         :client_settings => client_settings,
         :resurrect_delay => params["resurrect_delay"],
         :healthcheck_path => params["healthcheck_path"],
-        :absolute_healthcheck_path => params["absolute_healthcheck_path"]
+        :absolute_healthcheck_path => params["absolute_healthcheck_path"],
+        :sniffing_path => params["sniffing_path"],
+        :absolute_sniffing_path => params["absolute_sniffing_path"]
       }
 
       if params["sniffing"]

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '6.2.6'
+  s.version         = '6.3.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
same with healthcheck path allow customization of sniffing path by introducing `sniffing_path` and `absolute_sniffing_path` configuration parameters

NOTE: this PR should be only applied to 6.x major version