### PR TITLE
Deprecated field [template] used, replaced by [index_patterns]

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es6x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es6x.json
@@ -1,5 +1,5 @@
 {
-  "template" : "logstash-*",
+  "index_patterns" : "logstash-*",
   "version" : 60001,
   "settings" : {
     "index.refresh_interval" : "5s"


### PR DESCRIPTION
"template" is not working anymore.