### PR TITLE
[Docs] Fix link syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
+## 8.2.1
+  - Docs: Fix link syntax
+
 ## 8.2.0
   - Improved Elasticsearch version handling
   - Improved event error logging when DLQ is disabled in Logstash
-
+  
 ## 8.1.1
   - Retry all non-200 responses of the bulk API indefinitely
   - Improve documentation on retry codes
 
 ## 8.1.0
   - Support Elasticsearch 6.x join field type
+  
 ## 8.0.2
   - Fix bug where logging errors for bad response codes would raise an unhandled exception
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,7 +23,7 @@ include::{include_path}/plugin_header.asciidoc[]
 .Compatibility Note
 [NOTE]
 ================================================================================
-Starting with Elasticsearch 5.3, there's an {ref}modules-http.html[HTTP setting]
+Starting with Elasticsearch 5.3, there's an {ref}/modules-http.html[HTTP setting]
 called `http.content_type.required`. If this option is set to `true`, and you
 are using Logstash 2.4 through 5.2, you need to update the Elasticsearch output
 plugin to version 6.2.5 or higher.

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '8.2.0'
+  s.version         = '8.2.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Our convention for forming links changed when we went to a shared file for attributes. The old syntax will result in doc build errors.