### PR TITLE
Improve plugin behavior when Elasticsearch is down on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.1.3
+  - Improve plugin behavior when Elasticsearch is down on startup #758
+
 ## 9.1.2
   - No user facing changes, removed unnecessary test dep.
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -233,6 +233,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   def close
     @stopping.make_true
+    stop_template_installer
     @client.close if @client
   end
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -23,11 +23,10 @@ module LogStash; module Outputs; class ElasticSearch;
 
       setup_hosts # properly sets @hosts
       build_client
-      install_template_after_successful_connection
       check_action_validity
       @bulk_request_metrics = metric.namespace(:bulk_requests)
       @document_level_metrics = metric.namespace(:documents)
-
+      install_template_after_successful_connection
       @logger.info("New Elasticsearch output", :class => self.class.name, :hosts => @hosts.map(&:sanitized).map(&:to_s))
     end
 
@@ -41,15 +40,15 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def install_template_after_successful_connection
       @template_installer ||= Thread.new do
-          sleep_interval = @retry_initial_interval
-          until successful_connection? || @stopping.true?
-            @logger.debug("Waiting for connectivity to Elasticsearch cluster. Retrying in #{sleep_interval}s")
-            Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
-            sleep_interval = next_sleep_interval(sleep_interval)
-          end
-            install_template if successful_connection?
+        sleep_interval = @retry_initial_interval
+        until successful_connection? || @stopping.true?
+          @logger.debug("Waiting for connectivity to Elasticsearch cluster. Retrying in #{sleep_interval}s")
+          Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
+          sleep_interval = next_sleep_interval(sleep_interval)
         end
+        install_template if successful_connection?
       end
+    end
 
     def stop_template_installer
       @template_installer.join unless @template_installer.nil?

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -43,7 +43,7 @@ module LogStash; module Outputs; class ElasticSearch;
       @template_installer ||= Thread.new do
           sleep_interval = @retry_initial_interval
           until successful_connection? || @stopping.true?
-            @logger.debug("Waiting for connectivity to Elasticsearch cluster")
+            @logger.debug("Waiting for connectivity to Elasticsearch cluster. Retrying in #{sleep_interval}s")
             Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
             sleep_interval = next_sleep_interval(sleep_interval)
           end

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -16,15 +16,16 @@ module LogStash; module Outputs; class ElasticSearch;
     VERSION_TYPES_PERMITTING_CONFLICT = ["external", "external_gt", "external_gte"]
 
     def register
+      @template_installed = Concurrent::AtomicBoolean.new(false)
       @stopping = Concurrent::AtomicBoolean.new(false)
       # To support BWC, we check if DLQ exists in core (< 5.4). If it doesn't, we use nil to resort to previous behavior.
       @dlq_writer = dlq_enabled? ? execution_context.dlq_writer : nil
 
       setup_hosts # properly sets @hosts
       build_client
-
-      install_template
+      after_successful_connection { install_template }
       check_action_validity
+      #after_successful_connection { install_template }
       @bulk_request_metrics = metric.namespace(:bulk_requests)
       @document_level_metrics = metric.namespace(:documents)
 
@@ -33,7 +34,31 @@ module LogStash; module Outputs; class ElasticSearch;
 
     # Receive an array of events and immediately attempt to index them (no buffering)
     def multi_receive(events)
+      until @template_installed.true?
+        sleep 1
+      end
       retrying_submit(events.map {|e| event_action_tuple(e)})
+    end
+
+    def after_successful_connection
+      @template_installer = Thread.new do
+          sleep_interval = @retry_initial_interval
+          until successful_connection? || @stopping.true?
+            @logger.debug("Waiting for connectivity to Elasticsearch cluster")
+            Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
+            sleep_interval = next_sleep_interval(sleep_interval)
+          end
+          yield if successful_connection?
+        end
+      end
+
+    def stop_template_installer
+      @template_installer.join if @template_installer
+    end
+
+    def successful_connection?
+      # !!maximum_seen_major_version
+      maximum_seen_major_version
     end
 
     # Convert the event into a 3-tuple of action, params, and event
@@ -94,6 +119,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def install_template
       TemplateManager.install_template(self)
+      @template_installed.make_true
     end
 
     def check_action_validity

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '9.1.2'
+  s.version         = '9.1.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -11,6 +11,10 @@ module ESHelper
     Elasticsearch::Client.new(:hosts => [get_host_port])
   end
 
+  def self.es_version
+    RSpec.configuration.filter[:es_version] || ENV['ES_VERSION']
+  end
+
   def self.es_version_satisfies?(*requirement)
     es_version = RSpec.configuration.filter[:es_version] || ENV['ES_VERSION']
     es_release_version = Gem::Version.new(es_version).release

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -60,6 +60,7 @@ if ESHelper.es_version_satisfies?(">= 5")
     end
 
     it "sets the correct content-encoding header and body is compressed" do
+      allow(subject.client.pool.adapter.client).to receive(:send).with(anything, /_template/, anything).and_call_original
       expect(subject.client.pool.adapter.client).to receive(:send).
         with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
         and_call_original

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -99,9 +99,10 @@ describe "indexing" do
             :eager => true
           }}
       end
-
+      # Allow template to be checked for existence/installed
+      allow(subject.client.pool.adapter.client).to receive(:send).with(anything, /_template/, anything).and_call_original
       expect(subject.client.pool.adapter.client).to receive(:send).
-        with(anything, anything, expected_manticore_opts).
+        with(anything, anything, expected_manticore_opts).at_least(:once).
         and_call_original
       subject.multi_receive(events)
     end

