### PR TITLE
Add an example for "script" option in documentation

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -476,6 +476,14 @@ This can be dynamic using the `%{foo}` syntax.
 
 Set script name for scripted update mode
 
+Example:
+[source,ruby]
+    output {
+      elasticsearch {
+        script => "ctx._source.message = event.get('message')"
+      }
+    }
+
 [id="plugins-{type}s-{plugin}-script_lang"]
 ===== `script_lang` 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -480,7 +480,7 @@ Example:
 [source,ruby]
     output {
       elasticsearch {
-        script => "ctx._source.message = event.get('message')"
+        script => "ctx._source.message = params.event.get('message')"
       }
     }
 


### PR DESCRIPTION
Add this example : 
`script => "ctx._source.message = event.get('message')"`