### PR TITLE
Initialize BadResponseCodeError with SafeURI instead of string.

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -14,9 +14,9 @@ module LogStash; module Outputs; class ElasticSearch;
     CONFLICT_CODE = 409
 
     # When you use external versioning, you are communicating that you want
-    # to ignore conflicts. More obviously, since an external version is a 
+    # to ignore conflicts. More obviously, since an external version is a
     # constant part of the incoming document, we should not retry, as retrying
-    # will never succeed. 
+    # will never succeed.
     VERSION_TYPES_PERMITTING_CONFLICT = ["external", "external_gt", "external_gte"]
 
     def register
@@ -262,7 +262,7 @@ module LogStash; module Outputs; class ElasticSearch;
           sleep_interval = sleep_for_interval(sleep_interval)
           retry
         else
-          log_hash = {:code => e.response_code, 
+          log_hash = {:code => e.response_code,
                       :response_body => e.response_body}
           log_hash[:request_body] = e.request_body if @logger.debug?
           @logger.error("Got a bad response code from server, but this code is not considered retryable. Request will be dropped", log_hash)

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -3,7 +3,7 @@ require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch; class HttpClient;
   DEFAULT_HEADERS = { "Content-Type" => "application/json" }
-  
+
   class ManticoreAdapter
     attr_reader :manticore, :logger
 
@@ -18,14 +18,14 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       options[:cookies] = false
 
       @client_params = {:headers => DEFAULT_HEADERS.merge(options[:headers] || {})}
-      
+
       if options[:proxy]
         options[:proxy] = manticore_proxy_hash(options[:proxy])
       end
-      
+
       @manticore = ::Manticore::Client.new(options)
     end
-    
+
     # Transform the proxy option to a hash. Manticore's support for non-hash
     # proxy options is broken. This was fixed in https://github.com/cheald/manticore/commit/34a00cee57a56148629ed0a47c329181e7319af5
     # but this is not yet released
@@ -55,18 +55,18 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       params[:body] = body if body
 
       if url.user
-        params[:auth] = { 
+        params[:auth] = {
           :user => CGI.unescape(url.user),
           # We have to unescape the password here since manticore won't do it
           # for us unless its part of the URL
-          :password => CGI.unescape(url.password), 
-          :eager => true 
+          :password => CGI.unescape(url.password),
+          :eager => true
         }
       end
 
       request_uri = format_url(url, path)
 
-      resp = @manticore.send(method.downcase, request_uri, params)
+      resp = @manticore.send(method.downcase, request_uri.to_s, params)
 
       # Manticore returns lazy responses by default
       # We want to block for our usage, this will wait for the repsonse
@@ -85,28 +85,25 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
     def format_url(url, path_and_query=nil)
       request_uri = url.clone
-      
+
       # We excise auth info from the URL in case manticore itself tries to stick
       # sensitive data in a thrown exception or log data
       request_uri.user = nil
       request_uri.password = nil
 
-      return request_uri.to_s if path_and_query.nil?
-      
+      return request_uri if path_and_query.nil?
+
       parsed_path_and_query = java.net.URI.new(path_and_query)
-      
-      query = request_uri.query
-      parsed_query = parsed_path_and_query.query
-      
+
       new_query_parts = [request_uri.query, parsed_path_and_query.query].select do |part|
         part && !part.empty? # Skip empty nil and ""
       end
-      
+
       request_uri.query = new_query_parts.join("&") unless new_query_parts.empty?
-      
+
       request_uri.path = "#{request_uri.path}/#{parsed_path_and_query.path}".gsub(/\/{2,}/, "/")
-        
-      request_uri.to_s
+
+      request_uri
     end
 
     def close

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -46,7 +46,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       @logger = logger
       @adapter = adapter
       @initial_urls = initial_urls
-      
+
       raise ArgumentError, "No URL Normalizer specified!" unless options[:url_normalizer]
       @url_normalizer = options[:url_normalizer]
       DEFAULT_OPTIONS.merge(options).tap do |merged|
@@ -65,7 +65,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       @url_info = {}
       @stopping = false
     end
-    
+
     def start
       update_urls(@initial_urls)
       start_resurrectionist
@@ -156,7 +156,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     def check_sniff
       _, resp = perform_request(:get, @sniffing_path)
       parsed = LogStash::Json.load(resp.body)
-      
+
       nodes = parsed['nodes']
       if !nodes || nodes.empty?
         @logger.warn("Sniff returned no nodes! Will not update hosts.")
@@ -175,11 +175,11 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         end
       end
     end
-    
+
     def major_version(nodes)
       k,v = nodes.first; v['version'].split('.').first.to_i
     end
-    
+
     def sniff_5x_and_above(nodes)
       nodes.map do |id,info|
         if info["http"]
@@ -187,12 +187,12 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         end
       end.compact
     end
-    
+
     def sniff_2x_1x(nodes)
       nodes.map do |id,info|
         # TODO Make sure this works with shield. Does that listed
         # stuff as 'https_address?'
-        
+
         addr_str = info['http_address'].to_s
         next unless addr_str # Skip hosts with HTTP disabled
 
@@ -281,7 +281,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
     def update_urls(new_urls)
       return if new_urls.nil?
-      
+
       # Normalize URLs
       new_urls = new_urls.map(&method(:normalize_url))
 
@@ -311,14 +311,14 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           logger.info("Elasticsearch pool URLs updated", :changes => state_changes)
         end
       end
-      
+
       # Run an inline healthcheck anytime URLs are updated
       # This guarantees that during startup / post-startup
       # sniffing we don't have idle periods waiting for the
       # periodic sniffer to allow new hosts to come online
-      healthcheck! 
+      healthcheck!
     end
-    
+
     def size
       @state_mutex.synchronize { @url_info.size }
     end

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -15,21 +15,21 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
   it "should implement host unreachable exceptions" do
     expect(subject.host_unreachable_exceptions).to be_a(Array)
   end
-  
+
   describe "auth" do
     let(:user) { "myuser" }
     let(:password) { "mypassword" }
     let(:noauth_uri) { clone = uri.clone; clone.user=nil; clone.password=nil; clone }
     let(:uri) { ::LogStash::Util::SafeURI.new("http://#{user}:#{password}@localhost:9200") }
-    
+
     it "should convert the auth to params" do
       resp = double("response")
       allow(resp).to receive(:call)
       allow(resp).to receive(:code).and_return(200)
-      
+
       expected_uri = noauth_uri.clone
       expected_uri.path = "/"
-      
+
       expect(subject.manticore).to receive(:get).
         with(expected_uri.to_s, {
           :headers => {"Content-Type" => "application/json"},
@@ -39,7 +39,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
             :eager => true
           }
         }).and_return resp
-      
+
       subject.perform_request(uri, :get, "/")
     end
   end
@@ -50,35 +50,35 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
     subject { described_class.new(double("logger"), {}) }
 
     it "should add the path argument to the uri's path" do
-      expect(java.net.URI.new(subject.format_url(url, path)).path).to eq("/path/_bulk")
+      expect(subject.format_url(url, path).path).to eq("/path/_bulk")
     end
 
     context "when uri contains query parameters" do
       let(:query_params) { "query=value&key=value2" }
       let(:url) { ::LogStash::Util::SafeURI.new("http://localhost:9200/path/?#{query_params}") }
-      let(:formatted) { java.net.URI.new(subject.format_url(url, path))}
+      let(:formatted) { subject.format_url(url, path) }
 
       it "should retain query_params after format" do
         expect(formatted.query).to eq(query_params)
       end
-      
+
       context "and the path contains query parameters" do
         let(:path) { "/special_path?specialParam=123" }
-        
+
         it "should join the query correctly" do
           expect(formatted.query).to eq(query_params + "&specialParam=123")
         end
       end
     end
-    
+
     context "when the path contains query parameters" do
       let(:path) { "/special_bulk?pathParam=1"}
-      let(:formatted) { java.net.URI.new(subject.format_url(url, path)) }
-      
+      let(:formatted) { subject.format_url(url, path) }
+
       it "should add the path correctly" do
         expect(formatted.path).to eq("#{url.path}special_bulk")
-      end 
-      
+      end
+
       it "should add the query parameters correctly" do
         expect(formatted.query).to eq("pathParam=1")
       end
@@ -86,10 +86,10 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
 
     context "when uri contains credentials" do
       let(:url) { ::LogStash::Util::SafeURI.new("http://myuser:mypass@localhost:9200") }
-      let(:formatted) { java.net.URI.new(subject.format_url(url, path)) }
+      let(:formatted) { subject.format_url(url, path) }
 
       it "should remove credentials after format" do
-        expect(formatted.user_info).to be_nil
+        expect(formatted.userinfo).to be_nil
       end
     end
   end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -12,7 +12,7 @@ describe "outputs/elasticsearch" do
         "manage_template" => false
       }
     }