--- a/spec/integration/outputs/no_es_on_startup_spec.rb
+++ b/spec/integration/outputs/no_es_on_startup_spec.rb
@@ -1,0 +1,58 @@
+require "logstash/outputs/elasticsearch"
+require_relative "../../../spec/es_spec_helper"
+
+describe "elasticsearch is down on startup", :integration => true do
+  let(:event1) { LogStash::Event.new("somevalue" => 100, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
+  let(:event2) { LogStash::Event.new("message" => "a") }
+
+  subject {
+    LogStash::Outputs::ElasticSearch.new({
+                                           "manage_template" => true,
+                                           "index" => "logstash-2014.11.17",
+                                           "template_overwrite" => true,
+                                           "hosts" => get_host_port(),
+                                           "retry_max_interval" => 64,
+                                           "retry_initial_interval" => 2
+                                       })
+  }
+
+  before :each do
+    # Delete all templates first.
+    require "elasticsearch"
+    allow(Stud).to receive(:stoppable_sleep)
+
+    # Clean ES of data before we start.
+    @es = get_client
+    @es.indices.delete_template(:name => "*")
+    @es.indices.delete(:index => "*")
+    @es.indices.refresh
+  end
+
+  after :each do
+    subject.close
+  end
+
+  it 'should ingest events when Elasticsearch recovers before documents are sent' do
+    allow_any_instance_of(LogStash::Outputs::ElasticSearch::HttpClient::Pool).to receive(:get_es_version).and_raise(::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError.new(StandardError.new, "big fail"))
+    subject.register
+    allow_any_instance_of(LogStash::Outputs::ElasticSearch::HttpClient::Pool).to receive(:get_es_version).and_return(ESHelper.es_version)
+    subject.multi_receive([event1, event2])
+    @es.indices.refresh
+    r = @es.search
+    expect(r["hits"]["total"]).to eql(2)
+  end
+
+  it 'should ingest events when Elasticsearch recovers after documents are sent' do
+    allow_any_instance_of(LogStash::Outputs::ElasticSearch::HttpClient::Pool).to receive(:get_es_version).and_raise(::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError.new(StandardError.new, "big fail"))
+    subject.register
+    Thread.new do
+      sleep 4
+      allow_any_instance_of(LogStash::Outputs::ElasticSearch::HttpClient::Pool).to receive(:get_es_version).and_return(ESHelper.es_version)
+    end
+    subject.multi_receive([event1, event2])
+    @es.indices.refresh
+    r = @es.search
+    expect(r["hits"]["total"]).to eql(2)
+  end
+
+end

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -86,7 +86,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
 
         context "with the path option set" do
           let(:base_options) { super.merge(:client_settings => {:path => "/otherpath"}) }
-          
+
           it "should not allow paths in two places" do
             expect {
               subject.host_to_url(url)

--- a/spec/unit/outputs/elasticsearch_proxy_spec.rb
+++ b/spec/unit/outputs/elasticsearch_proxy_spec.rb
@@ -13,13 +13,13 @@ describe "Proxy option" do
     allow(::Manticore::Client).to receive(:new).with(any_args).and_call_original
   end
 
-  after do
-    subject.close
-  end
-
   describe "valid configs" do
     before do
       subject.register
+    end
+
+    after do
+      subject.close
     end
 
     context "when specified as a URI" do

--- a/spec/unit/outputs/elasticsearch_proxy_spec.rb
+++ b/spec/unit/outputs/elasticsearch_proxy_spec.rb
@@ -13,6 +13,10 @@ describe "Proxy option" do
     allow(::Manticore::Client).to receive(:new).with(any_args).and_call_original
   end
 
+  after do
+    subject.close
+  end
+
   describe "valid configs" do
     before do
       subject.register

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -457,7 +457,7 @@ describe LogStash::Outputs::ElasticSearch do
         end
       end
 
-      context "with explicity query parameters" do
+      context "with explicit query parameters" do
         let(:options) {
           {
             "hosts" => ["http://localhost:9202/path"],
@@ -470,7 +470,7 @@ describe LogStash::Outputs::ElasticSearch do
         end
       end
 
-      context "with explicity query parameters and existing url parameters" do
+      context "with explicit query parameters and existing url parameters" do
         let(:existing_query_string) { "existing=param" }
         let(:options) {
           {

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -314,7 +314,7 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   describe "SSL end to end" do
-    let(:do_register) { false }
+    let(:do_register) { false } # skip the register in the global before block, as is called here.
     let(:manticore_double) do
       double("manticoreX#{self.inspect}")
     end
@@ -408,6 +408,10 @@ describe LogStash::Outputs::ElasticSearch do
 
     before :each do
       allow(::Manticore::Client).to receive(:new).with(any_args).and_call_original
+    end
+
+    after :each do
+      subject.close
     end
 
     it "should set the correct http client option for 'validate_after_inactivity'" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -314,6 +314,7 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   describe "SSL end to end" do
+    let(:do_register) { false }
     let(:manticore_double) do
       double("manticoreX#{self.inspect}")
     end

--- a/spec/unit/outputs/elasticsearch_ssl_spec.rb
+++ b/spec/unit/outputs/elasticsearch_ssl_spec.rb
@@ -58,6 +58,7 @@ describe "SSL option" do
 
     after :each do
       File.delete(keystore_path)
+      subject.close
     end
 
     subject do


### PR DESCRIPTION
Prior to this commit, if Elasticsearch was down during Logstash startup,
  one of two outcomes would occur:

  If Elasticsearch was still down when the first events arrived, Logstash
    would immediately exit with an error
  If Elasticsearch was up when the first events arrived, Logstash would
    accept the messages, but would the template for the index would not
    be installed.

This commit will install the template only after a successful call to
  Elasticsearch has been made. New messages will block until connectivity
  to Elasticsearch is re-established and the template has been installed

fixes #715 
fixes #750 