### PR TITLE
remove obsolete fields and obsolete document_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 10.0.0
+  - Changed deprecated `document_type` option to obsolete
+  - Remove support for parent child (still support join data type) since we don't support multiple document types any more
+  - Removed obsolete `flush_size` and `idle_flush_time`
+
 ## 9.3.0
   - Adds support for Index Lifecycle Management for Elasticsearch 6.6.0 and above, running with at least a Basic License(Beta) [#805](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/805)
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -78,15 +78,11 @@ module LogStash; module Outputs; class ElasticSearch;
         params[:pipeline] = event.sprintf(@pipeline)
       end
 
-      if @parent
-        if @join_field
-          join_value = event.get(@join_field)
-          parent_value = event.sprintf(@parent)
-          event.set(@join_field, { "name" => join_value, "parent" => parent_value })
-          params[routing_field_name] = event.sprintf(@parent)
-        else
-          params[:parent] = event.sprintf(@parent)
-        end
+      if @parent && @join_field
+        join_value = event.get(@join_field)
+        parent_value = event.sprintf(@parent)
+        event.set(@join_field, { "name" => join_value, "parent" => parent_value })
+        params[routing_field_name] = event.sprintf(@parent)
       end
 
       if action == 'update'
@@ -260,16 +256,10 @@ module LogStash; module Outputs; class ElasticSearch;
     DEFAULT_EVENT_TYPE_ES7="_doc".freeze
     def get_event_type(event)
       # Set the 'type' value for the index.
-      type = if @document_type
-               event.sprintf(@document_type)
+      type = if client.maximum_seen_major_version < 7
+               DEFAULT_EVENT_TYPE_ES6
              else
-               if client.maximum_seen_major_version < 6
-                 event.get("type") || DEFAULT_EVENT_TYPE_ES6
-               elsif client.maximum_seen_major_version == 6
-                 DEFAULT_EVENT_TYPE_ES6
-               else
-                 DEFAULT_EVENT_TYPE_ES7
-               end
+               DEFAULT_EVENT_TYPE_ES7
              end
 
       if !(type.is_a?(String) || type.is_a?(Numeric))

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -17,8 +17,7 @@ module LogStash; module Outputs; class ElasticSearch
       mod.config :index, :validate => :string, :default => DEFAULT_INDEX_NAME
 
       mod.config :document_type, 
-        :validate => :string, 
-        :deprecated => "Document types are being deprecated in Elasticsearch 6.0, and removed entirely in 7.0. You should avoid this feature"
+        :obsolete => "Multiple document types per index were deprecated in Elasticsearch 6.0 and removed entirely in 7.0. We'll now default to 'doc' on ES 6 and '_doc' in 7"
 
       # From Logstash 1.3 onwards, a template is applied to Elasticsearch during
       # Logstash's startup if one with the name `template_name` does not already exist.
@@ -77,7 +76,7 @@ module LogStash; module Outputs; class ElasticSearch
       mod.config :routing, :validate => :string
 
       # For child documents, ID of the associated parent.
-      # This can be dynamic using the `%{foo}` syntax.
+      # This can be dynamic using the `%{foo}` syntax.:w
       mod.config :parent, :validate => :string, :default => nil
 
       # For child documents, name of the join field
@@ -95,10 +94,6 @@ module LogStash; module Outputs; class ElasticSearch
       # 
       # Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
       mod.config :hosts, :validate => :uri, :default => [::LogStash::Util::SafeURI.new("//127.0.0.1")], :list => true
-
-      mod.config :flush_size, :validate => :number, :obsolete => "This setting is no longer available as we now try to restrict bulk requests to sane sizes. See the 'Batch Sizes' section of the docs. If you think you still need to restrict payloads based on the number, not size, of events, please open a ticket."
-
-      mod.config :idle_flush_time, :validate => :number, :obsolete => "This settings is no longer valid. This was a no-op now as every pipeline batch is flushed synchronously obviating the need for this option."
 
       # Set upsert content for update mode.s
       # Create a new document with this parameter as json string if `document_id` doesn't exists

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '9.3.0'
+  s.version         = '10.0.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -1,82 +1,12 @@
 require_relative "../../../spec/es_spec_helper"
 require "logstash/outputs/elasticsearch"
 
-if ESHelper.es_version_satisfies?("<= 5.x")
-  context "when using elasticsearch 5.x and before", :integration => true do
-    shared_examples "a type based parent indexer" do
-      let(:index) { 10.times.collect { rand(10).to_s }.join("") }
-      let(:type) { 10.times.collect { rand(10).to_s }.join("") }
-      let(:event_count) { 10000 + rand(500) }
-      let(:parent) { "not_implemented" }
-      let(:config) { "not_implemented" }
-      let(:default_headers) {
-        {"Content-Type" => "application/json"}
-      }
-      subject { LogStash::Outputs::ElasticSearch.new(config) }
-
-      before do
-        # Add mapping and a parent document
-        index_url = "http://#{get_host_port()}/#{index}"
-        mapping = { "mappings" => { "#{type}" => { "_parent" => { "type" => "#{type}_parent" } } } }
-        Manticore.put("#{index_url}", {:body => mapping.to_json, :headers => default_headers}).call
-        pdoc = { "foo" => "bar" }
-        Manticore.put("#{index_url}/#{type}_parent/test", {:body => pdoc.to_json, :headers => default_headers}).call
-
-        subject.register
-        subject.multi_receive(event_count.times.map { LogStash::Event.new("link_to" => "test", "message" => "Hello World!", "type" => type) })
-      end
-
-
-      it "ships events" do
-        index_url = "http://#{get_host_port()}/#{index}"
-
-        Manticore.post("#{index_url}/_refresh").call
-
-        # Wait until all events are available.
-        Stud::try(10.times) do
-          query = { "query" => { "has_parent" => { "type" => "#{type}_parent", "query" => { "match" => { "foo" => "bar" } } } } }
-          response = Manticore.post("#{index_url}/_count", {:body => query.to_json, :headers => default_headers})
-          data = response.body
-          result = LogStash::Json.load(data)
-          cur_count = result["count"]
-          expect(cur_count).to eq(event_count)
-        end
-      end
-    end
-
-    describe "(http protocol) index events with static parent" do
-      it_behaves_like 'a type based parent indexer' do
-        let(:parent) { "test" }
-        let(:config) {
-          {
-            "hosts" => get_host_port,
-            "index" => index,
-            "parent" => parent
-          }
-        }
-      end
-    end
-
-    describe "(http_protocol) index events with fieldref in parent value" do
-      it_behaves_like 'a type based parent indexer' do
-        let(:config) {
-          {
-            "hosts" => get_host_port,
-            "index" => index,
-            "parent" => "%{link_to}"
-          }
-        }
-      end
-    end
-  end
-end
-
 if ESHelper.es_version_satisfies?(">= 5.6")
   context "when using elasticsearch 5.6 and above", :integration => true do
 
     shared_examples "a join field based parent indexer" do
       let(:index) { 10.times.collect { rand(10).to_s }.join("") }
-      let(:type) { 10.times.collect { rand(10).to_s }.join("") }
+      let(:type) { ESHelper.es_version_satisfies?("<= 6.3") ? "doc" : "doc" }
       let(:event_count) { 10000 + rand(500) }
       let(:parent) { "not_implemented" }
       let(:config) { "not_implemented" }
@@ -143,7 +73,6 @@ if ESHelper.es_version_satisfies?(">= 5.6")
             "hosts" => get_host_port,
             "index" => index,
             "parent" => parent_id,
-            "document_type" => type,
             "join_field" => join_field,
             "manage_template" => false
           }
