### PR TITLE
ILM event substitution PoC

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -17,7 +17,7 @@ require "forwardable"
 # called `http.content_type.required`. If this option is set to `true`, and you
 # are using Logstash 2.4 through 5.2, you need to update the Elasticsearch output
 # plugin to version 6.2.5 or higher.
-# 
+#
 # ================================================================================
 #
 # This plugin is the recommended method of storing logs in Elasticsearch.
@@ -26,8 +26,8 @@ require "forwardable"
 # This output only speaks the HTTP protocol. HTTP is the preferred protocol for interacting with Elasticsearch as of Logstash 2.0.
 # We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,
 # yet far easier to administer and work with. When using the HTTP protocol one may upgrade Elasticsearch versions without having
-# to upgrade Logstash in lock-step. 
-# 
+# to upgrade Logstash in lock-step.
+#
 # You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
 #
 # ==== Template management for Elasticsearch 5.x
@@ -75,12 +75,12 @@ require "forwardable"
 #
 # ==== HTTP Compression
 #
-# This plugin supports request and response compression. Response compression is enabled by default and 
-# for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for 
-# it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` in 
+# This plugin supports request and response compression. Response compression is enabled by default and
+# for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for
+# it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` in
 # Elasticsearch[https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http] to take advantage of response compression when using this plugin
 #
-# For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 
+# For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression`
 # setting in their Logstash config file.
 #
 class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -31,7 +31,9 @@ module LogStash; module Outputs; class ElasticSearch;
         end
       end
 
-      @logger.debug("Caching seen/created aliases #{@ilm_cache_once ? 'once' : 'every bulk'}") unless !(@ro_only_enabled || !ilm_in_use?)
+      if @ro_only_enabled || ilm_in_use?
+        @logger.debug("Caching seen/created aliases #{@ilm_cache_once ? 'once' : 'every bulk'}")
+      end
 
       setup_hosts # properly sets @hosts
       build_client

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -178,10 +178,10 @@ module LogStash; module Outputs; class ElasticSearch;
                   created_aliases << new_index
                   params[:_index] = new_index
                 rescue ::LogStash::Outputs::ElasticSearch::Ilm::ImproperAliasName => e
-                  @logger.error("Event alias name is not proper, using #{@ilm_rollover_alias} instead")
+                  @logger.warn("Event alias name is not proper, using #{@ilm_rollover_alias} instead")
                   params[:_index] = @ilm_rollover_alias
                 rescue => e
-                  @logger.error("Unknown error on creating event alias, #{e}, using #{@ilm_rollover_alias} instead")
+                  @logger.warn("Unknown error on creating event alias, #{e}, using #{@ilm_rollover_alias} instead")
                   params[:_index] = @ilm_rollover_alias
                 end
               end

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -23,15 +23,15 @@ module LogStash; module Outputs; class ElasticSearch;
       @ilm_seen_aliases = {}
 
       # Can only be used if ILM not in use
-      if ro_only_enabled
-        if ilm_in_use?
+      if @ro_only_enabled
+        if @ilm_enabled
           raise LogStash::ConfigurationError, "ILM and preemptive RO creation cannot both be enabled."
         else
           @logger.debug("Preemptively creating rollover aliases")
         end
       end
 
-      if @ro_only_enabled || ilm_in_use?
+      if @ro_only_enabled || @ilm_enabled
         @logger.debug("Caching seen/created aliases #{@ilm_cache_once ? 'once' : 'every bulk'}")
       end
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -31,7 +31,7 @@ module LogStash; module Outputs; class ElasticSearch;
         end
       end
 
-      @logger.debug("Caching seen/created aliases #{@ilm_cache_once : 'once' : 'every bulk'}") unless !(@ro_only_enabled || !ilm_in_use?)
+      @logger.debug("Caching seen/created aliases #{@ilm_cache_once ? 'once' : 'every bulk'}") unless !(@ro_only_enabled || !ilm_in_use?)
 
       setup_hosts # properly sets @hosts
       build_client

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -35,6 +35,8 @@ module LogStash; module Outputs; class ElasticSearch;
         @logger.debug("Caching seen/created aliases #{@ilm_cache_once ? 'once' : 'every bulk'}")
       end
 
+      @logger.trace("ilm_enabled: #{@ilm_enabled}, ro_only_enabled: #{@ro_only_enabled}")
+
       setup_hosts # properly sets @hosts
       build_client
       setup_after_successful_connection
