### PR TITLE
Doctype deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 9.0.0
+  - Change default document type to 'doc' from 'logs' to align with beats and reflect the generic nature of logstash.
+  - Deprecate 'document_type' option
+
 ### 8.2.2
   - Use `#response_body` instead of `#body` when debugging response from the server #679
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -236,8 +236,11 @@ Elasticsearch with the same ID.
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
+  * This option is deprecated
 
-The document type to write events to. Generally you should try to write only
+Note: This option is deprecated due to the https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html[removal of types in Logstash 6.0].
+It will be removed in the next major version of Logstash.
+This sets the document type to write events to. Generally you should try to write only
 similar events to the same 'type'. String expansion `%{foo}` works here.
 Unless you set 'document_type', the event 'type' will be used if it exists
 otherwise the document type will be assigned the value of 'logs'

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -243,7 +243,7 @@ It will be removed in the next major version of Logstash.
 This sets the document type to write events to. Generally you should try to write only
 similar events to the same 'type'. String expansion `%{foo}` works here.
 Unless you set 'document_type', the event 'type' will be used if it exists
-otherwise the document type will be assigned the value of 'logs'
+otherwise the document type will be assigned the value of 'doc'.
 
 [id="plugins-{type}s-{plugin}-failure_type_logging_whitelist"]
 ===== `failure_type_logging_whitelist` 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -204,7 +204,7 @@ module LogStash; module Outputs; class ElasticSearch;
       type = if @document_type
                event.sprintf(@document_type)
              else
-               event.get("type") || "logs"
+               event.get("type") || "doc"
              end
 
       if !(type.is_a?(String) || type.is_a?(Numeric))

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -12,11 +12,9 @@ module LogStash; module Outputs; class ElasticSearch
       # Joda formats are defined http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[here].
       mod.config :index, :validate => :string, :default => "logstash-%{+YYYY.MM.dd}"
 
-      # The document type to write events to. Generally you should try to write only
-      # similar events to the same 'type'. String expansion `%{foo}` works here.
-      # Unless you set 'document_type', the event 'type' will be used if it exists
-      # otherwise the document type will be assigned the value of 'logs'
-      mod.config :document_type, :validate => :string
+      mod.config :document_type, 
+        :validate => :string, 
+        :deprecated => "Elasticsearch 6.0 no longer supports multiple document types per index. This setting will be removed in the next major release."
 
       # From Logstash 1.3 onwards, a template is applied to Elasticsearch during
       # Logstash's startup if one with the name `template_name` does not already exist.

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -14,7 +14,7 @@ module LogStash; module Outputs; class ElasticSearch
 
       mod.config :document_type, 
         :validate => :string, 
-        :deprecated => "Elasticsearch 6.0 no longer supports multiple document types per index. This setting will be removed in the next major release."
+        :deprecated => "Document types are being deprecated in Elasticsearch 6.0, and removed entirely in 7.0. You should avoid this feature"
 
       # From Logstash 1.3 onwards, a template is applied to Elasticsearch during
       # Logstash's startup if one with the name `template_name` does not already exist.

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '8.2.2'
+  s.version         = '9.0.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/delete_spec.rb
+++ b/spec/integration/outputs/delete_spec.rb
@@ -40,12 +40,12 @@ if ESHelper.es_version_satisfies?(">= 2")
       it "should ignore non-monotonic external version updates" do
         id = "ev2"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "index", "message" => "foo", "my_version" => 99)])
-        r = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+        r = es.get(:index => 'logstash-delete', :type => 'doc', :id => id, :refresh => true)
         expect(r['_version']).to eq(99)
         expect(r['_source']['message']).to eq('foo')
 
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "delete", "message" => "foo", "my_version" => 98)])
-        r2 = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+        r2 = es.get(:index => 'logstash-delete', :type => 'doc', :id => id, :refresh => true)
         expect(r2['_version']).to eq(99)
         expect(r2['_source']['message']).to eq('foo')
       end
@@ -53,12 +53,12 @@ if ESHelper.es_version_satisfies?(">= 2")
       it "should commit monotonic external version updates" do
         id = "ev3"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "index", "message" => "foo", "my_version" => 99)])
