### PR TITLE
Raise logging level for 'invalid_index_name_exception' ES exceptions to ERROR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.1.4
+  - Log an error -- not a warning -- when ES raises an invalid\_index\_name\_exception.
+
 ## 9.1.3
   - Improve plugin behavior when Elasticsearch is down on startup #758
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '9.1.3'
+  s.version         = '9.1.4'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
As discussed in #759, an invalid index exception should log at the ERROR level.
Presumably, most of these will happen just after an update to a user's Logstash
configuration.

Still missing in this PR

- [x] Add tests
- [x] Version bump

Questions

- Does `dlq_writer.write` already support `(event, reason, params_hash)`?
- When we get an ES exception, are `response['index']` and `response['index']['error']`
  guaranteed to be set, or should I guard against anything in there being nil?
  - Got nil exceptions in the integration tests. Now guarding.

I would posit that making the list of exceptions that are elevated to ERROR is
out of scope for this. We could release this as is, and if there's interest we
make it configurable later on.

Generate an `invalid_index_name_exception` with

```
bin/logstash -e "input { generator { count => 1 } }
  output { elasticsearch { user => 'elastic' password => 'elastic'
    index => 'bad,index'
  }}"
```

Generate another ES exception (mapping) with

```
bin/logstash -e "input { generator { count => 2 } }
  filter { ruby { code => \" event.set('mapping_fail', (event.get('sequence') == 0 ? {'foo' => 'bar'} : 'foobar' ) ) \"} }
  output { elasticsearch { user => 'elastic' password => 'elastic' }}"
```

closes #759