### PR TITLE
Fix issue with templates being erroneously overwritten

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -48,7 +48,7 @@ module LogStash; module Outputs; class ElasticSearch;
         end
         if successful_connection?
           install_template
-          setup_ilm if ilm_enabled?
+          setup_ilm if ilm_in_use?
         end
       end
     end

--- a/lib/logstash/outputs/elasticsearch/ilm.rb
+++ b/lib/logstash/outputs/elasticsearch/ilm.rb
@@ -4,20 +4,22 @@ module LogStash; module Outputs; class ElasticSearch
     ILM_POLICY_PATH = "default-ilm-policy.json"
 
     def setup_ilm
-      return unless ilm_enabled?
-      if default_index?(@index) || !default_rollover_alias?(@ilm_rollover_alias)
+      return unless ilm_in_use?
         logger.warn("Overwriting supplied index #{@index} with rollover alias #{@ilm_rollover_alias}") unless default_index?(@index)
         @index = @ilm_rollover_alias
         maybe_create_rollover_alias
         maybe_create_ilm_policy
-      end
     end
 
     def default_rollover_alias?(rollover_alias)
       rollover_alias == LogStash::Outputs::ElasticSearch::DEFAULT_ROLLOVER_ALIAS
     end
 
-    def ilm_enabled?
+    def ilm_alias_set?
+      default_index?(@index) || !default_rollover_alias?(@ilm_rollover_alias)
+    end
+
+    def ilm_in_use?
       return @ilm_actually_enabled if defined?(@ilm_actually_enabled)
       @ilm_actually_enabled =
         begin
@@ -28,7 +30,7 @@ module LogStash; module Outputs; class ElasticSearch
                 @logger.info("Index Lifecycle Management is set to 'auto', but will be disabled - #{error}")
                 false
               else
-                true
+                ilm_alias_set?
               end
             else
               @logger.info("Index Lifecycle Management is set to 'auto', but will be disabled - Your Elasticsearch cluster is before 7.0.0, which is the minimum version required to automatically run Index Lifecycle Management")
@@ -37,7 +39,7 @@ module LogStash; module Outputs; class ElasticSearch
           elsif @ilm_enabled.to_s == 'true'
             ilm_ready, error = ilm_ready?
             raise LogStash::ConfigurationError,"Index Lifecycle Management is set to enabled in Logstash, but cannot be used - #{error}"  unless ilm_ready
-            true
+            ilm_alias_set?
           else
             false
           end

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -11,7 +11,7 @@ module LogStash; module Outputs; class ElasticSearch
 
 
       template = get_template(plugin.template, plugin.maximum_seen_major_version)
-      add_ilm_settings_to_template(plugin, template) if plugin.ilm_enabled?
+      add_ilm_settings_to_template(plugin, template) if plugin.ilm_in_use?
       plugin.logger.info("Attempting to install template", :manage_template => template)
       install(plugin.client, template_name(plugin), template, plugin.template_overwrite)
     rescue => e
@@ -43,7 +43,7 @@ module LogStash; module Outputs; class ElasticSearch
     #                 if not and ILM is enabled, use the rollover alias
     #                 else use the default value of template_name
     def self.template_name(plugin)
-      plugin.ilm_enabled? && !plugin.original_params.key?('template_name') ? plugin.ilm_rollover_alias : plugin.template_name
+      plugin.ilm_in_use? && !plugin.original_params.key?('template_name') ? plugin.ilm_rollover_alias : plugin.template_name
     end
 
     def self.default_template_path(es_major_version)

--- a/spec/integration/outputs/ilm_spec.rb
+++ b/spec/integration/outputs/ilm_spec.rb
@@ -395,6 +395,24 @@ if ESHelper.es_version_satisfies?(">= 6.6")
         it_behaves_like 'an ILM enabled Logstash'
       end
 
+      context 'with a set index and a custom index pattern' do
+        if ESHelper.es_version_satisfies?(">= 7.0")
+          let (:template) { "spec/fixtures/template-with-policy-es7x.json" }
+        else
+          let (:template) { "spec/fixtures/template-with-policy-es6x.json" }
+        end
+
+        let (:settings) { super.merge("template" => template,
+                                      "index" => "overwrite-4")}
+
+        it 'should not overwrite the index patterns' do
+          subject.register
+          sleep(1)
+          expect(@es.indices.get_template(name: "logstash")["logstash"]).to have_index_pattern("overwrite-*")
+        end
+      end
+
+
       context 'with a custom template' do
         let (:ilm_rollover_alias) { "the_cat_in_the_hat" }
         let (:index) { ilm_rollover_alias }


### PR DESCRIPTION
When customers were managing their own templates, but not using ilm,
templates could still be overwritten. This commit fixes the logic
to only overwrite templates when ilm is in use

