### PR TITLE
Make travis-run.sh script runnable on non-travis envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
 - jruby-1.7.25
 before_script:
   export PATH=$PATH:$TRAVIS_BUILD_DIR/gradle/bin/
-script: "./travis-run.sh"
+script: "./build.sh"
 before_install: []
 addons:
   apt:

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -ex
 
+# Set the build dir to ./ if not set by travis
+BUILD_DIR=./
+if [ -z "$TRAVIS_BUILD_DIR" ]; then
+	BUILD_DIR=$TRAVIS_BUILD_DIR
+fi
+
 function finish {
   last_result=$?
   set +e


### PR DESCRIPTION
This will set a default value for TRAVIS_BUILD_DIR (./) that
makes sense on a local laptop for testing.

This also renames travis-build.sh to build.sh to reflect the fact
that it can be used on envs other than travis