@@ -195,7 +197,7 @@ module LogStash; module Outputs; class ElasticSearch;
                   created_aliases[alias_name] = new_index
                   params[:_index] = new_index
                 rescue ::LogStash::Outputs::ElasticSearch::Ilm::ImproperAliasName => e
-                  @logger.warn("Event alias name is not proper, using #{@ilm_rollover_alias} instead")
+                  @logger.warn("Event alias name #{e.name} is not proper, using #{@ilm_rollover_alias} instead")
                   created_aliases[e.name] = @ilm_rollover_alias
                   params[:_index] = @ilm_rollover_alias
                 rescue => e

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -29,8 +29,6 @@ module LogStash; module Outputs; class ElasticSearch;
       @bulk_request_metrics = metric.namespace(:bulk_requests)
       @document_level_metrics = metric.namespace(:documents)
       @logger.info("New Elasticsearch output", :class => self.class.name, :hosts => @hosts.map(&:sanitized).map(&:to_s))
-      @logger.trace("Methods for ES Output on register: #{self.methods.to_s}")
-      @logger.trace("Instance variables for ES Output on register: #{self.instance_variables.to_s}")
     end
 
     # Receive an array of events and immediately attempt to index them (no buffering)
@@ -171,10 +169,12 @@ module LogStash; module Outputs; class ElasticSearch;
         begin
 
           # try making alias here? overwrite :_index with alias name?
+          # TODO: what if it doesn't match anything from the event? what then?
+          #       need to have it use the default pattern or something if it doesn't
           unless @ilm_event_alias.nil?
             created_aliases = Set[]
             submit_actions.each do |action, params, event|
-              logger.trace("Created aliases so far: #{created_aliases.to_s}")
+              logger.trace("Created/cached aliases so far: #{created_aliases.to_s}")
               if ['index', 'create'].include?(action)
                 new_index = maybe_create_rollover_alias_for_event(event, created_aliases)
                 created_aliases << new_index

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -165,6 +165,21 @@ module LogStash; module Outputs; class ElasticSearch
       # Cache seen/created aliases and their destinations once, not during each bulk batch.
       mod.config :ilm_cache_once, :validate => [true, false, 'true', 'false'], :default => false
 
+
+      # -----
+      # Rollover Alias Creation
+      # -----
+
+      # Reuses ilm_event_alias, ilm_pattern, ilm_cache_once as only ILM or RO can be used at one time. Preemptive RO creation
+      # follows all the same processes that the ILM tweaks does, however, it does not insert the lifecycle alias setting or policy.
+      # It is understood that this to bootstrap the rollover alias and index before indexing so that external tools can manage
+      # the actual rollover process, while ILM can manage the other lifecycle phases.
+      #
+      # Just like the ILM event substitution process, if anything does not match, it is thrown into the default alias set via
+      # ilm_rollover_alias.
+
+      # Flag for enabling Rollover alias creation, conflicts with ILM.
+      mod.config :ro_only_enabled, :validate => [true, false, 'true', 'false'], :default 'false'
     end
   end
 end end end

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -162,6 +162,9 @@ module LogStash; module Outputs; class ElasticSearch
       # Substituion syntax will work here, e.g. "%{my_fantastic_field_here}-alias".
       mod.config :ilm_event_alias, :validate => :string
 
+      # Cache seen/created aliases and their destinations once, not during each bulk batch.
+      mod.config :ilm_cache_once, :validate => [true, false, 'true', 'false'], :default => false
+
     end
   end
 end end end

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -17,8 +17,8 @@ module LogStash; module Outputs; class ElasticSearch
       # Joda formats are defined http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[here].
       mod.config :index, :validate => :string, :default => DEFAULT_INDEX_NAME
 
-      mod.config :document_type, 
-        :validate => :string, 
+      mod.config :document_type,
+        :validate => :string,
         :deprecated => "Document types are being deprecated in Elasticsearch 6.0, and removed entirely in 7.0. You should avoid this feature"
 
       # From Logstash 1.3 onwards, a template is applied to Elasticsearch during
@@ -67,7 +67,7 @@ module LogStash; module Outputs; class ElasticSearch
       # The version to use for indexing. Use sprintf syntax like `%{my_version}` to use a field value here.
       # See https://www.elastic.co/blog/elasticsearch-versioning-support.
       mod.config :version, :validate => :string
-      
+
       # The version_type to use for indexing.
       # See https://www.elastic.co/blog/elasticsearch-versioning-support.
       # See also https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_version_types
