### PR TITLE
Fix http_client_spec.rb unit tests

### DIFF
--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -8,7 +8,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     opts = {
       :hosts => [::LogStash::Util::SafeURI.new("127.0.0.1")],
       :logger => Cabin::Channel.get,
-      :metric => ::LogStash::Instrument::NamespacedNullMetric.new(:dummy_metric)
+      :metric => ::LogStash::Instrument::NullMetric.new(:dummy).namespace(:alsodummy)
     }
 
     if !ssl.nil? # Shortcut to set this


### PR DESCRIPTION
Unit tests were failing after a change introduced with Javafication of NamespacedNullMetric

