### PR TITLE
[7.x Backport] Fix error in instantiating bad response code exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.4.2
+  - Fix bug where logging errors for bad response codes would raise an unhandled exception
+
 ## 7.4.1
   - Properly detect if DLQ is supported and enabled
 
@@ -7,6 +10,19 @@
 
 ##  7.3.8
  - Fix bug where java class names were logged rather than actual host names in various scenarios
+
+## 8.0.2
+  - Fix bug where logging errors for bad response codes would raise an unhandled exception
+
+## 8.0.1
+  - Fix some documentation issues
+
+## 8.0.0
+ - Breaking: make deprecated options :flush_size and :idle_flush_time obsolete
+ - Remove obsolete options :max_retries and :retry_max_items
+ - Fix: handling of initial single big event
+ - Fix: typo was enabling http compression by default this returns it back to false
+>>>>>>> a4e18a8... Fix error in instantiating bad response code exceptions
 
 ## 7.3.7
  - Properly support characters needing escaping in users / passwords across multiple SafeURI implementions (pre/post LS 5.5.1)

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -66,7 +66,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
       request_uri = format_url(url, path)
 
-      resp = @manticore.send(method.downcase, request_uri, params)
+      resp = @manticore.send(method.downcase, request_uri.to_s, params)
 
       # Manticore returns lazy responses by default
       # We want to block for our usage, this will wait for the repsonse
@@ -106,7 +106,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       
       request_uri.path = "#{request_uri.path}/#{parsed_path_and_query.path}".gsub(/\/{2,}/, "/")
         
-      request_uri.to_s
+      request_uri
     end
 
     def close

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '7.4.1'
+  s.version         = '7.4.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Backport of https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/637#issuecomment-330187367 to 7.x