### PR TITLE
Don't try to sanitize the URL as there is no such method

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -247,7 +247,7 @@ module LogStash; module Outputs; class ElasticSearch;
         sleep_interval = next_sleep_interval(sleep_interval)
         retry unless @stopping.true?
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
-        log_hash = {:code => e.response_code, :url => e.url.sanitized.to_s}
+        log_hash = {:code => e.response_code, :url => e.url.to_s}
         log_hash[:body] = e.response_body if @logger.debug? # Generally this is too verbose
         message = "Encountered a retryable error. Will Retry with exponential backoff "
 


### PR DESCRIPTION
The rescue block for `::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError` was throwing an exception while logging and the original exception which should be logged is being lost.

https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/612 is caused because of this.