### PR TITLE
Clarify load balance behavior if array of hosts is used

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -344,7 +344,7 @@ If you have custom firewall rules you may need to change this
   * Value type is <<uri,uri>>
   * Default value is `[//127.0.0.1]`
 
-Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
+Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter (Round-robin per bulk request sent to Elasticsearch).
 Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
     `"127.0.0.1"`
     `["127.0.0.1:9200","127.0.0.2:9200"]`


### PR DESCRIPTION
I've seen the question, how the output load balances, coming up every now and then and the docs should have the answer.

I'd still like a logstash developer to review and double check that it still is Round-robin per bulk in the current version of the plugin. 

My assumption is based on https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/274 and https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/493#issuecomment-389808368, but the first one is from 2015 and the second onw is from 2018, but with Logstash 2.4.

