### PR TITLE
reduced logging verbosity and unecessary upper case error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.2.3
+  - Tweaked logging statements to reduce verbosity
+
 ## 9.2.2
   - Fixed numerous issues relating to builds on Travis [#799](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/799)
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -240,7 +240,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       # Try to keep locking granularity low such that we don't affect IO...
       @state_mutex.synchronize { @url_info.select {|url,meta| meta[:state] != :alive } }.each do |url,meta|
         begin
-          logger.info("Running health check to see if an Elasticsearch connection is working",
+          logger.debug("Running health check to see if an Elasticsearch connection is working",
                         :healthcheck_url => url, :path => @healthcheck_path)
           response = perform_request_to_url(url, :head, @healthcheck_path)
           # If no exception was raised it must have succeeded!
@@ -378,9 +378,6 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     rescue BadResponseCodeError => e
       # These aren't discarded from the pool because these are often very transient
       # errors
-      raise e
-    rescue => e
-      logger.warn("UNEXPECTED POOL ERROR", :e => e)
       raise e
     ensure
       return_connection(url)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '9.2.2'
+  s.version         = '9.2.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
There are multiple logging statements in this plugin that are either superfluous or could be moved to a more verbose level. This PR changes a couple of them to reduce overall logging fatigue when using the ES output.