### PR TITLE
Fix parent/child support for elasticsearch 6.x and support join type field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 8.0.2
+## 8.1.0
+  - Support Elasticsearch 6.x join field type
   - Fix bug where logging errors for bad response codes would raise an unhandled exception
 
 ## 8.0.1

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -122,31 +122,31 @@ else
         setup_es https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-SNAPSHOT.tar.gz https://snapshots.elastic.co/downloads/packs/x-pack/x-pack-$ES_VERSION-SNAPSHOT.zip
         start_es
         # Run all tests which are for versions > 5 but don't run ones tagged < 5.x. Include ingest, new template
-        bundle exec rspec -fd $extra_tag_args --tag version_greater_than_equal_to_5x --tag update_tests:painless --tag update_tests:groovy --tag ~version_less_than_5x $spec_path
+        bundle exec rspec -fd $extra_tag_args --tag version_greater_than_equal_to_5x --tag update_tests:painless --tag update_tests:groovy --tag ~version_less_than_5x --tag version_greater_than_equal_to_6x --tag ~version_less_than_equal_to_5x $spec_path
         ;;
       5.*)
           setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
           start_es -Escript.inline=true -Escript.stored=true -Escript.file=true
           # Run all tests which are for versions > 5 but don't run ones tagged < 5.x. Include ingest, new template
-          bundle exec rspec -fd $extra_tag_args --tag version_greater_than_equal_to_5x --tag update_tests:painless --tag update_tests:groovy --tag ~version_less_than_5x $spec_path
+          bundle exec rspec -fd $extra_tag_args --tag version_greater_than_equal_to_5x --tag update_tests:painless --tag update_tests:groovy --tag ~version_less_than_5x --tag version_less_than_equal_to_5x --tag ~version_greater_than_equal_to_6x $spec_path
           ;;
       2.*)
           setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
           start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
           # Run all tests which are for versions < 5 but don't run ones tagged 5.x and above. Skip ingest, new template
-          bundle exec rspec -fd $extra_tag_args --tag version_less_than_5x --tag update_tests:groovy --tag ~version_greater_than_equal_to_5x $spec_path
+          bundle exec rspec -fd $extra_tag_args --tag version_less_than_5x --tag update_tests:groovy --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_6x --tag ~version_less_than_equal_to_5x $spec_path
           ;;
       1.*)
           setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
           start_es -Des.script.inline=on -Des.script.indexed=on -Des.script.file=on
           # Still have to support ES versions < 2.x so run tests for those.
-          bundle exec rspec -fd $extra_tag_args --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x $spec_path
+          bundle exec rspec -fd $extra_tag_args --tag ~version_greater_than_equal_to_5x --tag ~version_greater_than_equal_to_2x --tag ~version_greater_than_equal_to_6x --tag ~version_less_than_equal_to_5x $spec_path
           ;;
       *)
           download_gradle
           build_es master
           start_es
-          bundle exec rspec -fd $extra_tag_args --tag version_greater_than_equal_to_5x --tag update_tests:painless --tag ~update_tests:groovy --tag ~version_less_than_5x $spec_path
+          bundle exec rspec -fd $extra_tag_args --tag version_greater_than_equal_to_5x --tag update_tests:painless --tag ~update_tests:groovy --tag ~version_less_than_5x --tag ~version_greater_than_equal_to_6x --tag ~version_less_than_equal_to_5x $spec_path
           ;;
   esac
 fi

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -174,8 +174,15 @@ module LogStash; module Outputs; class ElasticSearch;
         params[:pipeline] = event.sprintf(@pipeline)
       end
 
-     if @parent
-        params[:parent] = event.sprintf(@parent)
+      if @parent
+        if @join_field
+          join_value = event.get(@join_field)
+          parent_value = event.sprintf(@parent)
+          event.set(@join_field, { "name" => join_value, "parent" => parent_value })
+          params[:_routing] = event.sprintf(@parent)
+        else
+          params[:parent] = event.sprintf(@parent)
+        end
       end
 
       if @action == 'update'

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -78,6 +78,9 @@ module LogStash; module Outputs; class ElasticSearch
       # This can be dynamic using the `%{foo}` syntax.
       mod.config :parent, :validate => :string, :default => nil
 
+      # For child documents, name of the join field
+      mod.config :join_field, :validate => :string, :default => nil
+
       # Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
       # Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
       #     `"127.0.0.1"`

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '8.0.2'
+  s.version         = '8.1.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -1,7 +1,8 @@
 require_relative "../../../spec/es_spec_helper"
 require "logstash/outputs/elasticsearch"
 
-shared_examples "a parent indexer" do
+context "when using elasticsearch 5.x and before", :integration => true, :version_less_than_equal_to_5x => true do
+  shared_examples "a type based parent indexer" do
     let(:index) { 10.times.collect { rand(10).to_s }.join("") }
     let(:type) { 10.times.collect { rand(10).to_s }.join("") }
     let(:event_count) { 10000 + rand(500) }
@@ -15,11 +16,10 @@ shared_examples "a parent indexer" do
     before do
       # Add mapping and a parent document
       index_url = "http://#{get_host_port()}/#{index}"
-      ftw = FTW::Agent.new
       mapping = { "mappings" => { "#{type}" => { "_parent" => { "type" => "#{type}_parent" } } } }
-      ftw.put!("#{index_url}", {:body => mapping.to_json, :headers => default_headers})
+      Manticore.put("#{index_url}", {:body => mapping.to_json, :headers => default_headers}).call
       pdoc = { "foo" => "bar" }
