### PR TITLE
introduce ignore_above in string_fields default mapping for keywords

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es5x.json
@@ -23,7 +23,7 @@
           "mapping" : {
             "type" : "text", "norms" : false,
             "fields" : {
-              "keyword" : { "type": "keyword" }
+              "keyword" : { "type": "keyword", "ignore_above": 256 }
             }
           }
         }

--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es6x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es6x.json
@@ -22,7 +22,7 @@
           "mapping" : {
             "type" : "text", "norms" : false,
             "fields" : {
-              "keyword" : { "type": "keyword" }
+              "keyword" : { "type": "keyword", "ignore_above": 256 }
             }
           }
         }


### PR DESCRIPTION
fixes #588

Since the 5.x and 6.x templates override the default keyword mapping
in elasticsearch which defaults to `"ignore_above": 256`, the templates
should include this clause otherwise the burden of dealing with this
situation passes instead to Lucene.

Also, looking at the history I see no rationale for removing it in the first place, maybe it was a mistake?