@@ -158,7 +87,6 @@ if ESHelper.es_version_satisfies?(">= 5.6")
             "hosts" => get_host_port,
             "index" => index,
             "parent" => "%{link_to}",
-            "document_type" => type,
             "join_field" => join_field,
             "manage_template" => false
           }

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -43,34 +43,24 @@ describe LogStash::Outputs::ElasticSearch do
     let(:manticore_url) { manticore_urls.first }
 
     describe "getting a document type" do
-      context "if document_type isn't set" do
-        let(:options) { super.merge("document_type" => nil)}
-        context "for 7.x elasticsearch clusters" do
-          let(:maximum_seen_major_version) { 7 }
-          it "should return '_doc'" do
-            expect(subject.send(:get_event_type, LogStash::Event.new("type" => "foo"))).to eql("_doc")
-          end
-        end
-
-        context "for 6.x elasticsearch clusters" do
-          let(:maximum_seen_major_version) { 6 }
-          it "should return 'doc'" do
-            expect(subject.send(:get_event_type, LogStash::Event.new("type" => "foo"))).to eql("doc")
-          end
-        end
-
-        context "for < 6.0 elasticsearch clusters" do
-          let(:maximum_seen_major_version) { 5 }
-          it "should get the type from the event" do
-            expect(subject.send(:get_event_type, LogStash::Event.new("type" => "foo"))).to eql("foo")
-          end
+      context "for 7.x elasticsearch clusters" do
+        let(:maximum_seen_major_version) { 7 }
+        it "should return '_doc'" do
+          expect(subject.send(:get_event_type, LogStash::Event.new("type" => "foo"))).to eql("_doc")
         end
       end
 
-      context "with 'document type set'" do
-        let(:options) { super.merge("document_type" => "bar")}
-        it "should get the event type from the 'document_type' setting" do
-          expect(subject.send(:get_event_type, LogStash::Event.new())).to eql("bar")
+      context "for 6.x elasticsearch clusters" do
+        let(:maximum_seen_major_version) { 6 }
+        it "should return 'doc'" do
+          expect(subject.send(:get_event_type, LogStash::Event.new("type" => "foo"))).to eql("doc")
+        end
+      end
+
+      context "for < 6.0 elasticsearch clusters" do
+        let(:maximum_seen_major_version) { 5 }
+        it "should return 'doc'" do
+          expect(subject.send(:get_event_type, LogStash::Event.new("type" => "foo"))).to eql("doc")
         end
       end
 


### PR DESCRIPTION
- remove obsolete `flush_size` and `idle_flush_time`
- obsolete deprecated `document_type`
- remove support for parent child (still support join data type) since we don't support multiple document types any more