### PR TITLE
use gradle 4.3 because es 7 needs it

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -83,7 +83,7 @@ get_es_distribution_version() {
 # not here because this script runs in a different bash shell.
 download_gradle() {
   echo $PWD
-  local version="3.3"
+  local version="4.3"
   curl -sL https://services.gradle.org/distributions/gradle-$version-bin.zip > gradle.zip
   unzip -d . gradle.zip
   mv gradle-* gradle


### PR DESCRIPTION
see more in https://github.com/elastic/elasticsearch/pull/27885

an example of failure: https://travis-ci.org/logstash-plugins/logstash-output-elasticsearch/jobs/321736196#L1605