### PR TITLE
Adding 9.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
   - Changed deprecated `document_type` option to obsolete [#824](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/824)
   - Remove support for parent child (still support join data type) since we don't support multiple document types any more
   - Removed obsolete `flush_size` and `idle_flush_time`
-  - Added 'auto' setting for ILM with default of 'auto' [#838](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/838)
+  - Switched default setting for ilm_enabled to 'auto' [#838](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/838)
+
+## 9.4.0
+  - Added 'auto' setting for ilm_enabled with default of 'false'
 
 ## 9.3.2
   - Fixed sniffing support for 7.x [#827](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/827)


### PR DESCRIPTION
Per chat with @robbavey , ilm_enabled's 'auto' setting was actually added in 9.4.0 (but the default remained 'false').  10.0.0 is when we switched the default to 'auto'.

This PR updates the changelog accordingly.
