### PR TITLE
Use `#response_body` instead of `#body`

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -248,7 +248,7 @@ module LogStash; module Outputs; class ElasticSearch;
         retry unless @stopping.true?
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         log_hash = {:code => e.response_code, :url => e.url.sanitized.to_s}
-        log_hash[:body] = e.body if @logger.debug? # Generally this is too verbose
+        log_hash[:body] = e.response_body if @logger.debug? # Generally this is too verbose
         message = "Encountered a retryable error. Will Retry with exponential backoff "
 
         # We treat 429s as a special case because these really aren't errors, but


### PR DESCRIPTION
When  running logstash in debug mode we are dumping the response
body into the log, but the code wasn't calling the right method on the
error object throwing a method not found error.

We can target master + 7.x both of theses branch have the same issue.