-        r = es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true)
+        r = es.get(:index => 'logstash-delete', :type => 'doc', :id => id, :refresh => true)
         expect(r['_version']).to eq(99)
         expect(r['_source']['message']).to eq('foo')
 
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "delete", "message" => "foo", "my_version" => 100)])
-        expect { es.get(:index => 'logstash-delete', :type => 'logs', :id => id, :refresh => true) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+        expect { es.get(:index => 'logstash-delete', :type => 'doc', :id => id, :refresh => true) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
       end
     end
   end

--- a/spec/integration/outputs/groovy_update_spec.rb
+++ b/spec/integration/outputs/groovy_update_spec.rb
@@ -25,7 +25,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
       @es.indices.delete(:index => "*") rescue nil
       @es.index(
         :index => 'logstash-update',
-        :type => 'logs',
+        :type => 'doc',
         :id => "123",
         :body => { :message => 'Test', :counter => 1 }
       )
@@ -37,7 +37,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update', 'script_type' => 'file' })
         subject.register
         subject.multi_receive([LogStash::Event.new("count" => 2)])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["counter"] } == 3
       end
 
@@ -45,7 +45,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update_nested', 'script_type' => 'file' })
         subject.register
         subject.multi_receive([LogStash::Event.new("data" => { "count" => 3 })])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["counter"] } == 4
       end
 
@@ -58,7 +58,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         })
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 3 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["counter"] } == 4
       end
 
@@ -72,7 +72,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         })
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 3 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["counter"] } == 4
       end
 
@@ -86,7 +86,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         })
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 3 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["counter"] } == 3
       end
 
@@ -100,7 +100,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         })
         subject.register
         subject.multi_receive([LogStash::Event.new("count" => 4 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["counter"] } == 5
       end
     end
@@ -110,7 +110,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         subject = get_es_output({ 'document_id' => "456", 'upsert' => '{"message": "upsert message"}' })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'upsert message'
       end
 
@@ -118,7 +118,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         subject = get_es_output({ 'document_id' => "456", 'doc_as_upsert' => true })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'sample message here'
       end
 
@@ -133,7 +133,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_update', 'upsert' => '{"message": "upsert message"}', 'script_type' => 'file' })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'upsert message'
       end
 
@@ -142,7 +142,7 @@ if ESHelper.es_version_satisfies?('>= 2', '< 6')
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 1)])
         @es.indices.refresh
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["counter"] } == 1
       end
     end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -113,8 +113,8 @@ describe "indexing" do
     it_behaves_like("an indexer")
   end
 
-  describe "an indexer with no type value set (default to logs)", :integration => true do
-    let(:type) { "logs" }
+  describe "an indexer with no type value set (default to doc)", :integration => true do
+    let(:type) { "doc" }
     let(:config) {
       {
         "hosts" => get_host_port,

--- a/spec/integration/outputs/index_version_spec.rb
+++ b/spec/integration/outputs/index_version_spec.rb
@@ -38,11 +38,11 @@ if ESHelper.es_version_satisfies?(">= 2")
 
         it "should default to ES version" do
           subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foo")])
-          r = es.get(:index => 'logstash-index', :type => 'logs', :id => "123", :refresh => true)
+          r = es.get(:index => 'logstash-index', :type => 'doc', :id => "123", :refresh => true)
           expect(r["_version"]).to eq(1)
           expect(r["_source"]["message"]).to eq('foo')
           subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foobar")])
-          r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => "123", :refresh => true)
+          r2 = es.get(:index => 'logstash-index', :type => 'doc', :id => "123", :refresh => true)
           expect(r2["_version"]).to eq(2)
           expect(r2["_source"]["message"]).to eq('foobar')
         end  
@@ -66,7 +66,7 @@ if ESHelper.es_version_satisfies?(">= 2")
         it "should respect the external version" do
           id = "ev1"
           subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-          r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+          r = es.get(:index => 'logstash-index', :type => 'doc', :id => id, :refresh => true)
           expect(r["_version"]).to eq(99)
           expect(r["_source"]["message"]).to eq('foo')
         end
@@ -74,12 +74,12 @@ if ESHelper.es_version_satisfies?(">= 2")
         it "should ignore non-monotonic external version updates" do
           id = "ev2"
           subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-          r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+          r = es.get(:index => 'logstash-index', :type => 'doc', :id => id, :refresh => true)
           expect(r["_version"]).to eq(99)
           expect(r["_source"]["message"]).to eq('foo')
 
           subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "98", "message" => "foo")])
-          r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+          r2 = es.get(:index => 'logstash-index', :type => 'doc', :id => id, :refresh => true)
           expect(r2["_version"]).to eq(99)
           expect(r2["_source"]["message"]).to eq('foo')
         end
