### PR TITLE
Fix handling of retryable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.2
+ - Fix error where a 429 would cause this output to crash
+ - Wait for all inflight requests to complete before stopping
+
 ## 7.3.1
  - Fix the backwards compatibility layer used for detecting DLQ capabilities in logstash core
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.3.1'
+  s.version         = '7.3.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This fixes the retryable errors handling in a few key ways:

1. It fixes the missing RETRYABLE_CODES constant
2. It doesn't stop retrying just because logstash is shutting down (we
don't want to lose data here!)
3. It adds tests for this behavior

Right now the output is broken pretty badly, since the missing constant will cause it to crash on those exceptions.