### PR TITLE
Corrected documentation for `action => update`

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -248,7 +248,7 @@ The Elasticsearch action to perform. Valid actions are:
 - delete: deletes a document by id (An id is required for this action)
 - create: indexes a document, fails if a document by that id already exists in the index.
 - update: updates a document by id. Update has a special case where you can upsert -- update a
-  document if not already present. See the `upsert` option. NOTE: This does not work and is not supported
+  document if not already present. See the `doc_as_upsert` option. NOTE: This does not work and is not supported
   in Elasticsearch 1.x. Please upgrade to ES 2.x or greater to use this feature with Logstash!
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
   would use the foo field for the action


### PR DESCRIPTION
I think that the "update a document if not already present" only works with the `doc_as_upsert` option.  The `upsert` option adds data to the document if the document does not exist I think.
Some more explicit documentation for both `upsert` and `doc_as_upsert` would also be helpful
