### PR TITLE
Only use the type field for the event for ES versions < 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.0.2
+  - Ignore event's type field for the purpose of setting document `_type` if cluster is es 6.x or above
+
 ## 9.0.1
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -243,6 +243,7 @@ It will be removed in the next major version of Logstash.
 This sets the document type to write events to. Generally you should try to write only
 similar events to the same 'type'. String expansion `%{foo}` works here.
 If you don't set a value for this option:
+
 - for elasticsearch clusters 6.x and above: the value of 'doc' will be used;
 - for elasticsearch clusters 5.x and below: the event's 'type' field will be used, if the field is not present the value of 'doc' will be used.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -242,8 +242,9 @@ Note: This option is deprecated due to the https://www.elastic.co/guide/en/elast
 It will be removed in the next major version of Logstash.
 This sets the document type to write events to. Generally you should try to write only
 similar events to the same 'type'. String expansion `%{foo}` works here.
-Unless you set 'document_type', the event 'type' will be used if it exists
-otherwise the document type will be assigned the value of 'doc'.
+If you don't set a value for this option:
+- for elasticsearch clusters 6.x and above: the value of 'doc' will be used;
+- for elasticsearch clusters 5.x and below: the event's 'type' field will be used, if the field is not present the value of 'doc' will be used.
 
 [id="plugins-{type}s-{plugin}-failure_type_logging_whitelist"]
 ===== `failure_type_logging_whitelist` 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -23,13 +23,6 @@ module LogStash; module Outputs; class ElasticSearch;
       setup_hosts # properly sets @hosts
       build_client
 
-      # Wait until at least one host connects and we have a version
-      until maximum_seen_major_version
-        @logger.info("ES Output starting, determining ES version...")
-        sleep 1
-      end
-      @logger.info("ES Output version determined", :es_version => maximum_seen_major_version)
-
       install_template
       check_action_validity
 
@@ -54,10 +47,6 @@ module LogStash; module Outputs; class ElasticSearch;
         @logger.info("No 'host' set in elasticsearch output. Defaulting to localhost")
         @hosts.replace(["localhost"])
       end
-    end
-
-    def maximum_seen_major_version
-      client.maximum_seen_major_version
     end
 
     def install_template
@@ -217,7 +206,7 @@ module LogStash; module Outputs; class ElasticSearch;
       type = if @document_type
                event.sprintf(@document_type)
              else
-               if maximum_seen_major_version < 6
+               if client.maximum_seen_major_version < 6
                  event.get("type") || DEFAULT_EVENT_TYPE
                else
                  DEFAULT_EVENT_TYPE

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -49,6 +49,10 @@ module LogStash; module Outputs; class ElasticSearch;
       end
     end
 
+    def maximum_seen_major_version
+      client.maximum_seen_major_version
+    end
+
     def install_template
       TemplateManager.install_template(self)
     end

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -217,7 +217,7 @@ module LogStash; module Outputs; class ElasticSearch;
       type = if @document_type
                event.sprintf(@document_type)
              else
-               if maximum_seen_major_version > 6
+               if maximum_seen_major_version < 6
                  event.get("type") || DEFAULT_EVENT_TYPE
                else
                  DEFAULT_EVENT_TYPE

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -82,10 +82,6 @@ module LogStash; module Outputs; class ElasticSearch;
       template_put(name, template)
     end
 
-    def connected_es_versions
-      @pool.connected_es_versions
-    end
-
     def maximum_seen_major_version
       @pool.maximum_seen_major_version
     end

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -86,6 +86,10 @@ module LogStash; module Outputs; class ElasticSearch;
       @pool.connected_es_versions
     end
 
+    def maximum_seen_major_version
+      @pool.maximum_seen_major_version
+    end
+
     def bulk(actions)
       @action_count ||= 0
       @action_count += actions.size

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -113,6 +113,12 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       end
     end
 
+    def maximum_seen_major_version
+      @state_mutex.synchronize do
+        @maximum_seen_major_version
+      end
+    end
+
     def urls
       url_info.keys
     end
@@ -245,6 +251,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           es_version = get_es_version(url)
           @state_mutex.synchronize do
             meta[:version] = es_version
+            major = major_version(es_version)
+            @maximum_seen_major_version = major if !@maximum_seen_major_version || major > @maximum_seen_major_version
             meta[:state] = :alive
           end
         rescue HostUnreachableError, BadResponseCodeError => e

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -4,7 +4,7 @@ module LogStash; module Outputs; class ElasticSearch
     def self.install_template(plugin)
       return unless plugin.manage_template
       plugin.logger.info("Using mapping template from", :path => plugin.template)
-      template = get_template(plugin.template, get_es_major_version(plugin.client))
+      template = get_template(plugin.template, plugin.maximum_seen_major_version)
       plugin.logger.info("Attempting to install template", :manage_template => template)
       install(plugin.client, plugin.template_name, template, plugin.template_overwrite)
     rescue => e
@@ -12,12 +12,6 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     private
-    def self.get_es_major_version(client)
-      # get the elasticsearch version of each node in the pool and
-      # pick the biggest major version
-      client.connected_es_versions.uniq.map {|version| version.split(".").first.to_i}.max
-    end
-
     def self.get_template(path, es_major_version)
       template_path = path || default_template_path(es_major_version)
       read_template_file(template_path)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '9.0.1'
+  s.version         = '9.0.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -50,7 +50,11 @@ if ESHelper.es_version_satisfies?(">= 5")
         response = http_client.get("#{index_url}/_search?q=*&size=1000")
         result = LogStash::Json.load(response.body)
         result["hits"]["hits"].each do |doc|
-          expect(doc["_type"]).to eq(type)
+          if ESHelper.es_version_satisfies?(">= 6")
+            expect(doc["_type"]).to eq("doc")
+          else
+            expect(doc["_type"]).to eq(type)
+          end
           expect(doc["_index"]).to eq(index)
         end
       end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -78,7 +78,11 @@ describe "indexing" do
       response = http_client.get("#{index_url}/_search?q=*&size=1000")
       result = LogStash::Json.load(response.body)
       result["hits"]["hits"].each do |doc|
-        expect(doc["_type"]).to eq(type)
+        if ESHelper.es_version_satisfies?(">= 6")
+          expect(doc["_type"]).to eq("doc")
+        else
+          expect(doc["_type"]).to eq(type)
+        end
         expect(doc["_index"]).to eq(index)
       end
     end

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -5,26 +5,6 @@ require "json"
 
 describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
-  describe ".get_es_major_version" do
-    let(:client) { double("client") }
-
-    before(:each) do
-      allow(client).to receive(:connected_es_versions).and_return(["5.3.0"])
-    end
-
-    it "picks the largest major version" do
-      expect(described_class.get_es_major_version(client)).to eq(5)
-    end
-    context "if there are nodes with multiple major versions" do
-      before(:each) do
-        allow(client).to receive(:connected_es_versions).and_return(["5.3.0", "6.0.0"])
-      end
-      it "picks the largest major version" do
-        expect(described_class.get_es_major_version(client)).to eq(6)
-      end
-    end
-  end
-
   describe ".default_template_path" do
     context "elasticsearch 1.x" do
       it "chooses the 2x template" do

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -14,6 +14,7 @@ describe "whitelisting error types in expected behavior" do
 
     subject.register
 
+    allow(subject.client).to receive(:maximum_seen_major_version).and_return(0)
     allow(subject.client).to receive(:bulk).and_return(
       {
         "errors" => true,


### PR DESCRIPTION
aims to replace https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/709

This PR ensures the event field "type" isn't used as a document_type if elasticsearch cluster is on 6.0