### PR TITLE
add support for join based parent indexing (backport of #632 to 7.x)

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -176,8 +176,15 @@ module LogStash; module Outputs; class ElasticSearch;
         params[:pipeline] = event.sprintf(@pipeline)
       end
 
-     if @parent
-        params[:parent] = event.sprintf(@parent)
+      if @parent
+        if @join_field
+          join_value = event.get(@join_field)
+          parent_value = event.sprintf(@parent)
+          event.set(@join_field, { "name" => join_value, "parent" => parent_value })
+          params[:_routing] = event.sprintf(@parent)
+        else
+          params[:parent] = event.sprintf(@parent)
+        end
       end
 
       if @action == 'update'

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -78,6 +78,9 @@ module LogStash; module Outputs; class ElasticSearch
       # This can be dynamic using the `%{foo}` syntax.
       mod.config :parent, :validate => :string, :default => nil
 
+      # For child documents, name of the join field
+      mod.config :join_field, :validate => :string, :default => nil
+
       # Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
       # Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
       #     `"127.0.0.1"`

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -1,7 +1,7 @@
 require_relative "../../../spec/es_spec_helper"
 require "logstash/outputs/elasticsearch"
 
-if ESHelper.es_version_satisfies?("<= 5.x")
+if ESHelper.es_version_satisfies?("< 6")
   context "when using elasticsearch 5.x and before", :integration => true do
     shared_examples "a type based parent indexer" do
       let(:index) { 10.times.collect { rand(10).to_s }.join("") }
@@ -17,11 +17,10 @@ if ESHelper.es_version_satisfies?("<= 5.x")
       before do
         # Add mapping and a parent document
         index_url = "http://#{get_host_port()}/#{index}"
-        ftw = FTW::Agent.new
         mapping = { "mappings" => { "#{type}" => { "_parent" => { "type" => "#{type}_parent" } } } }
-        ftw.put!("#{index_url}", {:body => mapping.to_json, :headers => default_headers})
+        Manticore.put("#{index_url}", {:body => mapping.to_json, :headers => default_headers}).call
         pdoc = { "foo" => "bar" }
-        ftw.put!("#{index_url}/#{type}_parent/test", {:body => pdoc.to_json, :headers => default_headers})
+        Manticore.put("#{index_url}/#{type}_parent/test", {:body => pdoc.to_json, :headers => default_headers}).call
 
         subject.register
         subject.multi_receive(event_count.times.map { LogStash::Event.new("link_to" => "test", "message" => "Hello World!", "type" => type) })
@@ -31,15 +30,13 @@ if ESHelper.es_version_satisfies?("<= 5.x")
       it "ships events" do
         index_url = "http://#{get_host_port()}/#{index}"
 
-        ftw = FTW::Agent.new
-        ftw.post!("#{index_url}/_refresh")
+        Manticore.post("#{index_url}/_refresh").call
 
         # Wait until all events are available.
         Stud::try(10.times) do
           query = { "query" => { "has_parent" => { "type" => "#{type}_parent", "query" => { "match" => { "foo" => "bar" } } } } }
-          data = ""
-          response = ftw.post!("#{index_url}/_count", {:body => query.to_json, :headers => default_headers})
-          response.read_body { |chunk| data << chunk }
+          response = Manticore.post("#{index_url}/_count", {:body => query.to_json, :headers => default_headers})
+          data = response.body
           result = LogStash::Json.load(data)
           cur_count = result["count"]
           insist { cur_count } == event_count
@@ -76,7 +73,6 @@ end
 
 if ESHelper.es_version_satisfies?(">= 5.6")
   context "when using elasticsearch 5.6 and above", :integration => true do
-
     shared_examples "a join field based parent indexer" do
       let(:index) { 10.times.collect { rand(10).to_s }.join("") }
       let(:type) { 10.times.collect { rand(10).to_s }.join("") }
@@ -108,10 +104,7 @@ if ESHelper.es_version_satisfies?(">= 5.6")
           }
         }
         if ESHelper.es_version_satisfies?('<6')
-          mapping.merge!({
-                 "settings" => {
-                   "mapping.single_type" => true
-                 }})
+          mapping.merge!({ "settings" => { "mapping.single_type" => true }})
         end
         Manticore.put("#{index_url}", {:body => mapping.to_json, :headers => default_headers}).call
         pdoc = { "message" => "ohayo", join_field => parent_relation }


### PR DESCRIPTION
* add support for join based parent indexing (available in ES 5.6 and 6.0)
* dont use ftw on parent integration specs

backport of #632 to 7.x