### PR TITLE
Set number_of_shards to 1

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es7x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es7x.json
@@ -2,7 +2,8 @@
   "template" : "logstash-*",
   "version" : 60001,
   "settings" : {
-    "index.refresh_interval" : "5s"
+    "index.refresh_interval" : "5s",
+    "number_of_shards": 1
   },
   "mappings" : {
     "_doc" : {


### PR DESCRIPTION
Override Elasticsearch default sharding via logstash-specific index template.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
