### PR TITLE
Fix: script parameter is lost on retry.

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -350,6 +350,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
     # Build a bulk item for an elasticsearch update action
     def update_action_builder(args, source)
+      args = args.clone()
       if args[:_script]
         # Use the event as a hash from your script with variable name defined
         # by script_var_name (default: "event")


### PR DESCRIPTION
The script parameter was lost on retry.

update_action_builder shouldn't change the args parameter (it deletes _script and _upsert), because it will be reused on next attempts.
This fix will clone 'args' object at the beginning to avoid side effects.

