### PR TITLE
Avoid infinite loop by checking for zero body size #736

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -242,7 +242,7 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def http_compression
-      client_settings.fetch(:http_compression, {})
+      client_settings.fetch(:http_compression, false)
     end
 
     def build_adapter(options)

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -115,7 +115,9 @@ module LogStash; module Outputs; class ElasticSearch;
                     action.map {|line| LogStash::Json.dump(line)}.join("\n") :
                     LogStash::Json.dump(action)
         as_json << "\n"
-        bulk_responses << bulk_send(body_stream) if (body_stream.size + as_json.bytesize) > TARGET_BULK_BYTES
+	if (body_stream.size + as_json.bytesize) > TARGET_BULK_BYTES
+          bulk_responses << bulk_send(body_stream) unless body_stream.size == 0
+	end
         stream_writer.write(as_json)
       end
       stream_writer.close if http_compression

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -29,7 +29,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     let(:http_hostname_port) { ::LogStash::Util::SafeURI.new("http://#{hostname_port}") }
     let(:https_hostname_port) { ::LogStash::Util::SafeURI.new("https://#{hostname_port}") }
     let(:http_hostname_port_path) { ::LogStash::Util::SafeURI.new("http://#{hostname_port}/path") }
-    
+
     shared_examples("proper host handling") do
       it "should properly transform a host:port string to a URL" do
         expect(subject.host_to_url(hostname_port_uri).to_s).to eq(http_hostname_port.to_s + "/")
@@ -58,7 +58,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
         context "when SSL is false" do
           let(:ssl) { false }
           let(:base_options) { super.merge(:hosts => [https_hostname_port]) }
-          
+
           it "should refuse to handle an https url" do
             expect {
               subject.host_to_url(https_hostname_port)
@@ -72,32 +72,32 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
             subject
             expect(subject.host_to_url(https_hostname_port).to_s).to eq(https_hostname_port.to_s + "/")
           end
-        end       
+        end
       end
 
       describe "path" do
         let(:url) { http_hostname_port_path }
         let(:base_options) { super.merge(:hosts => [url]) }
-        
+
         it "should allow paths in a url" do
           expect(subject.host_to_url(url)).to eq(url)
         end
 
         context "with the path option set" do
           let(:base_options) { super.merge(:client_settings => {:path => "/otherpath"}) }
-          
+
           it "should not allow paths in two places" do
             expect {
               subject.host_to_url(url)
             }.to raise_error(LogStash::ConfigurationError)
           end
         end
-        
+
         context "with a path missing a leading /" do
           let(:url) { http_hostname_port }
           let(:base_options) { super.merge(:client_settings => {:path => "otherpath"}) }
-          
-          
+
+
           it "should automatically insert a / in front of path overlays" do
             expected = url.clone
             expected.path = url.path + "/otherpath"
@@ -182,8 +182,6 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
 
   describe "#bulk" do
     subject { described_class.new(base_options) }
-
-    require "json"
     let(:message) { "hey" }
     let(:actions) { [
       ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> message}],
@@ -193,7 +191,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
       let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
       let(:message) { "a" * (target_bulk_bytes + 1) }
 
-      it "should be handled properly" do
+      it "sends the message as its own bulk payload" do
         allow(subject).to receive(:join_bulk_responses)
         expect(subject).to receive(:bulk_send).once do |data|
           expect(data.size).to be > target_bulk_bytes
@@ -209,6 +207,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
         ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> message1}],
         ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> message2}],
       ]}
+
       it "executes one bulk_send operation" do
         allow(subject).to receive(:join_bulk_responses)
         expect(subject).to receive(:bulk_send).once


### PR DESCRIPTION
Implement https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/lib/logstash/outputs/elasticsearch/http_client.rb#L118 from master in 7.x.

Avoid an infinite loop caused by sending a bulk request to Elasticsearch with a zero body size.
Issue #736 
https://discuss.elastic.co/t/inifinite-loop-encountered-a-retryable-error-400-error-from-elasticsearch/119290
https://discuss.elastic.co/t/logstash-5-6-1-inifinite-loop-encountered-a-retryable-error/101753
