### PR TITLE
Survive attempts at indexing events that don't have  a @timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 9.2.0
+  - Fix a crash when the plugin tries to index an event missing a timestamp
+    to an index that needs time-based interpolation
+    (like the default `logstash-%{+YYYY.MM.dd}`).
+    When this happens, an error is logged instead.
+    ([PR #777](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/777))
+
 ## 9.1.4
   - Log an error -- not a warning -- when ES raises an invalid\_index\_name\_exception.
 

--- a/lib/logstash/outputs/elasticsearch/helpers.rb
+++ b/lib/logstash/outputs/elasticsearch/helpers.rb
@@ -1,0 +1,12 @@
+# Small functions that don't require a full instance of the plugin should go here.
+# This will promote lightning fast tests.
+module LogStash; module Outputs; class ElasticSearch;
+  module Helpers
+    INDEX_REQUIRING_TIMESTAMP = /%{\+.+\}/
+    def self.predict_timestamp_issue_for(index, event)
+      return false  if event.include?('@timestamp')
+      return true   if index =~ INDEX_REQUIRING_TIMESTAMP
+      false
+    end
+  end
+end ; end ; end

--- a/lib/logstash/outputs/elasticsearch/helpers.rb
+++ b/lib/logstash/outputs/elasticsearch/helpers.rb
@@ -1,5 +1,7 @@
 # Small functions that don't require a full instance of the plugin should go here.
 # This will promote lightning fast tests.
+#
+# Methods are defined right on the module to ensure no context can be shared with the plugin instance :-)
 module LogStash; module Outputs; class ElasticSearch;
   module Helpers
     INDEX_REQUIRING_TIMESTAMP = /%{\+.+\}/

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '9.1.4'
+  s.version         = '9.2.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_helpers.rb
+++ b/spec/unit/outputs/elasticsearch_helpers.rb
@@ -1,0 +1,39 @@
+require_relative "../../../spec/es_spec_helper"
+require "logstash/outputs/elasticsearch"
+require "logstash/outputs/elasticsearch/helpers"
+
+describe LogStash::Outputs::ElasticSearch::Helpers do
+  context "detecting if an index name can be determined for an event" do
+    let(:event_with_ts) { LogStash::Event.new() }
+    let(:event_with_no_ts) { LogStash::Event.new().tap { |e| e.remove('@timestamp') } }
+
+    context "when the index pattern doesn't include a timestamp" do
+      ['my-index', 'logstash-%{normal_field_interpolation}'].each do |index|
+        context "where index = #{index.inspect}" do
+          it "should detect no problems for events that have a timestamp" do
+            expect(subject.predict_timestamp_issue_for(index, event_with_ts)).to eq(false)
+          end
+
+          it "should detect no problems for events that do not have a timestamp" do
+            expect(subject.predict_timestamp_issue_for(index, event_with_no_ts)).to eq(false)
+          end
+        end
+      end
+    end
+
+    context "when the index pattern includes a timestamp" do
+      ['logstash-%{+YYYY.MM.dd}', 'logstash-%{+YYYY}', '%{+YYYY.MM.dd}-what'].each do |index|
+        context "where index = #{index.inspect}" do
+          it "should detect no problems for events that have a timestamp" do
+            expect(subject.predict_timestamp_issue_for(index, event_with_ts)).to eq(false)
+          end
+
+          it "should detect a problem for events that do not have a timestamp" do
+            expect(subject.predict_timestamp_issue_for(index, event_with_no_ts)).to eq(true)
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/spec/unit/outputs/elasticsearch_helpers.rb
+++ b/spec/unit/outputs/elasticsearch_helpers.rb
@@ -4,8 +4,8 @@ require "logstash/outputs/elasticsearch/helpers"
 
 describe LogStash::Outputs::ElasticSearch::Helpers do
   context "detecting if an index name can be determined for an event" do
-    let(:event_with_ts) { LogStash::Event.new() }
-    let(:event_with_no_ts) { LogStash::Event.new().tap { |e| e.remove('@timestamp') } }
+    let(:event_with_ts) { LogStash::Event.new }
+    let(:event_with_no_ts) { LogStash::Event.new.tap { |e| e.remove('@timestamp') } }
 
     context "when the index pattern doesn't include a timestamp" do
       ['my-index', 'logstash-%{normal_field_interpolation}'].each do |index|


### PR DESCRIPTION
- Events being indexed to an index that doesn't require time-based interpolation
  are unaffected and are still indexed, whether or not they have a `@timestamp`.
- When events are missing `@timestamp` are destined to a timestamped index name,
  we don't send them for indexing, and we log an error.
- `#event_action_tuple` now returns nil when an event is discarded this way.
- Created a helper class to be a home for trivial functions that don't
  require the full plugin to be tested.
- I am perhaps over-testing this.

This prevents a full Logstash crash, and closes #739

**Update**

After multiple discussions on the subject elsewhere, let’s remind ourselves that this PR is about fixing a crash today for all users of 5.x and 6.x.

Whether or not we eventually prevent the removal of `@timestamp` in a future breaking change (in LS 7.0 or later) is orthogonal to this.

Let’s try to discuss only the merits of this PR in whether it solves the crash in a good way or if needs improvements.