### PR TITLE
allow failures in es master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     env: LOGSTASH_BRANCH=6.0
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6
+  allow_failures:
+  - env: INTEGRATION=true ES_VERSION=master TEST_DEBUG=true
   fast_finish: true
 install: true
 script: ci/build.sh


### PR DESCRIPTION
due to elasticsearch master containing breaking changes as it moves to 7.0.0,
it's not required that the tests pass for this particular scenario until
it reaches closer to 7.0.0-alpha1
