### PR TITLE
Docs: Clarify default 'document_type' for 7.x indices

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -303,6 +303,7 @@ This sets the document type to write events to. Generally you should try to writ
 similar events to the same 'type'. String expansion `%{foo}` works here.
 If you don't set a value for this option:
 
+- for elasticsearch clusters 7.x and above: the value of '_doc' will be used. 
 - for elasticsearch clusters 6.x and above: the value of 'doc' will be used;
 - for elasticsearch clusters 5.x and below: the event's 'type' field will be used, if the field is not present the value of 'doc' will be used.
 


### PR DESCRIPTION
I was confused that the default document type was "doc" not "_docs" in 6.x.
From https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/lib/logstash/outputs/elasticsearch/common.rb#L269 it appears this has changed from
6.x to 7.x, to clarify this it would be good to add the behaviour that probably started with 7.0?

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
