### PR TITLE
new elasticsearch version handling

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -238,7 +238,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         begin
           logger.info("Running health check to see if an Elasticsearch connection is working",
                         :healthcheck_url => url, :path => @healthcheck_path)
-          response = perform_request_to_url(url, :get, @healthcheck_path)
+          response = perform_request_to_url(url, :head, @healthcheck_path)
           # If no exception was raised it must have succeeded!
           logger.warn("Restored connection to ES instance", :url => url.sanitized.to_s)
           # We reconnected to this node, check its ES version

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -339,7 +339,6 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
     def add_url(url)
       @url_info[url] ||= empty_url_meta
-      @url_info[url][:version] = get_es_version(url)
     end
 
     def remove_url(url)

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -28,7 +28,7 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.default_template_path(es_major_version)
-      template_version = es_major_version == "1" ? "2" : es_major_version
+      template_version = es_major_version == 1 ? 2 : es_major_version
       default_template_name = "elasticsearch-template-es#{template_version}x.json"
       ::File.expand_path(default_template_name, ::File.dirname(__FILE__))
     end

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -12,12 +12,10 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     private
-    def self.get_es_version(client)
-      client.get_version
-    end
-
     def self.get_es_major_version(client)
-      get_es_version(client)["number"][0]
+      # get the elasticsearch version of each node in the pool and
+      # pick the biggest major version
+      client.connected_es_versions.uniq.map {|version| version.split(".").first.to_i}.sort.last
     end
 
     def self.get_template(path, es_major_version)

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -21,6 +21,9 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
 
     allow(::Manticore::Client).to receive(:new).and_return(manticore_double)
 
+    allow(subject).to receive(:connected_es_versions).with(any_args).and_return(["0.0.0"])
+    allow(subject).to receive(:get_es_version).with(any_args).and_return("0.0.0")
+
     subject.start
   end
 

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -132,7 +132,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     }
 
     it "returns the hash response" do
-      expect(subject.pool).to receive(:get).with(path, nil).and_return([nil, get_response])
+      expect(subject.pool).to receive(:get).with(path, nil).and_return(get_response)
       expect(subject.get(path)["body"]).to eq(body)
     end
   end

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -6,32 +6,21 @@ require "json"
 describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
   describe ".get_es_major_version" do
-    let(:es_1x_version) { '{ "number" : "1.7.0", "build_hash" : "929b9739cae115e73c346cb5f9a6f24ba735a743", "build_timestamp" : "2015-07-16T14:31:07Z", "build_snapshot" : false, "lucene_version" : "4.10.4" }' }
-    let(:es_2x_version) { '{ "number" : "2.3.4", "build_hash" : "e455fd0c13dceca8dbbdbb1665d068ae55dabe3f", "build_timestamp" : "2016-06-30T11:24:31Z", "build_snapshot" : false, "lucene_version" : "5.5.0" }' }
-    let(:es_5x_version) { '{ "number" : "5.0.0-alpha4", "build_hash" : "b0da471", "build_date" : "2016-06-22T12:33:48.164Z", "build_snapshot" : false, "lucene_version" : "6.1.0" }' }
     let(:client) { double("client") }
-    context "elasticsearch 1.x" do
-      before(:each) do
-        allow(client).to receive(:get_version).and_return(JSON.parse(es_1x_version))
-      end
-      it "detects major version is 1" do
-        expect(described_class.get_es_major_version(client)).to eq("1")
-      end
+
+    before(:each) do
+      allow(client).to receive(:connected_es_versions).and_return(["5.3.0"])
     end
-    context "elasticsearch 2.x" do
-      before(:each) do
-        allow(client).to receive(:get_version).and_return(JSON.parse(es_2x_version))
-      end
-      it "detects major version is 2" do
-        expect(described_class.get_es_major_version(client)).to eq("2")
-      end
+
+    it "picks the largest major version" do
+      expect(described_class.get_es_major_version(client)).to eq(5)
     end
-    context "elasticsearch 5.x" do
+    context "if there are nodes with multiple major versions" do
       before(:each) do
-        allow(client).to receive(:get_version).and_return(JSON.parse(es_5x_version))
+        allow(client).to receive(:connected_es_versions).and_return(["5.3.0", "6.0.0"])
       end
-      it "detects major version is 5" do
-        expect(described_class.get_es_major_version(client)).to eq("5")
+      it "picks the largest major version" do
+        expect(described_class.get_es_major_version(client)).to eq(6)
       end
     end
   end
@@ -39,19 +28,18 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
   describe ".default_template_path" do
     context "elasticsearch 1.x" do
       it "chooses the 2x template" do
-        expect(described_class.default_template_path("1")).to match(/elasticsearch-template-es2x.json/)
+        expect(described_class.default_template_path(1)).to match(/elasticsearch-template-es2x.json/)
       end
     end
     context "elasticsearch 2.x" do
       it "chooses the 2x template" do
-        expect(described_class.default_template_path("2")).to match(/elasticsearch-template-es2x.json/)
+        expect(described_class.default_template_path(2)).to match(/elasticsearch-template-es2x.json/)
       end
     end
     context "elasticsearch 5.x" do
       it "chooses the 5x template" do
-        expect(described_class.default_template_path("5")).to match(/elasticsearch-template-es5x.json/)
+        expect(described_class.default_template_path(5)).to match(/elasticsearch-template-es5x.json/)
       end
     end
   end
-
 end


### PR DESCRIPTION
* have the connection pool remember the elasticsearch version for each connection
* the http_client can get a list of all these versions
* the sniffing now knows the version of elasticsearch the _nodes/http came from
* the template manager installs the template version of the biggest major version of any connected client


This PR is still not production ready but seems to work: it makes the pool track the info about the es versions of each node.
Then the HttpClient, TemplateManager and others can pull that list and decide what to do.