### PR TITLE
Extend retry HTTP codes

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -54,6 +54,7 @@ require "forwardable"
 # - Network errors (Inability to connect)
 # - 404 (Not found) Indicating an upstream proxy has no matching route
 # - 429 (Too many requests) Graceful backoff indication by Elastic
+# - 500 (Internal Server Error) when an ES node disconnect occurs this is temporarily returned
 # - 502 (Bad gateway) During shutdown a proxy might return this
 # - 503 (Service unavailable) Proxy returns an unavailable service
 # - 504 (Gateway timed out) Proxy backend timed out

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -51,9 +51,12 @@ require "forwardable"
 #
 # The following errors are retried infinitely:
 #
-# - Network errors (inability to connect)
-# - 429 (Too many requests) and
-# - 503 (Service unavailable) errors
+# - Network errors (Inability to connect)
+# - 404 (Not found) Indicating an upstream proxy has no matching route
+# - 429 (Too many requests) Graceful backoff indication by Elastic
+# - 502 (Bad gateway) During shutdown a proxy might return this
+# - 503 (Service unavailable) Proxy returns an unavailable service
+# - 504 (Gateway timed out) Proxy backend timed out
 #
 # NOTE: 409 exceptions are no longer retried. Please set a higher `retry_on_conflict` value if you experience 409 exceptions.
 # It is more performant for Elasticsearch to retry these exceptions than this plugin.

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -7,10 +7,11 @@ module LogStash; module Outputs; class ElasticSearch;
     # These are codes for temporary recoverable conditions
     # 404 indicates an endpoint is not found (yet)
     # 429 just means that ES has too much traffic ATM
+    # 500 when an ES node disconnect occurs this is temporarily returned
     # 502 occurs when a proxy fails a request to ES (could happen during node shutdown)
     # 503 means ES, or a proxy is temporarily unavailable
     # 504 when using a proxy, indicates the backend timed out
-    RETRYABLE_CODES = [404, 429, 502, 503, 504]
+    RETRYABLE_CODES = [404, 429, 500, 502, 503, 504]
 
     DLQ_CODES = [400]
     SUCCESS_CODES = [200, 201]

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -5,11 +5,14 @@ module LogStash; module Outputs; class ElasticSearch;
     attr_reader :client, :hosts
 
     # These are codes for temporary recoverable conditions
+    # 404 indicates an endpoint is not found (yet)
     # 429 just means that ES has too much traffic ATM
-    # 503 means it , or a proxy is temporarily unavailable
-    RETRYABLE_CODES = [429, 503]
+    # 502 occurs when a proxy fails a request to ES (could happen during node shutdown)
+    # 503 means ES, or a proxy is temporarily unavailable
+    # 504 when using a proxy, indicates the backend timed out
+    RETRYABLE_CODES = [404, 429, 502, 503, 504]
 
-    DLQ_CODES = [400, 404]
+    DLQ_CODES = [400]
     SUCCESS_CODES = [200, 201]
     CONFLICT_CODE = 409
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
   s.version         = '7.3.8'
-  s.licenses        = ['apache-2.0']
+  s.licenses        = ['Apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]


### PR DESCRIPTION
  When using a service like Elastic Cloud there are more possible
  recoverable HTTP error codes because there is a proxy in between
  the ES data nodes and the client.
  Extend the list of retry codes with these errors.