### PR TITLE
fix a few bugs in ci/run.sh

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -ex
 
-export PATH=$PATH:$TRAVIS_BUILD_DIR/gradle/bin/
-
 # Set the build dir to ./ if not set by travis
 BUILD_DIR=$PWD
 if [[ -z "$TRAVIS_BUILD_DIR" && "$TRAVIS_BUILD_DIR" -ne "" ]]; then
-	BUILD_DIR=$TRAVIS_BUILD_DIR
+  BUILD_DIR=$TRAVIS_BUILD_DIR
 fi
+
+export PATH=$BUILD_DIR/gradle/bin:$PATH
 
 function finish {
   last_result=$?
@@ -90,11 +90,11 @@ build_es() {
   git clone https://github.com/elastic/elasticsearch.git es_src
   cd es_src
   gradle :distribution:zip:assemble
-  unzip -d $TRAVIS_BUILD_DIR distribution/zip/build/distributions/elasticsearch-*.zip
-  mv $TRAVIS_BUILD_DIR/elasticsearch-* $TRAVIS_BUILD_DIR/elasticsearch
-  cd $TRAVIS_BUILD_DIR
+  unzip -d $BUILD_DIR distribution/zip/build/distributions/elasticsearch-*.zip
+  mv $BUILD_DIR/elasticsearch-* $BUILD_DIR/elasticsearch
+  cd $BUILD_DIR
   mkdir -p elasticsearch/config/scripts
-  cp $TRAVIS_BUILD_DIR/spec/fixtures/scripts/painless/* elasticsearch/config/scripts
+  cp $BUILD_DIR/spec/fixtures/scripts/painless/* elasticsearch/config/scripts
 }
 
 start_nginx() {


### PR DESCRIPTION
fixes a few problems with the `ci/run.sh` script:

- running the script locally breaks because $TRAVIS_BUILD_DIR is null
   * Fix: use only $BUILD_DIR
- we append the local gradle path to the $PATH, but that means the existing gradle always wins
  * Fix: prepend the gradle path to $PATH instead of append

[Tests against elasticsearch master were not running for a long time](https://travis-ci.org/logstash-plugins/logstash-output-elasticsearch/jobs/266824924#L992), this PR will allow the tests to run.