### PR TITLE
Resolve 413 Payload Too Large

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -313,6 +313,11 @@ module LogStash; module Outputs; class ElasticSearch;
         # Even though we retry the user should be made aware of these
         if e.response_code == 429
           logger.debug(message, log_hash)
+        # 413 means that the request is to large. So trying to decrease the request size if there
+        # actually where multiple actions in a bulk request.
+        elsif e.response_code == 413 && e.num_actions_in_request > 1
+          @client.target_bulk_bytes /= 2;
+          logger.info(message + "and decreased request size " , log_hash)
         else
           logger.error(message, log_hash)
         end

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -2,13 +2,14 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
   class Pool
     class NoConnectionAvailableError < Error; end
     class BadResponseCodeError < Error
-      attr_reader :url, :response_code, :request_body, :response_body
+      attr_reader :url, :response_code, :request_body, :response_body, :num_actions_in_request
 
-      def initialize(response_code, url, request_body, response_body)
+      def initialize(response_code, url, request_body, response_body, num_actions_in_request = 1)
         @response_code = response_code
         @url = url
         @request_body = request_body
         @response_body = response_body
+        @num_actions_in_request = num_actions_in_request
       end
 
       def message

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -1,8 +1,7 @@
 require_relative "../../../spec/es_spec_helper"
 require "logstash/outputs/elasticsearch"
 
-describe "TARGET_BULK_BYTES", :integration => true do
-  let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
+describe "target_bulk_bytes", :integration => true do
   let(:event_count) { 1000 }
   let(:events) { event_count.times.map { event }.to_a }
   let(:config) {
@@ -22,11 +21,11 @@ describe "TARGET_BULK_BYTES", :integration => true do
   end
 
   describe "batches that are too large for one" do
-    let(:event) { LogStash::Event.new("message" => "a " * (((target_bulk_bytes/2) / event_count)+1)) }
+    let(:event) { LogStash::Event.new("message" => "a " * (((subject.target_bulk_bytes/2) / event_count)+1)) }
 
     it "should send in two batches" do
       expect(subject.client).to have_received(:bulk_send).twice do |payload|
-        expect(payload.size).to be <= target_bulk_bytes
+        expect(payload.size).to be <= subject.target_bulk_bytes
       end
     end
 
@@ -37,7 +36,7 @@ describe "TARGET_BULK_BYTES", :integration => true do
 
       it "should send in one batch" do
         expect(subject.client).to have_received(:bulk_send).once do |payload|
-          expect(payload.size).to be <= target_bulk_bytes
+          expect(payload.size).to be <= subject.target_bulk_bytes
         end
       end
     end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -21,11 +21,11 @@ describe "target_bulk_bytes", :integration => true do
   end
 
   describe "batches that are too large for one" do
-    let(:event) { LogStash::Event.new("message" => "a " * (((subject.target_bulk_bytes/2) / event_count)+1)) }
+    let(:event) { LogStash::Event.new("message" => "a " * (((subject.client.target_bulk_bytes/2) / event_count)+1)) }
 
     it "should send in two batches" do
       expect(subject.client).to have_received(:bulk_send).twice do |payload|
-        expect(payload.size).to be <= subject.target_bulk_bytes
+        expect(payload.size).to be <= subject.client.target_bulk_bytes
       end
     end
 
@@ -36,7 +36,7 @@ describe "target_bulk_bytes", :integration => true do
 
       it "should send in one batch" do
         expect(subject.client).to have_received(:bulk_send).once do |payload|
-          expect(payload.size).to be <= subject.target_bulk_bytes
+          expect(payload.size).to be <= subject.client.target_bulk_bytes
         end
       end
     end

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -190,14 +190,13 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
       ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> message}],
     ]}
 
-    context "if a message is over TARGET_BULK_BYTES" do
-      let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
-      let(:message) { "a" * (target_bulk_bytes + 1) }
+    context "if a message is over target_bulk_bytes" do
+      let(:message) { "a" * (subject.target_bulk_bytes + 1) }
 
       it "should be handled properly" do
         allow(subject).to receive(:join_bulk_responses)
         expect(subject).to receive(:bulk_send).once do |data|
-          expect(data.size).to be > target_bulk_bytes
+          expect(data.size).to be > subject.target_bulk_bytes
         end
         s = subject.send(:bulk, actions)
       end
@@ -216,9 +215,8 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
         s = subject.send(:bulk, actions)
       end
 
-      context "if one exceeds TARGET_BULK_BYTES" do
-        let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
-        let(:message1) { "a" * (target_bulk_bytes + 1) }
+      context "if one exceeds target_bulk_bytes" do
+        let(:message1) { "a" * (subject.target_bulk_bytes + 1) }
         it "executes two bulk_send operations" do
           allow(subject).to receive(:join_bulk_responses)
           expect(subject).to receive(:bulk_send).twice


### PR DESCRIPTION
If we get a http status 413 on a bulk request we try halfing target_bulk_bytes, which is also changed from constant to attribute.

solving issue #785

