### PR TITLE
perform some deprecation/obsoletion cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-##  7.3.8
- - Fix bug where java class names were logged rather than actual host names in various scenarios
+## 8.0.0
+ - Breaking: make deprecated options :flush_size and :idle_flush_time obsolete
+ - Remove obsolete options :max_retries and :retry_max_items
 
 ## 7.3.7
  - Properly support characters needing escaping in users / passwords across multiple SafeURI implementions (pre/post LS 5.5.1)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -234,15 +234,6 @@ Set the Elasticsearch errors in the whitelist that you don't want to log.
 A useful example is when you want to skip all 409 errors
 which are `document_already_exists_exception`.
 
-[id="plugins-{type}s-{plugin}-flush_size"]
-===== `flush_size`  (DEPRECATED)
-
-  * DEPRECATED WARNING: This configuration item is deprecated and may not be available in future versions.
-  * Value type is <<number,number>>
-  * There is no default value for this setting.
-
-
-
 [id="plugins-{type}s-{plugin}-healthcheck_path"]
 ===== `healthcheck_path` 
 
@@ -279,15 +270,6 @@ Any special characters present in the URLs here MUST be URL escaped! This means 
   * Default value is `false`
 
 Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
-
-[id="plugins-{type}s-{plugin}-idle_flush_time"]
-===== `idle_flush_time`  (DEPRECATED)
-
-  * DEPRECATED WARNING: This configuration item is deprecated and may not be available in future versions.
-  * Value type is <<number,number>>
-  * Default value is `1`
-
-
 
 [id="plugins-{type}s-{plugin}-index"]
 ===== `index` 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -34,13 +34,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
     # Receive an array of events and immediately attempt to index them (no buffering)
     def multi_receive(events)
-      if @flush_size
-        events.each_slice(@flush_size) do |slice|
-          retrying_submit(slice.map {|e| event_action_tuple(e) })
-        end
-      else
-        retrying_submit(events.map {|e| event_action_tuple(e)})
-      end
+      retrying_submit(events.map {|e| event_action_tuple(e)})
     end
 
     # Convert the event into a 3-tuple of action, params, and event

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -91,9 +91,9 @@ module LogStash; module Outputs; class ElasticSearch
       # Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
       mod.config :hosts, :validate => :uri, :default => [::LogStash::Util::SafeURI.new("//127.0.0.1")], :list => true
 
-      mod.config :flush_size, :validate => :number, :deprecated => "This setting is no longer necessary as we now try to restrict bulk requests to sane sizes. See the 'Batch Sizes' section of the docs. If you think you still need to restrict payloads based on the number, not size, of events, please open a ticket."
+      mod.config :flush_size, :validate => :number, :obsolete => "This setting is no longer available as we now try to restrict bulk requests to sane sizes. See the 'Batch Sizes' section of the docs. If you think you still need to restrict payloads based on the number, not size, of events, please open a ticket."
 
-      mod.config :idle_flush_time, :validate => :number, :default => 1, :deprecated => "This is a no-op now as every pipeline batch is flushed synchronously obviating the need for this option."
+      mod.config :idle_flush_time, :validate => :number, :obsolete => "This settings is no longer valid. This was a no-op now as every pipeline batch is flushed synchronously obviating the need for this option."
 
       # Set upsert content for update mode.s
       # Create a new document with this parameter as json string if `document_id` doesn't exists
@@ -102,9 +102,6 @@ module LogStash; module Outputs; class ElasticSearch
       # Enable `doc_as_upsert` for update mode.
       # Create a new document with source if `document_id` doesn't exist in Elasticsearch
       mod.config :doc_as_upsert, :validate => :boolean, :default => false
-
-      #Obsolete since 4.1.0
-      mod.config :max_retries, :obsolete => "This setting no longer does anything. Please remove it from your config"
 
       # Set script name for scripted update mode
       mod.config :script, :validate => :string, :default => ""
@@ -129,9 +126,6 @@ module LogStash; module Outputs; class ElasticSearch
 
       # Set max interval in seconds between bulk retries.
       mod.config :retry_max_interval, :validate => :number, :default => 64
-
-      #Obsolete since 4.1.0
-      mod.config :retry_max_items, :obsolete => "This setting no longer does anything. Please remove it from your config"
 
       # The number of times Elasticsearch should internally retry an update/upserted document
       # See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.3.8'
+  s.version         = '8.0.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -186,7 +186,6 @@ describe "outputs/elasticsearch" do
     describe "#multi_receive" do
       let(:events) { [double("one"), double("two"), double("three")] }
       let(:events_tuples) { [double("one t"), double("two t"), double("three t")] }
-      let(:options) { super.merge("flush_size" => 2) }
 
       before do
         allow(eso).to receive(:retrying_submit).with(anything)
@@ -195,11 +194,6 @@ describe "outputs/elasticsearch" do
           allow(eso).to receive(:event_action_tuple).with(e).and_return(et)
         end
         eso.multi_receive(events)
-      end
-
-      it "should receive an array of events and invoke retrying_submit with them, split by flush_size" do
-        expect(eso).to have_received(:retrying_submit).with(events_tuples.slice(0,2))
-        expect(eso).to have_received(:retrying_submit).with(events_tuples.slice(2,3))
       end
 
     end
@@ -246,7 +240,6 @@ describe "outputs/elasticsearch" do
       {
         "manage_template" => false,
         "hosts" => "localhost:#{port}",
-        "flush_size" => 1,
         "timeout" => 0.1, # fast timeout
       }
     end


### PR DESCRIPTION
* make deprecated options :flush_size and :idle_flush_time obsolete
* remove obsolete options :max_retries and :retry_max_items