### PR TITLE
Fix bug where logs would log URI class name instead of the actual URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+##  7.3.8
+ - Fix bug where java class names were logged rather than actual host names in various scenarios
+
 ## 7.3.7
  - Properly support characters needing escaping in users / passwords across multiple SafeURI implementions (pre/post LS 5.5.1)
  - Logstash 5.5.0 does NOT work with this release as it has a broken SafeURI implementation
+
+## 7.3.6
+ - Bump for doc gen
 
 ## 7.3.5
  - Fix incorrect variable reference when DLQing events

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -29,7 +29,7 @@ module LogStash; module Outputs; class ElasticSearch;
       install_template
       check_action_validity
 
-      @logger.info("New Elasticsearch output", :class => self.class.name, :hosts => @hosts.map(&:sanitized))
+      @logger.info("New Elasticsearch output", :class => self.class.name, :hosts => @hosts.map(&:sanitized).map(&:to_s))
     end
 
     # Receive an array of events and immediately attempt to index them (no buffering)
@@ -251,7 +251,7 @@ module LogStash; module Outputs; class ElasticSearch;
         retry unless @stopping.true?
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         if RETRYABLE_CODES.include?(e.response_code)
-          log_hash = {:code => e.response_code, :url => e.url.sanitized}
+          log_hash = {:code => e.response_code, :url => e.url.sanitized.to_s}
           log_hash[:body] = e.body if @logger.debug? # Generally this is too verbose
           message = "Encountered a retryable error. Will Retry with exponential backoff "
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -236,10 +236,10 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
                         :healthcheck_url => url, :path => @healthcheck_path)
           response = perform_request_to_url(url, :head, @healthcheck_path)
           # If no exception was raised it must have succeeded!
-          logger.warn("Restored connection to ES instance", :url => url.sanitized)
+          logger.warn("Restored connection to ES instance", :url => url.sanitized.to_s)
           @state_mutex.synchronize { meta[:state] = :alive }
         rescue HostUnreachableError, BadResponseCodeError => e
-          logger.warn("Attempted to resurrect connection to dead ES instance, but got an error.", url: url.sanitized, error_type: e.class, error: e.message)
+          logger.warn("Attempted to resurrect connection to dead ES instance, but got an error.", url: url.sanitized.to_s, error_type: e.class, error: e.message)
         end
       end
     end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.3.7'
+  s.version         = '7.3.8'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Since the upgrade of the SafeURI class the SafeURI#sanitized method returns a java object,
which is fine, but jruby does not invoke #to_s on those objects automatically, so we must be
explicit to have those values show in the logs.