@@ -87,12 +87,12 @@ if ESHelper.es_version_satisfies?(">= 2")
         it "should commit monotonic external version updates" do
           id = "ev3"
           subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-          r = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+          r = es.get(:index => 'logstash-index', :type => 'doc', :id => id, :refresh => true)
           expect(r["_version"]).to eq(99)
           expect(r["_source"]["message"]).to eq('foo')
 
           subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "100", "message" => "foo")])
-          r2 = es.get(:index => 'logstash-index', :type => 'logs', :id => id, :refresh => true)
+          r2 = es.get(:index => 'logstash-index', :type => 'doc', :id => id, :refresh => true)
           expect(r2["_version"]).to eq(100)
           expect(r2["_source"]["message"]).to eq('foo')
         end

--- a/spec/integration/outputs/painless_update_spec.rb
+++ b/spec/integration/outputs/painless_update_spec.rb
@@ -27,7 +27,7 @@ if ESHelper.es_version_satisfies?(">= 5")
       @es.indices.delete(:index => "*") rescue nil
       @es.index(
         :index => 'logstash-update',
-        :type => 'logs',
+        :type => 'doc',
         :id => "123",
         :body => { :message => 'Test', :counter => 1 }
       )
@@ -41,7 +41,7 @@ if ESHelper.es_version_satisfies?(">= 5")
             subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update', 'script_type' => 'file' })
             subject.register
             subject.multi_receive([LogStash::Event.new("count" => 2)])
-            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+            r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
             insist { r["_source"]["counter"] } == 3
           end
 
@@ -49,7 +49,7 @@ if ESHelper.es_version_satisfies?(">= 5")
             subject = get_es_output({ 'document_id' => "123", 'script' => 'scripted_update_nested', 'script_type' => 'file' })
             subject.register
             subject.multi_receive([LogStash::Event.new("data" => { "count" => 3 })])
-            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+            r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
             insist { r["_source"]["counter"] } == 4
           end
         end
@@ -63,7 +63,7 @@ if ESHelper.es_version_satisfies?(">= 5")
         })
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 3 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["counter"] } == 4
       end
 
@@ -76,7 +76,7 @@ if ESHelper.es_version_satisfies?(">= 5")
         })
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 3 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["counter"] } == 4
       end
 
@@ -89,7 +89,7 @@ if ESHelper.es_version_satisfies?(">= 5")
         })
         subject.register
         subject.multi_receive([LogStash::Event.new("counter" => 3 )])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["counter"] } == 3
       end
 
@@ -114,7 +114,7 @@ if ESHelper.es_version_satisfies?(">= 5")
           subject = get_es_output(plugin_parameters)
           subject.register
           subject.multi_receive([LogStash::Event.new("count" => 4 )])
-          r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+          r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
           insist { r["_source"]["counter"] } == 5
         end
       end
@@ -125,7 +125,7 @@ if ESHelper.es_version_satisfies?(">= 5")
         subject = get_es_output({ 'document_id' => "456", 'upsert' => '{"message": "upsert message"}' })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'upsert message'
       end
 
@@ -133,7 +133,7 @@ if ESHelper.es_version_satisfies?(">= 5")
         subject = get_es_output({ 'document_id' => "456", 'doc_as_upsert' => true })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'sample message here'
       end
 
@@ -150,7 +150,7 @@ if ESHelper.es_version_satisfies?(">= 5")
             subject = get_es_output({ 'document_id' => "456", 'script' => 'scripted_update', 'upsert' => '{"message": "upsert message"}', 'script_type' => 'file' })
             subject.register
             subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+            r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
             insist { r["_source"]["message"] } == 'upsert message'
           end
 
@@ -159,7 +159,7 @@ if ESHelper.es_version_satisfies?(">= 5")
             subject.register
             subject.multi_receive([LogStash::Event.new("counter" => 1)])
             @es.indices.refresh
-            r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+            r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
             insist { r["_source"]["counter"] } == 1
           end
         end
@@ -170,7 +170,7 @@ if ESHelper.es_version_satisfies?(">= 5")
           subject = get_es_output({ 'document_id' => "456", 'script' => 'ctx._source.counter = params.event.counter', 'upsert' => '{"message": "upsert message"}', 'script_type' => 'inline' })
           subject.register
           subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-          r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+          r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
           insist { r["_source"]["message"] } == 'upsert message'
         end
 
@@ -179,7 +179,7 @@ if ESHelper.es_version_satisfies?(">= 5")
           subject.register
           subject.multi_receive([LogStash::Event.new("counter" => 1)])
           @es.indices.refresh