-    
+
     let(:eso) { LogStash::Outputs::ElasticSearch.new(options) }
 
     let(:manticore_urls) { eso.client.pool.urls }
@@ -23,19 +23,19 @@ describe "outputs/elasticsearch" do
     before(:each) do
       if do_register
         eso.register
-        
-        # Rspec mocks can't handle background threads, so... we can't use any 
+
+        # Rspec mocks can't handle background threads, so... we can't use any
         allow(eso.client.pool).to receive(:start_resurrectionist)
         allow(eso.client.pool).to receive(:start_sniffer)
         allow(eso.client.pool).to receive(:healthcheck!)
         eso.client.pool.adapter.manticore.respond_with(:body => "{}")
       end
     end
-    
+
     after(:each) do
-      eso.close 
+      eso.close
     end
-    
+
     describe "getting a document type" do
       it "should default to 'logs'" do
         expect(eso.send(:get_event_type, LogStash::Event.new)).to eql("logs")
@@ -70,25 +70,25 @@ describe "outputs/elasticsearch" do
         end
       end
     end
-    
+
     describe "with auth" do
       let(:user) { "myuser" }
       let(:password) { ::LogStash::Util::Password.new("mypassword") }
-      
+
       shared_examples "an authenticated config" do
         it "should set the URL auth correctly" do
           expect(manticore_url.user).to eq user
         end
       end
