### PR TITLE
Bump to 7.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.3.3
+ - Fix JRuby 9k incompatibilities and use new URI class that is JRuby 9k compatible
+
 ## 7.3.2
  - Fix error where a 429 would cause this output to crash
  - Wait for all inflight requests to complete before stopping

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.3.2'
+  s.version         = '7.3.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This releases 9k + 9K URI compatibility https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/605