@@ -93,7 +93,7 @@ module LogStash; module Outputs; class ElasticSearch
       #     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
       # It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
       # to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
-      # 
+      #
       # Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
       mod.config :hosts, :validate => :uri, :default => [::LogStash::Util::SafeURI.new("//127.0.0.1")], :list => true
 
@@ -154,6 +154,9 @@ module LogStash; module Outputs; class ElasticSearch
 
       # ILM policy to use, if undefined the default policy will be used.
       mod.config :ilm_policy, :validate => :string, :default => DEFAULT_POLICY
+
+      # Add index.lifecycle.rollover_alias setting to alias upon creation
+      mod.config :ilm_set_rollover_alias, :validate => [true, false, 'true', 'false'], :default => false
 
     end
   end

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -155,10 +155,11 @@ module LogStash; module Outputs; class ElasticSearch
       # ILM policy to use, if undefined the default policy will be used.
       mod.config :ilm_policy, :validate => :string, :default => DEFAULT_POLICY
 
-      # Add index.lifecycle.rollover_alias setting to alias upon creation
+      # Add index.lifecycle.rollover_alias setting to alias upon creation, always done in the case of aliases created via the ilm_event_alias setting.
       mod.config :ilm_set_rollover_alias, :validate => [true, false, 'true', 'false'], :default => false
 
-      # Use this for event substitution aliases
+      # Use this for event substitution aliases, ilm_rollover_alias is used as a default in the event the field is missing or other unknown errors.
+      # Substituion syntax will work here, e.g. "%{my_fantastic_field_here}-alias".
       mod.config :ilm_event_alias, :validate => :string
 
     end

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -158,6 +158,9 @@ module LogStash; module Outputs; class ElasticSearch
       # Add index.lifecycle.rollover_alias setting to alias upon creation
       mod.config :ilm_set_rollover_alias, :validate => [true, false, 'true', 'false'], :default => false
 
+      # Use this for event substitution aliases
+      mod.config :ilm_event_alias, :validate => :string
+
     end
   end
 end end end

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -179,7 +179,7 @@ module LogStash; module Outputs; class ElasticSearch
       # ilm_rollover_alias.
 
       # Flag for enabling Rollover alias creation, conflicts with ILM.
-      mod.config :ro_only_enabled, :validate => [true, false, 'true', 'false'], :default 'false'
+      mod.config :ro_only_enabled, :validate => [true, false, 'true', 'false'], :default => false
     end
   end
 end end end

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -178,7 +178,7 @@ module LogStash; module Outputs; class ElasticSearch
       # Just like the ILM event substitution process, if anything does not match, it is thrown into the default alias set via
       # ilm_rollover_alias.
 
-      # Flag for enabling Rollover alias creation, conflicts with ILM.
+      # Flag for enabling Rollover alias creation, overrides ILM behavior.
       mod.config :ro_only_enabled, :validate => [true, false, 'true', 'false'], :default => false
     end
   end

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -365,6 +365,7 @@ module LogStash; module Outputs; class ElasticSearch;
       begin
         if add_rollover_settings
           real_alias_name, _ = alias_definition["aliases"].first