-          r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+          r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
           insist { r["_source"]["counter"] } == 1
         end
       end

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -4,9 +4,9 @@ require_relative "../../../spec/es_spec_helper"
 describe "failures in bulk class expected behavior", :integration => true do
   let(:template) { '{"template" : "not important, will be updated by :index"}' }
   let(:event1) { LogStash::Event.new("somevalue" => 100, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
-  let(:action1) { ["index", {:_id=>nil, :_routing=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event1] }
+  let(:action1) { ["index", {:_id=>nil, :_routing=>nil, :_index=>"logstash-2014.11.17", :_type=>"doc"}, event1] }
   let(:event2) { LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0] }, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
-  let(:action2) { ["index", {:_id=>nil, :_routing=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event2] }
+  let(:action2) { ["index", {:_id=>nil, :_routing=>nil, :_index=>"logstash-2014.11.17", :_type=>"doc"}, event2] }
   let(:invalid_event) { LogStash::Event.new("geoip" => { "location" => "notlatlon" }, "@timestamp" => "2014-11-17T20:37:17.223Z") }
 
   def mock_actions_with_response(*resp)

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -24,7 +24,7 @@ if ESHelper.es_version_satisfies?(">= 2")
       @es.indices.delete(:index => "*") rescue nil
       @es.index(
         :index => 'logstash-update',
-        :type => 'logs',
+        :type => 'doc',
         :id => "123",
         :body => { :message => 'Test', :counter => 1 }
       )
@@ -41,14 +41,14 @@ if ESHelper.es_version_satisfies?(">= 2")
         subject = get_es_output({ 'document_id' => "456" } )
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        expect {@es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)}.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+        expect {@es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)}.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
       end
 
       it "should update existing document" do
         subject = get_es_output({ 'document_id' => "123" })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "updated message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["message"] } == 'updated message here'
       end
 
@@ -58,7 +58,7 @@ if ESHelper.es_version_satisfies?(">= 2")
         subject = get_es_output({ 'document_id' => "123" })
         subject.register
         subject.multi_receive([LogStash::Event.new("data" => "updated message here", "message" => "foo")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "123", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "123", :refresh => true)
         insist { r["_source"]["data"] } == 'updated message here'
         insist { r["_source"]["message"] } == 'foo'
       end
@@ -95,7 +95,7 @@ if ESHelper.es_version_satisfies?(">= 2")
         subject = get_es_output({ 'document_id' => "456", 'upsert' => '{"message": "upsert message"}' })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'upsert message'
       end
 
@@ -103,7 +103,7 @@ if ESHelper.es_version_satisfies?(">= 2")
         subject = get_es_output({ 'document_id' => "456", 'doc_as_upsert' => true })
         subject.register
         subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-        r = @es.get(:index => 'logstash-update', :type => 'logs', :id => "456", :refresh => true)
+        r = @es.get(:index => 'logstash-update', :type => 'doc', :id => "456", :refresh => true)
         insist { r["_source"]["message"] } == 'sample message here'
       end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -37,8 +37,8 @@ describe "outputs/elasticsearch" do
     end
     
     describe "getting a document type" do
-      it "should default to 'logs'" do
-        expect(eso.send(:get_event_type, LogStash::Event.new)).to eql("logs")
+      it "should default to 'doc'" do
+        expect(eso.send(:get_event_type, LogStash::Event.new)).to eql("doc")
       end
 
       it "should get the type from the event if nothing else specified in the config" do

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../../spec/es_spec_helper"
 describe "whitelisting error types in expected behavior" do
   let(:template) { '{"template" : "not important, will be updated by :index"}' }
   let(:event1) { LogStash::Event.new("somevalue" => 100, "@timestamp" => "2014-11-17T20:37:17.223Z") }
-  let(:action1) { ["index", {:_id=>1, :_routing=>nil, :_index=>"logstash-2014.11.17", :_type=>"logs"}, event1] }
+  let(:action1) { ["index", {:_id=>1, :_routing=>nil, :_index=>"logstash-2014.11.17", :_type=>"doc"}, event1] }
   let(:settings) { {"manage_template" => true, "index" => "logstash-2014.11.17", "template_overwrite" => true, "hosts" => get_host_port() } }
 
   subject { LogStash::Outputs::ElasticSearch.new(settings) }


### PR DESCRIPTION
Resolves #669 by deprecating the `doc_type` option and moving the default type name from `logs` to `doc`.

We want to get this in before 6.0.0 GA otherwise it will have to wait for LS 7.0.0

The really nice thing about moving from `logs` to `doc`, aside from beats integration, is that it better reflects the generic nature of Logstash.

We will also need to add this to breaking changes in Logstash core.