### PR TITLE
Only add _type if ES version < 8

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -70,9 +70,12 @@ module LogStash; module Outputs; class ElasticSearch;
       params = {
         :_id => @document_id ? event.sprintf(@document_id) : nil,
         :_index => event.sprintf(@index),
-        :_type => get_event_type(event),
         routing_field_name => @routing ? event.sprintf(@routing) : nil
       }
+
+      if client.maximum_seen_major_version < 8
+        params[:_type] = get_event_type(event)
+      end
 
       if @pipeline
         params[:pipeline] = event.sprintf(@pipeline)


### PR DESCRIPTION
Resolves #887.

Starting from 8.0.0, Elasticsearch has removed the `_type` field from its bulk API actions. This PR teaches the Elasticsearch output to only add the `_type` field to bulk API actions if the Elasticsearch cluster's major version is < 8.
