### PR TITLE
fix secure integration spec tagging

### DIFF
--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -23,8 +23,10 @@ module ESHelper
 
   def self.es_version_satisfies?(*requirement)
     es_version = RSpec.configuration.filter[:es_version] || ENV['ES_VERSION']
-    puts "Info: ES_VERSION environment variable wasn't set. Skipping all tests related to specific ES versions"
-    return false
+    if es_version.nil?
+      puts "Info: ES_VERSION environment or 'es_version' tag wasn't set. Returning false to all `es_version_satisfies?` call."
+      return false
+    end
     es_release_version = Gem::Version.new(es_version).release
     Gem::Requirement.new(requirement).satisfied_by?(es_release_version)
   end

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -2,6 +2,12 @@ require "logstash/devutils/rspec/spec_helper"
 require 'manticore'
 require 'elasticsearch'
 
+# by default exclude secure_integration tests unless requested
+# normal integration specs are already excluded by devutils' spec helper
+RSpec.configure do |config|
+   config.filter_run_excluding config.exclusion_filter.add(:secure_integration => true)
+end
+
 module ESHelper
   def get_host_port
     "127.0.0.1:9200"

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -23,6 +23,8 @@ module ESHelper
 
   def self.es_version_satisfies?(*requirement)
     es_version = RSpec.configuration.filter[:es_version] || ENV['ES_VERSION']
+    puts "Info: ES_VERSION environment variable wasn't set. Skipping all tests related to specific ES versions"
+    return false
     es_release_version = Gem::Version.new(es_version).release
     Gem::Requirement.new(requirement).satisfied_by?(es_release_version)
   end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -129,7 +129,7 @@ describe "indexing" do
     it_behaves_like("an indexer")
   end
 
-  describe "a secured indexer", :elasticsearch_secure => true do
+  describe "a secured indexer", :secure_integration => true do
     let(:user) { "simpleuser" }
     let(:password) { "abc123" }
     let(:cacert) { "spec/fixtures/test_certs/test.crt" }


### PR DESCRIPTION
by default devutils exludes a set of spec tags but that set doesn't
include this plugin's "secure_integration" tag. This PR adds that tag
to the default set of exclusions.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
