### PR TITLE
[Doc]Add note about _type setting change from doc to _doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.4.1
+ - [DOC] Added note about `_type` setting change from `doc` to `_doc` [#884](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/884)
+
 ## 10.4.0
  - Fixed default index value [#927](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/927)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,16 +24,16 @@ include::{include_path}/plugin_header.asciidoc[]
 .Compatibility Note
 [NOTE]
 ================================================================================
-The `_type` setting changed from `doc` to `_doc` in Elasticsearch 7.0.
+When connected to Elasticsearch 7.x, modern versions of this plugin
+use the required `_doc` document-type when inserting documents.
 
-If you are using an earlier version of Logstash, upgrade to
-version 6.8 to pick up changes to the Elasticsearch index template before you
-upgrade to version 7.0 (or later). 
+If you are using an earlier version of Logstash and wish to connect to
+Elasticsearch 7.x, first upgrade Logstash to version 6.8 to ensure it
+picks up changes to the Elasticsearch index template.
 
-After upgrading to 6.8, use the {ref}/indices-templates.html#getting[Index
-Template API] to verify that the 6.8 index template has been created in
-Elasticsearch.
-
+If you are using a custom <<plugins-{type}s-{plugin}-template>>,
+ensure your template uses the `_doc` document-type before
+connecting to Elasticsearch 7.x.
 ================================================================================
 
 .Compatibility Note

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,6 +24,21 @@ include::{include_path}/plugin_header.asciidoc[]
 .Compatibility Note
 [NOTE]
 ================================================================================
+The `_type` setting changed from `doc` to `_doc` in Elasticsearch 7.0.
+
+If you are using an earlier version of Logstash, upgrade to
+version 6.8 to pick up changes to the Elasticsearch index template before you
+upgrade to version 7.0 (or later). 
+
+After upgrading to 6.8, use the {ref}/indices-templates.html#getting[Index
+Template API] to verify that the 6.8 index template has been created in
+Elasticsearch.
+
+================================================================================
+
+.Compatibility Note
+[NOTE]
+================================================================================
 Starting with Elasticsearch 5.3, there's an {ref}/modules-http.html[HTTP setting]
 called `http.content_type.required`. If this option is set to `true`, and you
 are using Logstash 2.4 through 5.2, you need to update the Elasticsearch output

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.4.0'
+  s.version         = '10.4.1'
+
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Call out _type change from `doc` to `_doc` in documentation