### PR TITLE
docs: flag as `no_codec` to reduce confusion

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,6 @@
 :plugin: elasticsearch
 :type: output
-:default_codec: plain
+:no_codec:
 
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
@@ -814,4 +814,4 @@ See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-in
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:default_codec!:
+:no_codec!:


### PR DESCRIPTION
Resolves: logstash-plugins/logstash-output-elasticsearch#819
