### PR TITLE
cleanup travis ci file for 7.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,14 @@ env:
  - INTEGRATION=false
  - INTEGRATION=true ES_VERSION=1.7.6 TEST_DEBUG=true
  - INTEGRATION=true ES_VERSION=2.4.4 TEST_DEBUG=true
- - INTEGRATION=true ES_VERSION=5.5.0 TEST_DEBUG=true
- - SECURE_INTEGRATION=true INTEGRATION=true ES_VERSION=5.5.0 TEST_DEBUG=true
- - INTEGRATION=true ES_VERSION=5.6.0 TEST_DEBUG=true
- - INTEGRATION=true ES_VERSION=6.0.0-beta2 TEST_DEBUG=true
- - SECURE_INTEGRATION=true INTEGRATION=true ES_VERSION=6.0.0-beta2 TEST_DEBUG=true
+ - INTEGRATION=true ES_VERSION=5.6.9 TEST_DEBUG=true
+ - SECURE_INTEGRATION=true INTEGRATION=true ES_VERSION=5.6.9 TEST_DEBUG=true
 rvm:
-  - jruby-1.7.25
+  - jruby-1.7.27
 matrix:
   include:
-    - rvm: jruby-9.1.10.0
-      env: LOGSTASH_BRANCH=6.x
-    - rvm: jruby-1.7.25
+    - rvm: jruby-1.7.27
       env: LOGSTASH_BRANCH=5.6
-  allow_failures:
-    - env: INTEGRATION=true ES_VERSION=master TEST_DEBUG=true
   fast_finish: true
 install: true
 script: ci/build.sh

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -123,23 +123,11 @@ else
   fi
 
   case "$ES_VERSION" in
-    6.*)
-      setup_es https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-SNAPSHOT.tar.gz https://snapshots.elastic.co/downloads/packs/x-pack/x-pack-$ES_VERSION-SNAPSHOT.zip
-      es_distribution_version=$(get_es_distribution_version)
-      start_es
-      bundle exec rspec -fd $extra_tag_args --tag update_tests:painless --tag update_tests:groovy --tag es_version:$es_distribution_version $spec_path
-      ;;
     5.6.*)
-      setup_es https://snapshots.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-SNAPSHOT.tar.gz
-      es_distribution_version=$(get_es_distribution_version)
-      start_es -Escript.inline=true -Escript.stored=true -Escript.file=true
-      bundle exec rspec -fd $extra_tag_args --tag update_tests:painless --tag update_tests:groovy --tag es_version:$es_distribution_version $spec_path
-      ;;
-    5.*)
       setup_es https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
       es_distribution_version=$(get_es_distribution_version)
       start_es -Escript.inline=true -Escript.stored=true -Escript.file=true
-      bundle exec rspec -fd $extra_tag_args --tag update_tests:painless --tag es_version:$es_distribution_version --tag update_tests:groovy $spec_path
+      bundle exec rspec -fd $extra_tag_args --tag update_tests:painless --tag update_tests:groovy --tag es_version:$es_distribution_version $spec_path
       ;;
     2.*)
       setup_es https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz


### PR DESCRIPTION
no point in testing against logstash 6.x as 6.0.0 shipped with es output 9.0.0

remove references to 6.0.0-beta2, update version of logstash 5.6 from 5.6.0 to 5.6.9