### PR TITLE
Log 429 errors as debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.0
+ - Log 429 errors as debug instead of error. These aren't actual errors and cause users undue concern.
+   This status code is triggered when ES wants LS to backoff, which it does correctly (exponentially)
+
 ## 7.2.2
  - Docs: Add requirement to use version 6.2.5 or higher to support sending Content-Type headers.
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.2.2'
+  s.version         = '7.3.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Before these were all logged at the `error` level. This confused users
and caused issues like the one seen here:
https://discuss.elastic.co/t/throttling-processing-of-log-backfill-using-filebeat/83740/3

This patch should result in fewer false alarms
