### PR TITLE
Remove SECURE_INTEGRATION tests against master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ env:
  - INTEGRATION=false
  - INTEGRATION=true ES_VERSION=1.7.6 TEST_DEBUG=true
  - INTEGRATION=true ES_VERSION=2.4.4 TEST_DEBUG=true
- - INTEGRATION=true ES_VERSION=5.2.1 TEST_DEBUG=true
+ - INTEGRATION=true ES_VERSION=5.5.0 TEST_DEBUG=true
  - INTEGRATION=true ES_VERSION=master TEST_DEBUG=true
  - SECURE_INTEGRATION=true INTEGRATION=true ES_VERSION=5.5.0 TEST_DEBUG=true 
- - SECURE_INTEGRATION=true INTEGRATION=true ES_VERSION=master TEST_DEBUG=true
 rvm:
   - jruby-1.7.25
 matrix:
@@ -20,7 +19,6 @@ matrix:
       env: LOGSTASH_BRANCH=5.x
   allow_failures:
     - env: INTEGRATION=true ES_VERSION=master TEST_DEBUG=true
-    - env: SECURE_INTEGRATION=true INTEGRATION=true ES_VERSION=master TEST_DEBUG=true
   fast_finish: true
 install: true
 script: ci/build.sh


### PR DESCRIPTION
These specs don't make sense because x-pack master isn't publicly available. We should be well covered by the tests against the current released branch.

Alternatively we could use a different testing approach with a different HTTPS/Auth provider in the future, but since we're testing the client, not x-pack, this should all be fine unless we use something other than HTTP auth in the future.
