### PR TITLE
fix stored painless script integration testing for es 6 and above

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -477,7 +477,8 @@ Set script name for scripted update mode
   * Value type is <<string,string>>
   * Default value is `"painless"`
 
-Set the language of the used script. If not set, this defaults to painless in ES 5.0
+Set the language of the used script. If not set, this defaults to painless in ES 5.0.
+When using indexed (stored) scripts on Elasticsearch 6 and higher, you must set this parameter to `""` (empty string).
 
 [id="plugins-{type}s-{plugin}-script_type"]
 ===== `script_type` 

--- a/spec/integration/outputs/painless_update_spec.rb
+++ b/spec/integration/outputs/painless_update_spec.rb
@@ -93,20 +93,29 @@ if ESHelper.es_version_satisfies?(">= 5")
         insist { r["_source"]["counter"] } == 3
       end
 
-      if ESHelper.es_version_satisfies?('<6')
-        context 'with an indexed script' do
-          it "should increment a counter with event/doc 'count' variable with indexed script" do
-            @es.put_script lang: 'painless', id: 'indexed_update', body: { script: 'ctx._source.counter += params.event.count' }
-            subject = get_es_output({
-              'document_id' => "123",
-              'script' => 'indexed_update',
-              'script_type' => 'indexed'
-            })
-            subject.register
-            subject.multi_receive([LogStash::Event.new("count" => 4 )])
-            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
-            insist { r["_source"]["counter"] } == 5
+      context 'with an indexed script' do
+        it "should increment a counter with event/doc 'count' variable with indexed script" do
+          if ESHelper.es_version_satisfies?('<6')
+            @es.perform_request(:put, "_scripts/painless/indexed_update", {}, {"script": "ctx._source.counter += params.event.count"})
+          else
+            @es.perform_request(:put, "_scripts/indexed_update", {}, {"script": {"source":"ctx._source.counter += params.event.count", "lang": "painless"}})
           end
+
+          plugin_parameters = {
+            'document_id' => "123",
+            'script' => 'indexed_update',
+            'script_type' => 'indexed'
+          }
+
+          if ESHelper.es_version_satisfies?('>= 6.0.0')
+            plugin_parameters.merge!('script_lang' => '')
+          end
+
+          subject = get_es_output(plugin_parameters)
+          subject.register
+          subject.multi_receive([LogStash::Event.new("count" => 4 )])
+          r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+          insist { r["_source"]["counter"] } == 5
         end
       end
      end

--- a/spec/integration/outputs/painless_update_spec.rb
+++ b/spec/integration/outputs/painless_update_spec.rb
@@ -96,9 +96,9 @@ if ESHelper.es_version_satisfies?(">= 5")
       context 'with an indexed script' do
         it "should increment a counter with event/doc 'count' variable with indexed script" do
           if ESHelper.es_version_satisfies?('<6')
-            @es.perform_request(:put, "_scripts/painless/indexed_update", {}, {"script": "ctx._source.counter += params.event.count"})
+            @es.perform_request(:put, "_scripts/painless/indexed_update", {}, {"script" => "ctx._source.counter += params.event.count" })
           else
-            @es.perform_request(:put, "_scripts/indexed_update", {}, {"script": {"source":"ctx._source.counter += params.event.count", "lang": "painless"}})
+            @es.perform_request(:put, "_scripts/indexed_update", {}, {"script" => {"source" => "ctx._source.counter += params.event.count", "lang" => "painless"}})
           end
 
           plugin_parameters = {


### PR DESCRIPTION
Also adds documentation explaining that for ES 6 it's necessary to set the `script_lang` parameter to empty string (`""`).

fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/638

replaces #642