### PR TITLE
Selectively disable and amend scripting tests to fix es6 integration tests

### DIFF
--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -11,7 +11,7 @@ module ESHelper
     Elasticsearch::Client.new(:hosts => [get_host_port])
   end
 
-  def self.es_version_satisfies?(requirement)
+  def self.es_version_satisfies?(*requirement)
     es_version = RSpec.configuration.filter[:es_version] || ENV['ES_VERSION']
     es_release_version = Gem::Version.new(es_version).release
     Gem::Requirement.new(requirement).satisfied_by?(es_release_version)

--- a/spec/integration/outputs/groovy_update_spec.rb
+++ b/spec/integration/outputs/groovy_update_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../../spec/es_spec_helper"
 
-if ESHelper.es_version_satisfies?(">= 2")
+if ESHelper.es_version_satisfies?('>= 2', '< 6')
   describe "Update actions using groovy scripts", :integration => true, :update_tests => 'groovy' do
     require "logstash/outputs/elasticsearch"
 

--- a/spec/integration/outputs/painless_update_spec.rb
+++ b/spec/integration/outputs/painless_update_spec.rb
@@ -10,9 +10,11 @@ if ESHelper.es_version_satisfies?(">= 5")
         "index" => "logstash-update",
         "template_overwrite" => true,
         "hosts" => get_host_port(),
-        "action" => "update",
-        "script_lang" => "painless"
+        "action" => "update"
       }
+      if ESHelper.es_version_satisfies?('<6')
+        settings.merge!({"script_lang" => "painless"})
+      end
       LogStash::Outputs::ElasticSearch.new(settings.merge!(options))
     end
 
@@ -53,7 +55,6 @@ if ESHelper.es_version_satisfies?(">= 5")
         subject = get_es_output({
           'document_id' => "123",
           'script' => 'ctx._source.counter += params.event.counter',
-          'script_lang' => 'painless',
           'script_type' => 'inline'
         })
         subject.register
@@ -67,7 +68,6 @@ if ESHelper.es_version_satisfies?(">= 5")
           'document_id' => "123",
           'doc_as_upsert' => true,
           'script' => 'if( ctx._source.containsKey("counter") ){ ctx._source.counter += params.event.counter; } else { ctx._source.counter = params.event.counter; }',
-          'script_lang' => 'painless',
           'script_type' => 'inline'
         })
         subject.register
@@ -81,7 +81,6 @@ if ESHelper.es_version_satisfies?(">= 5")
           'document_id' => "456",
           'doc_as_upsert' => true,
           'script' => 'if( ctx._source.containsKey("counter") ){ ctx._source.counter += params.event.counter; } else { ctx._source.counter = params.event.counter; }',
-          'script_lang' => 'painless',
           'script_type' => 'inline'
         })
         subject.register
@@ -95,7 +94,6 @@ if ESHelper.es_version_satisfies?(">= 5")
         subject = get_es_output({
           'document_id' => "123",
           'script' => 'indexed_update',
-          'script_lang' => 'painless',
           'script_type' => 'indexed'
         })
         subject.register

--- a/spec/integration/outputs/painless_update_spec.rb
+++ b/spec/integration/outputs/painless_update_spec.rb
@@ -35,20 +35,24 @@ if ESHelper.es_version_satisfies?(">= 5")
     end
 
     context "scripted updates" do
-      it "should increment a counter with event/doc 'count' variable" do
-        subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update', 'script_type' => 'file' })
-        subject.register
-        subject.multi_receive([LogStash::Event.new("count" => 2)])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
-        insist { r["_source"]["counter"] } == 3
-      end
+      if ESHelper.es_version_satisfies?('<6')
+        context 'with file based scripts' do
+          it "should increment a counter with event/doc 'count' variable" do
+            subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update', 'script_type' => 'file' })
+            subject.register
+            subject.multi_receive([LogStash::Event.new("count" => 2)])
+            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+            insist { r["_source"]["counter"] } == 3
+          end
 
-      it "should increment a counter with event/doc '[data][count]' nested variable" do
-        subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update_nested', 'script_type' => 'file' })
-        subject.register
-        subject.multi_receive([LogStash::Event.new("data" => { "count" => 3 })])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
-        insist { r["_source"]["counter"] } == 4
+          it "should increment a counter with event/doc '[data][count]' nested variable" do
+            subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update_nested', 'script_type' => 'file' })
+            subject.register
+            subject.multi_receive([LogStash::Event.new("data" => { "count" => 3 })])
+            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+            insist { r["_source"]["counter"] } == 4
+          end
+        end
       end
 
       it "should increment a counter with event/doc 'count' variable with inline script" do
@@ -89,19 +93,23 @@ if ESHelper.es_version_satisfies?(">= 5")
         insist { r["_source"]["counter"] } == 3
       end
 
-      it "should increment a counter with event/doc 'count' variable with indexed script" do
-        @es.put_script lang: 'painless', id: 'indexed_update', body: { script: 'ctx._source.counter += params.event.count' }
-        subject = get_es_output({
-          'document_id' => "123",
-          'script' => 'indexed_update',
-          'script_type' => 'indexed'
-        })
-        subject.register
-        subject.multi_receive([LogStash::Event.new("count" => 4 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
-        insist { r["_source"]["counter"] } == 5
+      if ESHelper.es_version_satisfies?('<6')
+        context 'with an indexed script' do
+          it "should increment a counter with event/doc 'count' variable with indexed script" do
+            @es.put_script lang: 'painless', id: 'indexed_update', body: { script: 'ctx._source.counter += params.event.count' }
+            subject = get_es_output({
+              'document_id' => "123",
+              'script' => 'indexed_update',
+              'script_type' => 'indexed'
+            })
+            subject.register
+            subject.multi_receive([LogStash::Event.new("count" => 4 )])
+            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+            insist { r["_source"]["counter"] } == 5
+          end
+        end
       end
-    end  
+     end
 
     context "when update with upsert" do
       it "should create new documents with provided upsert" do

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -104,6 +104,12 @@ if ESHelper.es_version_satisfies?(">= 5.6")
             }
           }
         }
+        if ESHelper.es_version_satisfies?('<6')
+          mapping.merge!({
+                 "settings" => {
+                   "mapping.single_type" => true
+                 }})
+        end
         Manticore.put("#{index_url}", {:body => mapping.to_json, :headers => default_headers}).call
         pdoc = { "message" => "ohayo", join_field => parent_relation }
         Manticore.put("#{index_url}/#{type}/#{parent_id}", {:body => pdoc.to_json, :headers => default_headers}).call


### PR DESCRIPTION
Fix integration tests to handle scripting changes in Elasticsearch 6.0:

- Do not run groovy scripting tests unless version is < 6
- Do not run 'file' tests unless version is < 6
- Only specify 'lang:painless' if version is < 6