### PR TITLE
Avoid getting stuck on infinite loop

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -272,7 +272,7 @@ module LogStash; module Outputs; class ElasticSearch;
         end
 
         sleep_interval = sleep_for_interval(sleep_interval)
-        retry
+        retry unless @stopping.true?
       rescue => e
         # Stuff that should never happen
         # For all other errors print out full connection issues


### PR DESCRIPTION
If we get 400 which could be part of DLQ, plugin here gets stuck in loop indefinitely on retry
e.g. https://discuss.elastic.co/t/logstash-5-6-1-inifinite-loop-encountered-a-retryable-error/101753

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