+          logger.info("Adding lifecycle rollover_alias setting for #{real_alias_name}")
           alias_definition.merge!({
             'settings' => {
               'index.lifecycle.rollover_alias' => real_alias_name

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -64,7 +64,6 @@ module LogStash; module Outputs; class ElasticSearch;
       # mutex to prevent requests and sniffing to access the
       # connection pool at the same time
       @bulk_path = @options[:bulk_path]
-      logger.trace("All methods for ES output: #{self.methods.to_s}")
     end
 
     def build_url_template
@@ -356,18 +355,15 @@ module LogStash; module Outputs; class ElasticSearch;
 
     # check whether rollover alias already exists
     def rollover_alias_exists?(name)
-      logger.debug("Rollover alias exists?: #{exists?(name)}")
       exists?(name)
-      # TODO: maybe try adding a sprintf here for @event?
     end
 
     # Create a new rollover alias
     def rollover_alias_put(alias_name, alias_definition, add_rollover_settings)
-      logger.info("Creating rollover alias #{alias_name}, escaped: #{CGI::escape(alias_name)}")
       begin
         if add_rollover_settings
           real_alias_name, _ = alias_definition["aliases"].first
-          logger.info("Adding lifecycle rollover_alias setting for #{real_alias_name}")
+          logger.debug("Adding lifecycle rollover_alias setting for #{real_alias_name}")
           alias_definition.merge!({
             'settings' => {
               'index.lifecycle.rollover_alias' => real_alias_name

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -110,7 +110,7 @@ module LogStash; module Outputs; class ElasticSearch;
       if http_compression
         body_stream.set_encoding "BINARY"
         stream_writer = Zlib::GzipWriter.new(body_stream, Zlib::DEFAULT_COMPRESSION, Zlib::DEFAULT_STRATEGY)
-      else 
+      else
         stream_writer = body_stream
       end
       bulk_responses = []
@@ -215,7 +215,7 @@ module LogStash; module Outputs; class ElasticSearch;
                         else
                           nil
                         end
-      
+
       calculated_scheme = calculate_property(uris, :scheme, explicit_scheme, sniffing)
 
       if calculated_scheme && calculated_scheme !~ /https?/
@@ -235,7 +235,7 @@ module LogStash; module Outputs; class ElasticSearch;
       # Enter things like foo:123, bar and wind up with foo:123, bar:9200
       calculate_property(uris, :port, nil, sniffing) || 9200
     end
-    
+
     def uris
       @options[:hosts]
     end
@@ -254,7 +254,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def build_adapter(options)
       timeout = options[:timeout] || 0
-      
+
       adapter_options = {
         :socket_timeout => timeout,
         :request_timeout => timeout,
@@ -281,7 +281,7 @@ module LogStash; module Outputs; class ElasticSearch;
       adapter_class = ::LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter
       adapter = adapter_class.new(@logger, adapter_options)
     end
-    
+
     def build_pool(options)
       adapter = build_adapter(options)
 
@@ -331,7 +331,7 @@ module LogStash; module Outputs; class ElasticSearch;
                     h.query
                   end
       prefixed_raw_query = raw_query && !raw_query.empty? ? "?#{raw_query}" : nil
-      
+
       raw_url = "#{raw_scheme}://#{postfixed_userinfo}#{raw_host}:#{raw_port}#{prefixed_raw_path}#{prefixed_raw_query}"
 
       ::LogStash::Util::SafeURI.new(raw_url)
@@ -360,9 +360,17 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     # Create a new rollover alias
-    def rollover_alias_put(alias_name, alias_definition)
+    def rollover_alias_put(alias_name, alias_definition, add_rollover_settings)
       logger.info("Creating rollover alias #{alias_name}")
       begin
+        if add_rollover_settings
+          real_alias_name, _ = alias_definition["aliases"].first
+          alias_definition.merge!({
+            'settings' => {
+              'index.lifecycle.rollover_alias' => real_alias_name
+            }
+          })
+        end
         @pool.put(CGI::escape(alias_name), nil, LogStash::Json.dump(alias_definition))
         # If the rollover alias already exists, ignore the error that comes back from Elasticsearch
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -361,9 +361,9 @@ module LogStash; module Outputs; class ElasticSearch;
     # Create a new rollover alias
     def rollover_alias_put(alias_name, alias_definition, add_rollover_settings)
       begin
-        if add_rollover_settings
+        if add_rollover_settings == true
           real_alias_name, _ = alias_definition["aliases"].first
-          logger.debug("Adding lifecycle rollover_alias setting for #{real_alias_name}")
+          logger.debug("Adding lifecycle rollover_alias setting for #{alias_name} => #{real_alias_name}, add rollover was #{add_rollover_settings}")
           alias_definition.merge!({
             'settings' => {
               'index.lifecycle.rollover_alias' => real_alias_name

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -30,7 +30,6 @@ module LogStash; module Outputs; class ElasticSearch;
     #   :setting => value
     # }
 
-#
     # The `options` is a hash where the following symbol keys have meaning:
     #
     # * `:hosts` - array of String. Set a list of hosts to use for communication.
@@ -65,6 +64,7 @@ module LogStash; module Outputs; class ElasticSearch;
       # mutex to prevent requests and sniffing to access the
       # connection pool at the same time
       @bulk_path = @options[:bulk_path]
+      logger.trace("All methods for ES output: #{self.methods.to_s}")
     end
 
     def build_url_template
@@ -356,12 +356,14 @@ module LogStash; module Outputs; class ElasticSearch;
 
     # check whether rollover alias already exists
     def rollover_alias_exists?(name)
+      logger.debug("Rollover alias exists?: #{exists?(name)}")
       exists?(name)
+      # TODO: maybe try adding a sprintf here for @event?
     end
 
     # Create a new rollover alias
     def rollover_alias_put(alias_name, alias_definition, add_rollover_settings)
-      logger.info("Creating rollover alias #{alias_name}")
+      logger.info("Creating rollover alias #{alias_name}, escaped: #{CGI::escape(alias_name)}")
       begin
         if add_rollover_settings
           real_alias_name, _ = alias_definition["aliases"].first

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -64,6 +64,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         }
       end
 
+      @logger.debug("Manticore, url: #{url}, path: #{path}, params: #{params.to_s}, body: #{body}")
       request_uri = format_url(url, path)
       request_uri_as_string = remove_double_escaping(request_uri.to_s)
       resp = @manticore.send(method.downcase, request_uri_as_string, params)

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -3,7 +3,7 @@ require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch; class HttpClient;
   DEFAULT_HEADERS = { "Content-Type" => "application/json" }
-  
+
   class ManticoreAdapter
     attr_reader :manticore, :logger
 
@@ -18,14 +18,14 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       options[:cookies] = false
 
       @client_params = {:headers => DEFAULT_HEADERS.merge(options[:headers] || {})}
-      
+
       if options[:proxy]
         options[:proxy] = manticore_proxy_hash(options[:proxy])
       end
-      
+
       @manticore = ::Manticore::Client.new(options)
     end
-    
+
     # Transform the proxy option to a hash. Manticore's support for non-hash
     # proxy options is broken. This was fixed in https://github.com/cheald/manticore/commit/34a00cee57a56148629ed0a47c329181e7319af5
     # but this is not yet released
@@ -55,16 +55,15 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       params[:body] = body if body
 
       if url.user
-        params[:auth] = { 
+        params[:auth] = {
           :user => CGI.unescape(url.user),
           # We have to unescape the password here since manticore won't do it
           # for us unless its part of the URL
-          :password => CGI.unescape(url.password), 
-          :eager => true 
+          :password => CGI.unescape(url.password),
+          :eager => true
         }
       end
 
-      @logger.debug("Manticore, url: #{url}, path: #{path}, params: #{params.to_s}, body: #{body}")
       request_uri = format_url(url, path)
       request_uri_as_string = remove_double_escaping(request_uri.to_s)
       resp = @manticore.send(method.downcase, request_uri_as_string, params)
@@ -87,7 +86,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     # Returned urls from this method should be checked for double escaping.
     def format_url(url, path_and_query=nil)
       request_uri = url.clone
-      
+
       # We excise auth info from the URL in case manticore itself tries to stick
       # sensitive data in a thrown exception or log data
       request_uri.user = nil
@@ -103,7 +102,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       new_query_parts = [request_uri.query, parsed_path_and_query.query].select do |part|
         part && !part.empty? # Skip empty nil and ""
       end
-      
+
       request_uri.query = new_query_parts.join("&") unless new_query_parts.empty?
 
       # use `raw_path`` as `path` will unescape any escaped '/' in the path

--- a/lib/logstash/outputs/elasticsearch/ilm.rb
+++ b/lib/logstash/outputs/elasticsearch/ilm.rb
@@ -98,14 +98,14 @@ module LogStash; module Outputs; class ElasticSearch
           }
         }
       }
-      logger.debug("Maybe create rollover alias for an event?: alias_name: #{alias_name}, alias_target: #{alias_target}, alias_payload: #{alias_payload.to_s}")
-      client.rollover_alias_put(alias_target, alias_payload, ilm_set_rollover_alias) unless client.rollover_alias_exists?(alias_name)
+      # settings put must be done, otherwise you end up with a properly made rollover index
+      # with a lifecycle rollover alias setting for a completely different alias (if using a template)
+      client.rollover_alias_put(alias_target, alias_payload, true) unless client.rollover_alias_exists?(alias_name)
 
       alias_name
     end
 
     def maybe_create_rollover_alias
-      logger.debug("Maybe create ro alias?: #{rollover_alias_target}, exists? #{client.rollover_alias_exists?(ilm_rollover_alias)}")
       client.rollover_alias_put(rollover_alias_target, rollover_alias_payload, ilm_set_rollover_alias) unless client.rollover_alias_exists?(ilm_rollover_alias)
     end
 
@@ -116,7 +116,7 @@ module LogStash; module Outputs; class ElasticSearch
     def rollover_alias_payload
       {
           'aliases' => {
-              ilm_rollover_alias =>{
+              ilm_rollover_alias => {
                   'is_write_index' =>  true
               }
           }

--- a/lib/logstash/outputs/elasticsearch/ilm.rb
+++ b/lib/logstash/outputs/elasticsearch/ilm.rb
@@ -89,9 +89,7 @@ module LogStash; module Outputs; class ElasticSearch
 
     def maybe_create_rollover_alias_for_event(event, created_aliases)
       alias_name = event.sprintf(ilm_event_alias)
-      if client.rollover_alias_exists?(alias_name) or created_aliases.include?(alias_name)
-        return alias_name
-      end
+      return alias_name unless !created_aliases.include?(alias_name)
       alias_target = "<#{alias_name}-#{ilm_pattern}>"
       alias_payload = {
         'aliases' => {

--- a/lib/logstash/outputs/elasticsearch/ilm.rb
+++ b/lib/logstash/outputs/elasticsearch/ilm.rb
@@ -88,7 +88,7 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def maybe_create_rollover_alias
-      client.rollover_alias_put(rollover_alias_target, rollover_alias_payload) unless client.rollover_alias_exists?(ilm_rollover_alias)
+      client.rollover_alias_put(rollover_alias_target, rollover_alias_payload, ilm_set_rollover_alias) unless client.rollover_alias_exists?(ilm_rollover_alias)
     end
 
     def rollover_alias_target

--- a/lib/logstash/outputs/elasticsearch/ilm.rb
+++ b/lib/logstash/outputs/elasticsearch/ilm.rb
@@ -95,7 +95,7 @@ module LogStash; module Outputs; class ElasticSearch
       end
     end
 
-    def maybe_create_rollover_alias_for_event(event, created_aliases)
+    def maybe_create_rollover_alias_for_event(event, created_aliases, is_ilm_request)
       alias_name = event.sprintf(ilm_event_alias)
       return alias_name, created_aliases[alias_name] if created_aliases.has_key?(alias_name)
       raise ImproperAliasName.new(name=alias_name) if alias_name == ilm_event_alias
@@ -109,7 +109,7 @@ module LogStash; module Outputs; class ElasticSearch
       }
       # Without placing the settings on the index you'll need something to run by and add this
       # afterwards (or by a template) or the first index will never rollover.
-      client.rollover_alias_put(alias_target, alias_payload, ilm_set_rollover_alias) unless client.rollover_alias_exists?(alias_name)
+      client.rollover_alias_put(alias_target, alias_payload, is_ilm_request ? ilm_set_rollover_alias : false) unless client.rollover_alias_exists?(alias_name)
 
       return alias_name, alias_name
     end

--- a/lib/logstash/outputs/elasticsearch/ilm.rb
+++ b/lib/logstash/outputs/elasticsearch/ilm.rb
@@ -109,6 +109,7 @@ module LogStash; module Outputs; class ElasticSearch
       }
       # Without placing the settings on the index you'll need something to run by and add this
       # afterwards (or by a template) or the first index will never rollover.
+      logger.trace("Putting rollover alias #{alias_target} for #{alias_name}, is this an ILM request?: #{is_ilm_request}, will we set rollover alias setting? #{ilm_set_rollover_alias}")
       client.rollover_alias_put(alias_target, alias_payload, is_ilm_request ? ilm_set_rollover_alias : false) unless client.rollover_alias_exists?(alias_name)
 
       return alias_name, alias_name


### PR DESCRIPTION
This is more or less a POC for ILM event substitution via Logstash spun off from this issue [here](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/858). The problems from this comment [here](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/805#issuecomment-438385822) can apply as well.

However, we're using this internally for about ~25 clusters and it works reasonably well with a setup such as: 

```
elasticsearch {
  hosts => [
    ...
  ]
  index => "%{elasticsearch_index}"
  document_type => "log"
  codec => "json"
  user => "logstash"
  manage_template => false

  # ilm
  ilm_enabled => true
  ro_only_enabled => true
  ilm_set_rollover_alias => false
  ilm_rollover_alias => "catchall-example"
  ilm_event_alias => "%{elasticsearch_index}"
  ilm_cache_once => false
}
```

It's by no means perfect. Performance hit isn't that bad when set to cache once, we then have something external to attach the lifecycle rollover alias names and policies which solves our dynamic ILM event index name substitution problem at the moment.

I wrote a simple test to demonstrate the results [here](https://gist.github.com/Battleroid/beec2b88c9b59fd3665defa08162c4fb).