### PR TITLE
dont allow failures in es 6.0.0-beta1 integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
       env: LOGSTASH_BRANCH=5.6
   allow_failures:
     - env: INTEGRATION=true ES_VERSION=master TEST_DEBUG=true
-    - env: INTEGRATION=true ES_VERSION=6.0.0-beta1 TEST_DEBUG=true
   fast_finish: true
 install: true
 script: ci/build.sh


### PR DESCRIPTION
with the upcoming release of 6.0.0, having failing tests is an important concern, so builds should fail if the integration tests fail against es 6.0.0-beta1

this is also related to https://github.com/elastic/logstash/issues/8003