-      ftw.put!("#{index_url}/#{type}_parent/test", {:body => pdoc.to_json, :headers => default_headers})
+      Manticore.put("#{index_url}/#{type}_parent/test", {:body => pdoc.to_json, :headers => default_headers}).call
 
       subject.register
       subject.multi_receive(event_count.times.map { LogStash::Event.new("link_to" => "test", "message" => "Hello World!", "type" => type) })
@@ -29,43 +29,131 @@ shared_examples "a parent indexer" do
     it "ships events" do
       index_url = "http://#{get_host_port()}/#{index}"
 
-      ftw = FTW::Agent.new
-      ftw.post!("#{index_url}/_refresh")
+      Manticore.post("#{index_url}/_refresh").call
 
       # Wait until all events are available.
       Stud::try(10.times) do
         query = { "query" => { "has_parent" => { "type" => "#{type}_parent", "query" => { "match" => { "foo" => "bar" } } } } }
-        data = ""
-        response = ftw.post!("#{index_url}/_count", {:body => query.to_json, :headers => default_headers})
-        response.read_body { |chunk| data << chunk }
+        response = Manticore.post("#{index_url}/_count", {:body => query.to_json, :headers => default_headers})
+        data = response.body
         result = LogStash::Json.load(data)
         cur_count = result["count"]
         insist { cur_count } == event_count
       end
     end
-end
+  end
 
-describe "(http protocol) index events with static parent", :integration => true do
-  it_behaves_like 'a parent indexer' do
-    let(:parent) { "test" }
-    let(:config) {
-      {
-        "hosts" => get_host_port,
-        "index" => index,
-        "parent" => parent
+  describe "(http protocol) index events with static parent" do
+    it_behaves_like 'a type based parent indexer' do
+      let(:parent) { "test" }
+      let(:config) {
+        {
+          "hosts" => get_host_port,
+          "index" => index,
+          "parent" => parent
+        }
       }
-    }
+    end
+  end
+
+  describe "(http_protocol) index events with fieldref in parent value" do
+    it_behaves_like 'a type based parent indexer' do
+      let(:config) {
+        {
+          "hosts" => get_host_port,
+          "index" => index,
+          "parent" => "%{link_to}"
+        }
+      }
+    end
   end
 end
 
-describe "(http_protocol) index events with fieldref in parent value", :integration => true do
-  it_behaves_like 'a parent indexer' do
-    let(:config) {
-      {
-        "hosts" => get_host_port,
-        "index" => index,
-        "parent" => "%{link_to}"
-      }
+context "when using elasticsearch 6.x and above", :integration => true, :version_greater_than_equal_to_6x => true do
+
+  shared_examples "a join field based parent indexer" do
+    let(:index) { 10.times.collect { rand(10).to_s }.join("") }
+    let(:type) { 10.times.collect { rand(10).to_s }.join("") }
+    let(:event_count) { 10000 + rand(500) }
+    let(:parent) { "not_implemented" }
+    let(:config) { "not_implemented" }
+    let(:parent_id) { "test" }
+    let(:join_field) { "join_field" }
+    let(:parent_relation) { "parent_type" }
+    let(:child_relation) { "child_type" }
+    let(:default_headers) {
+      {"Content-Type" => "application/json"}
     }
+    subject { LogStash::Outputs::ElasticSearch.new(config) }
+
+    before do
+      # Add mapping and a parent document
+      index_url = "http://#{get_host_port()}/#{index}"
+      mapping = {
+        "mappings" => {
+          type => {
+            "properties" => {
+              join_field => {
+                "type" => "join",
+                "relations" => { parent_relation => child_relation }
+              }
+            }
+          }
+        }
+      }
+      Manticore.put("#{index_url}", {:body => mapping.to_json, :headers => default_headers}).call
+      pdoc = { "message" => "ohayo", join_field => parent_relation }
+      Manticore.put("#{index_url}/#{type}/#{parent_id}", {:body => pdoc.to_json, :headers => default_headers}).call
+
+      subject.register
+      subject.multi_receive(event_count.times.map { LogStash::Event.new("link_to" => parent_id, "message" => "Hello World!", join_field => child_relation) })
+    end
+
+
+    it "ships events" do
+      index_url = "http://#{get_host_port()}/#{index}"
+
+      Manticore.post("#{index_url}/_refresh").call
+
+      # Wait until all events are available.
+      Stud::try(10.times) do
+        query = { "query" => { "has_parent" => { "parent_type" => parent_relation, "query" => { "match_all" => { } } } } }
+        response = Manticore.post("#{index_url}/_count", {:body => query.to_json, :headers => default_headers})
+        data = response.body
+        result = LogStash::Json.load(data)
+        cur_count = result["count"]
+        insist { cur_count } == event_count
+      end
+    end
+  end
+
+  describe "(http protocol) index events with static parent" do
+    it_behaves_like 'a join field based parent indexer' do
+      let(:config) {
+        {
+          "hosts" => get_host_port,
+          "index" => index,
+          "parent" => parent_id,
+          "document_type" => type,
+          "join_field" => join_field,
+          "manage_template" => false
+        }
+      }
+    end
+  end
+
+  describe "(http_protocol) index events with fieldref in parent value" do
+    it_behaves_like 'a join field based parent indexer' do
+      let(:config) {
+        {
+          "hosts" => get_host_port,
+          "index" => index,
+          "parent" => "%{link_to}",
+          "document_type" => type,
+          "join_field" => join_field,
+          "manage_template" => false
+        }
+      }
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new parameter `join` to support elasticsearch 6.x join field type and associated changes in the parent/child feature, along with a test for it. It also excludes existing parent/child specs from running if the tested ES is 6.x or higher.

The specs are currently failing since scripting also requires changes to make this plugin compatible with ES 6.x, but I believe these are out of scope for this PR.

fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/602