### PR TITLE
Fix 9k path concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.3.4
+ - Fix incorrect handling of bulk_path containing ?s
+
 ## 7.3.3
  - Fix JRuby 9k incompatibilities and use new URI class that is JRuby 9k compatible
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.3.3'
+  s.version         = '7.3.4'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This allows for query strings in the bulk path to work correctly.
The implementation required extra parsing of the query string to work
correctly.

This also restores some of the slash de-duplication logic removed when
we switched over to java.net.URI compatibility since it simplifies the
logic here.