### PR TITLE
Minor updates to the 7x template

### DIFF
--- a/lib/logstash/outputs/elasticsearch/elasticsearch-template-es7x.json
+++ b/lib/logstash/outputs/elasticsearch/elasticsearch-template-es7x.json
@@ -1,44 +1,42 @@
 {
-  "template" : "logstash-*",
+  "index_patterns" : "logstash-*",
   "version" : 60001,
   "settings" : {
     "index.refresh_interval" : "5s",
     "number_of_shards": 1
   },
   "mappings" : {
-    "_doc" : {
-      "dynamic_templates" : [ {
-        "message_field" : {
-          "path_match" : "message",
-          "match_mapping_type" : "string",
-          "mapping" : {
-            "type" : "text",
-            "norms" : false
+    "dynamic_templates" : [ {
+      "message_field" : {
+        "path_match" : "message",
+        "match_mapping_type" : "string",
+        "mapping" : {
+          "type" : "text",
+          "norms" : false
+        }
+      }
+    }, {
+      "string_fields" : {
+        "match" : "*",
+        "match_mapping_type" : "string",
+        "mapping" : {
+          "type" : "text", "norms" : false,
+          "fields" : {
+            "keyword" : { "type": "keyword", "ignore_above": 256 }
           }
         }
-      }, {
-        "string_fields" : {
-          "match" : "*",
-          "match_mapping_type" : "string",
-          "mapping" : {
-            "type" : "text", "norms" : false,
-            "fields" : {
-              "keyword" : { "type": "keyword", "ignore_above": 256 }
-            }
-          }
-        }
-      } ],
-      "properties" : {
-        "@timestamp": { "type": "date"},
-        "@version": { "type": "keyword"},
-        "geoip"  : {
-          "dynamic": true,
-          "properties" : {
-            "ip": { "type": "ip" },
-            "location" : { "type" : "geo_point" },
-            "latitude" : { "type" : "half_float" },
-            "longitude" : { "type" : "half_float" }
-          }
+      }
+    } ],
+    "properties" : {
+      "@timestamp": { "type": "date"},
+      "@version": { "type": "keyword"},
+      "geoip"  : {
+        "dynamic": true,
+        "properties" : {
+          "ip": { "type": "ip" },
+          "location" : { "type" : "geo_point" },
+          "latitude" : { "type" : "half_float" },
+          "longitude" : { "type" : "half_float" }
         }
       }
     }


### PR DESCRIPTION
This commit removes the _doc type placeholder from the index mapping
and replaces the deprecated template with index_patterns.

---------

Note - This change IS for 7.x. 

"template" still works but will emit a deprecation warning
"_doc" will still work from master today, but will not by the time 7.0.0 ships unless you also send "include_type_name=true".

EDIT: this IS required for 7.x
