### PR TITLE
bump version to 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.1.0
+  - Set number_of_shards to 1 and document_type to '_doc' for es 7.x clusters #741 #747
+  - Fix usage of upsert and script when update action is interpolated #239
+  - Add metrics to track bulk level and document level responses #585
+
 ## 9.0.3
   - Ignore master-only nodes when using sniffing
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '9.0.3'
+  s.version         = '9.1.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
changelog computed from:

```
% git lg v9.0.3..master
* b0c0c54 - (origin/master, origin/HEAD, master) Minor fix link representation (3 days ago) <Pavel Alexeev aka Pahan-Hubbitus>
* 71b2e53 - assume document type is _doc for ES 7.x clusters (#747) (3 days ago) <João Duarte>
* 353e4f5 - add a few metrics to the plugin (#585) (3 days ago) <João Duarte>
* 9f3fffd - Set number_of_shards to 1 (4 days ago) <Glen Smith>
* 32ca02c - Update index.asciidoc (8 days ago) <Thomas Decaux>
* 7575f62 - Fix typo "elasticseach’s" => "elasticsearch’s" (8 days ago) <Takahiro Ethan Ikeuchi>
* 7dde2de - Merge pull request #385 from dchauviere/issue_239 (3 weeks ago) <Guy Boertje>
* 5272a72 - Fix #239 - interpolated action "update" don't get params "upsert" and "script" (3 weeks ago) <David Chauviere>
```