### PR TITLE
Refactor use of SafeURI to conform to 9k compatible subset

### DIFF
--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -19,15 +19,19 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
   describe "auth" do
     let(:user) { "myuser" }
     let(:password) { "mypassword" }
-    let(:noauth_uri) { clone = uri.uri.clone;clone.user=nil; clone.password=nil; clone.to_s }
+    let(:noauth_uri) { clone = uri.clone; clone.user=nil; clone.password=nil; clone }
     let(:uri) { ::LogStash::Util::SafeURI.new("http://#{user}:#{password}@localhost:9200") }
     
     it "should convert the auth to params" do
       resp = double("response")
       allow(resp).to receive(:call)
       allow(resp).to receive(:code).and_return(200)
+      
+      expected_uri = noauth_uri.clone
+      expected_uri.path = "/"
+      
       expect(subject.manticore).to receive(:get).
-        with(noauth_uri, {
+        with(expected_uri.to_s, {
           :headers => {"Content-Type" => "application/json"},
           :auth => {
             :user => user,
@@ -46,7 +50,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
     subject { described_class.new(double("logger"), {}) }
 
     it "should add the path argument to the uri's path" do
-      expect(subject.format_url(url, path).path).to eq("/path/_bulk")
+      expect(subject.format_url(url, path).path).to eq("/path//_bulk")
     end
 
     context "when uri contains query parameters" do
@@ -59,7 +63,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
     end
 
     context "when uri contains credentials" do
-      let(:url) { ::LogStash::Util::SafeURI.new("http://user:pass@localhost:9200") }
+      let(:url) { ::LogStash::Util::SafeURI.new("http://myuser:mypass@localhost:9200") }
 
       it "should remove credentials after format" do
         expect(subject.format_url(url, path).user).to be_nil

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -32,7 +32,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     
     shared_examples("proper host handling") do
       it "should properly transform a host:port string to a URL" do
-        expect(subject.host_to_url(hostname_port_uri)).to eq(http_hostname_port)
+        expect(subject.host_to_url(hostname_port_uri).to_s).to eq(http_hostname_port.to_s + "/")
       end
 
       it "should not raise an error with a / for a path" do
@@ -40,7 +40,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
       end
 
       it "should parse full URLs correctly" do
-        expect(subject.host_to_url(http_hostname_port)).to eq(http_hostname_port)
+        expect(subject.host_to_url(http_hostname_port).to_s).to eq(http_hostname_port.to_s + "/")
       end
 
       describe "ssl" do
@@ -70,7 +70,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
           let(:base_options) { super.merge(:hosts => [https_hostname_port]) }
           it "should handle an ssl url correctly when SSL is nil" do
             subject
-            expect(subject.host_to_url(https_hostname_port)).to eq(https_hostname_port)
+            expect(subject.host_to_url(https_hostname_port).to_s).to eq(https_hostname_port.to_s + "/")
           end
         end       
       end
@@ -99,7 +99,9 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
           
           
           it "should automatically insert a / in front of path overlays" do
-            expect(subject.host_to_url(url)).to eq(LogStash::Util::SafeURI.new(url + "/otherpath"))
+            expected = url.clone
+            expected.path = url.path + "/otherpath"
+            expect(subject.host_to_url(url)).to eq(expected)
           end
         end
       end


### PR DESCRIPTION
Fixes #604 

Requires https://github.com/elastic/logstash/pull/7236

As part of this work this removes the slash de-duplication that runs when executing HTTP requests. This is really work that doesn't need to be done. ES handles duplicate slashes fine, no reason to complicate code over it. 

The slash de-duplication was trickier to do with the changes to SafeURI, and it never had a point, hence its removal.
