### PR TITLE
Update `truststore` description

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -637,8 +637,9 @@ a timeout occurs, the request will be retried.
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-The JKS truststore to validate the server's certificate.
-Use either `:truststore` or `:cacert`
+The truststore to validate the server's certificate.
+It can be either .jks or .p12.
+Use either `:truststore` or `:cacert`.
 
 [id="plugins-{type}s-{plugin}-truststore_password"]
 ===== `truststore_password` 


### PR DESCRIPTION
The `truststore` setting also accepts `jks` and `p12`.

This makes it's description closer to `keystore`, in regards to file type.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
