### PR TITLE
WIP Only use the type field for the event for ES versions < 6.0.

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -217,7 +217,7 @@ module LogStash; module Outputs; class ElasticSearch;
       type = if @document_type
                event.sprintf(@document_type)
              else
-               if maximum_seen_major_version > 6
+               if maximum_seen_major_version < 6
                  event.get("type") || DEFAULT_EVENT_TYPE
                else
                  DEFAULT_EVENT_TYPE

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -86,6 +86,10 @@ module LogStash; module Outputs; class ElasticSearch;
       @pool.connected_es_versions
     end
 
+    def maximum_seen_major_version
+      @pool.maximum_seen_major_version
+    end
+
     def bulk(actions)
       @action_count ||= 0
       @action_count += actions.size

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -113,6 +113,12 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       end
     end
 
+    def maximum_seen_major_version
+      @state_mutex.synchronize do
+        @maximum_seen_major_version
+      end
+    end
+
     def urls
       url_info.keys
     end
@@ -245,6 +251,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           es_version = get_es_version(url)
           @state_mutex.synchronize do
             meta[:version] = es_version
+            major = major_version(es_version)
+            @maximum_seen_major_version = major if !@maximum_seen_major_version || major > @maximum_seen_major_version
             meta[:state] = :alive
           end
         rescue HostUnreachableError, BadResponseCodeError => e

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -4,7 +4,7 @@ module LogStash; module Outputs; class ElasticSearch
     def self.install_template(plugin)
       return unless plugin.manage_template
       plugin.logger.info("Using mapping template from", :path => plugin.template)
-      template = get_template(plugin.template, get_es_major_version(plugin.client))
+      template = get_template(plugin.template, plugin.maximum_seen_major_version)
       plugin.logger.info("Attempting to install template", :manage_template => template)
       install(plugin.client, plugin.template_name, template, plugin.template_overwrite)
     rescue => e
@@ -12,12 +12,6 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     private
-    def self.get_es_major_version(client)
-      # get the elasticsearch version of each node in the pool and
-      # pick the biggest major version
-      client.connected_es_versions.uniq.map {|version| version.split(".").first.to_i}.max
-    end
-
     def self.get_template(path, es_major_version)
       template_path = path || default_template_path(es_major_version)
       read_template_file(template_path)


### PR DESCRIPTION
Since 6.0 only supports a single type this behavior can be problematic as
multiple types will break ES.

Fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/708

This is a WIP, it still needs tests