### PR TITLE
Fix incorrect logging of non-SafeURI as BadResponseCode

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -143,8 +143,9 @@ module LogStash; module Outputs; class ElasticSearch;
       end
 
       if response.code != 200
+        url = ::LogStash::Util::SafeURI.new(response.final_url)
         raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(
-          response.code, @bulk_path, body_stream.to_s, response.body
+          response.code, url, body_stream.to_s, response.body
         )
       end
 


### PR DESCRIPTION
This would cause the exception handler in common.rb to fail, since it expects to be able to call .sanitized on the URL

fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/662