-        
+
       context "as part of a URL" do
         let(:options) {
           super.merge("hosts" => ["http://#{user}:#{password.value}@localhost:9200"])
         }
-        
+
         include_examples("an authenticated config")
       end
-      
+
       context "as a hash option" do
           let(:options) {
             super.merge!(
@@ -96,7 +96,7 @@ describe "outputs/elasticsearch" do
               "password" => password
             )
         }
-        
+
         include_examples("an authenticated config")
       end
     end
@@ -200,7 +200,7 @@ describe "outputs/elasticsearch" do
 
     context "429 errors" do
       let(:event) { ::LogStash::Event.new("foo" => "bar") }
-      let(:error) do 
+      let(:error) do
         ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(
           429, double("url").as_null_object, double("request body"), double("response body")
         )
@@ -232,7 +232,7 @@ describe "outputs/elasticsearch" do
       end
     end
   end
-  
+
   context "with timeout set" do
     let(:listener) { Flores::Random.tcp_listener }
     let(:port) { listener[2] }
@@ -284,10 +284,10 @@ describe "outputs/elasticsearch" do
   end
 
   describe "SSL end to end" do
-    let(:manticore_double) do 
-      double("manticoreX#{self.inspect}") 
+    let(:manticore_double) do
+      double("manticoreX#{self.inspect}")
     end
-    
+
     let(:eso) {LogStash::Outputs::ElasticSearch.new(options)}
 
     before(:each) do
@@ -296,23 +296,23 @@ describe "outputs/elasticsearch" do
       allow(manticore_double).to receive(:head).with(any_args).and_return(response_double)
       allow(manticore_double).to receive(:get).with(any_args).and_return(response_double)
       allow(manticore_double).to receive(:close)
-        
+
       allow(::Manticore::Client).to receive(:new).and_return(manticore_double)
       eso.register
     end
-    
+
     after(:each) do
       eso.close
     end
-    
-    
+
+
     shared_examples("an encrypted client connection") do
       it "should enable SSL in manticore" do
         expect(eso.client.pool.urls.map(&:scheme).uniq).to eql(['https'])
       end
     end
 
-      
+
     context "With the 'ssl' option" do
       let(:options) { {"ssl" => true}}
 


### PR DESCRIPTION
Fixes `NoMethodError` on `e.url.sanitized`.

[Closes #630]