### PR TITLE
set secure tag so integration test is excluded by default

### DIFF
--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -128,7 +128,7 @@ describe "indexing" do
     it_behaves_like("an indexer")
   end
 
-  describe "a secured indexer", :secure_integration => true do
+  describe "a secured indexer", :elasticsearch_secure => true do
     let(:user) { "simpleuser" }
     let(:password) { "abc123" }
     let(:cacert) { "spec/fixtures/test_certs/test.crt" }


### PR DESCRIPTION
by default devutils sets up the following exclusions:

{:redis=>true, :socket=>true, :performance=>true,
  :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true,
  :export_cypher=>true, :integration=>true, :windows=>true}

However there was a test suite that ran integration tests against a
secured elasticsearch instance, tagged with `integration_secure`

This meant that a normal `bundle exec rspec` would run these tests
and fail. This PR replaces the `integration_secure` tag with the
`elasticsearch_secure` so that the tests are excluded by default too.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
