### PR TITLE
Feat: Added support for cloud_id and cloud_auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.3.0
+  - Feat: Added support for cloud_id and cloud_auth [#906](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/906)
+
 ## 10.2.2
   - Fixed 8.x type removal compatibility issue [#892](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/892) 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -230,6 +230,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-action>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-bulk_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-cloud_auth>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-cloud_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-custom_headers>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-doc_as_upsert>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-document_id>> |<<string,string>>|No
@@ -325,6 +327,26 @@ this defaults to a concatenation of the path parameter and "_bulk"
 
 The .cer or .pem file to validate the server's certificate
 
+[id="plugins-{type}s-{plugin}-cloud_auth"]
+===== `cloud_auth`
+
+  * Value type is <<password,password>>
+  * There is no default value for this setting.
+
+Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` pair.
+
+For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[cloud documentation]
+
+[id="plugins-{type}s-{plugin}-cloud_id"]
+===== `cloud_id`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
+
+For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[cloud documentation]
+
 [id="plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert` 
 
@@ -340,8 +362,7 @@ Create a new document with source if `document_id` doesn't exist in Elasticsearc
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-The document ID for the index. Useful for overwriting existing entries in
-Elasticsearch with the same ID.
+The document ID for the index. Useful for overwriting existing entries in Elasticsearch with the same ID.
 
 [id="plugins-{type}s-{plugin}-document_type"]
 ===== `document_type` 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -125,7 +125,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` configuration.
   #
   # For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[cloud documentation]
-  config :cloud_auth, :validate => :string
+  config :cloud_auth, :validate => :password
 
   # HTTP Path at which the Elasticsearch server lives. Use this if you must run Elasticsearch behind a proxy that remaps
   # the root path for the Elasticsearch HTTP API lives.

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -17,7 +17,7 @@ require "forwardable"
 # called `http.content_type.required`. If this option is set to `true`, and you
 # are using Logstash 2.4 through 5.2, you need to update the Elasticsearch output
 # plugin to version 6.2.5 or higher.
-# 
+#
 # ================================================================================
 #
 # This plugin is the recommended method of storing logs in Elasticsearch.
@@ -26,8 +26,8 @@ require "forwardable"
 # This output only speaks the HTTP protocol. HTTP is the preferred protocol for interacting with Elasticsearch as of Logstash 2.0.
 # We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,
 # yet far easier to administer and work with. When using the HTTP protocol one may upgrade Elasticsearch versions without having
-# to upgrade Logstash in lock-step. 
-# 
+# to upgrade Logstash in lock-step.
+#
 # You can learn more about Elasticsearch at <https://www.elastic.co/products/elasticsearch>
 #
 # ==== Template management for Elasticsearch 5.x
@@ -121,6 +121,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   config :user, :validate => :string
   # Password to authenticate to a secure Elasticsearch cluster
   config :password, :validate => :password
+
+  # Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` configuration.
+  #
+  # For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_auth[cloud documentation]
+  config :cloud_auth, :validate => :string
 
   # HTTP Path at which the Elasticsearch server lives. Use this if you must run Elasticsearch behind a proxy that remaps
   # the root path for the Elasticsearch HTTP API lives.

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -146,7 +146,8 @@ module LogStash; module Outputs; class ElasticSearch;
       begin # might not be available on older LS
         require 'logstash/util/cloud_setting_id'
       rescue LoadError
-        raise LogStash::ConfigurationError, 'The cloud.id setting is not supported by LogStash, please set hosts instead.'
+        raise LogStash::ConfigurationError, 'The cloud_id setting is not supported by your version of Logstash, ' +
+            'please upgrade your installation (or set hosts instead).'
       end
 
       begin
@@ -163,7 +164,8 @@ module LogStash; module Outputs; class ElasticSearch;
       begin # might not be available on older LS
         require 'logstash/util/cloud_setting_auth'
       rescue LoadError
-        raise LogStash::ConfigurationError, 'The cloud.auth setting is not supported by LogStash, please set user/password instead.'
+        raise LogStash::ConfigurationError, 'The cloud_auth setting is not supported by your version of Logstash, ' +
+            'please upgrade your installation (or set user/password instead).'
       end
 
       begin

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -21,6 +21,8 @@ module LogStash; module Outputs; class ElasticSearch;
       # To support BWC, we check if DLQ exists in core (< 5.4). If it doesn't, we use nil to resort to previous behavior.
       @dlq_writer = dlq_enabled? ? execution_context.dlq_writer : nil
 
+      fill_hosts_from_cloud_id
+      fill_user_password_from_cloud_auth
       setup_hosts # properly sets @hosts
       build_client
       setup_after_successful_connection
@@ -108,11 +110,6 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def setup_hosts
-      if setup_hosts_from_cloud_id
-        @logger.info("Using default cloud.id/cloud.auth from command line.")
-        return
-      end
-
       @hosts = Array(@hosts)
       if @hosts.empty?
         @logger.info("No 'host' set in elasticsearch output. Defaulting to localhost")
@@ -120,23 +117,63 @@ module LogStash; module Outputs; class ElasticSearch;
       end
     end
 
-    def setup_hosts_from_cloud_id
+    def hosts_default?(hosts)
       # NOTE: would be nice if pipeline allowed us a clean way to detect a config default :
-      if @hosts.is_a?(Array) && @hosts.size == 1 && @hosts.first.equal?(CommonConfigs::DEFAULT_HOST)
-        if cloud_id = LogStash::SETTINGS.get_value('cloud.id')
-          # LogStash::Util::CloudSettingId already does append ':{port}' to host :
-          cloud_uri = "#{cloud_id.elasticsearch_scheme}://#{cloud_id.elasticsearch_host}"
-          cloud_uri = LogStash::Util::SafeURI.new(cloud_uri)
-
-          if cloud_auth = LogStash::SETTINGS.get_value('cloud.auth')
-            cloud_uri.user = cloud_auth.username
-            cloud_uri.password = cloud_auth.password.value
-          end
-
-          return @hosts = [ cloud_uri ]
-        end
-      end
+      hosts.is_a?(Array) && hosts.size == 1 && hosts.first.equal?(CommonConfigs::DEFAULT_HOST)
     end
+    private :hosts_default?
+
+    def fill_hosts_from_cloud_id
+      return unless @cloud_id
+
+      if @hosts && !hosts_default?(@hosts)
+        raise LogStash::ConfigurationError, 'Both cloud_id and hosts specified, please only use one of those.'
+      end
+      @hosts = parse_host_uri_from_cloud_id(@cloud_id)
+    end
+
+    def fill_user_password_from_cloud_auth
+      return unless @cloud_auth
+
+      if @user || @password
+        raise LogStash::ConfigurationError, 'Both cloud_auth and user/password specified, please only use one.'
+      end
+      @user, @password = parse_user_password_from_cloud_auth(@cloud_auth)
+      params['user'], params['password'] = @user, @password
+    end
+
+    def parse_host_uri_from_cloud_id(cloud_id)
+      begin # might not be available on older LS
+        require 'logstash/util/cloud_setting_id'
+      rescue LoadError
+        raise LogStash::ConfigurationError, 'The cloud.id setting is not supported by LogStash, please set hosts instead.'
+      end
+
+      begin
+        cloud_id = LogStash::Util::CloudSettingId.new(cloud_id) # already does append ':{port}' to host
+      rescue ArgumentError => e
+        raise LogStash::ConfigurationError, e.message.to_s.sub(/Cloud Id/i, 'cloud_id')
+      end
+      cloud_uri = "#{cloud_id.elasticsearch_scheme}://#{cloud_id.elasticsearch_host}"
+      LogStash::Util::SafeURI.new(cloud_uri)
+    end
+    private :parse_host_uri_from_cloud_id
+
+    def parse_user_password_from_cloud_auth(cloud_auth)
+      begin # might not be available on older LS
+        require 'logstash/util/cloud_setting_auth'
+      rescue LoadError
+        raise LogStash::ConfigurationError, 'The cloud.auth setting is not supported by LogStash, please set user/password instead.'
+      end
+
+      begin
+        cloud_auth = LogStash::Util::CloudSettingAuth.new(cloud_auth)
+      rescue ArgumentError => e
+        raise LogStash::ConfigurationError, e.message.to_s.sub(/Cloud Auth/i, 'cloud_auth')
+      end
+      [ cloud_auth.username, cloud_auth.password ]
+    end
+    private :parse_user_password_from_cloud_auth
 
     def maximum_seen_major_version
       client.maximum_seen_major_version

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -168,6 +168,7 @@ module LogStash; module Outputs; class ElasticSearch;
             'please upgrade your installation (or set user/password instead).'
       end
 
+      cloud_auth = cloud_auth.value if cloud_auth.is_a?(LogStash::Util::Password)
       begin
         cloud_auth = LogStash::Util::CloudSettingAuth.new(cloud_auth)
       rescue ArgumentError => e

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -7,6 +7,11 @@ module LogStash; module Outputs; class ElasticSearch
     DEFAULT_POLICY = "logstash-policy"
     DEFAULT_ROLLOVER_ALIAS = 'logstash'
 
+    # TODO LS will replace the provided config :default
+    # BONUS points for .freeze then it just dies with IllegalStateException
+    # DEFAULT_HOSTS = [ ::LogStash::Util::SafeURI.new("//127.0.0.1") ]
+    DEFAULT_HOST = ::LogStash::Util::SafeURI.new("//127.0.0.1")
+
     def self.included(mod)
       # The index to write events to. This can be dynamic using the `%{foo}` syntax.
       # The default value will partition your indices by day so you can more easily
@@ -95,7 +100,7 @@ module LogStash; module Outputs; class ElasticSearch
       # to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
       # 
       # Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
-      mod.config :hosts, :validate => :uri, :default => [::LogStash::Util::SafeURI.new("//127.0.0.1")], :list => true
+      mod.config :hosts, :validate => :uri, :default => [ DEFAULT_HOST ], :list => true
 
       # Set upsert content for update mode.s
       # Create a new document with this parameter as json string if `document_id` doesn't exists

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -7,9 +7,6 @@ module LogStash; module Outputs; class ElasticSearch
     DEFAULT_POLICY = "logstash-policy"
     DEFAULT_ROLLOVER_ALIAS = 'logstash'
 
-    # TODO LS will replace the provided config :default
-    # BONUS points for .freeze then it just dies with IllegalStateException
-    # DEFAULT_HOSTS = [ ::LogStash::Util::SafeURI.new("//127.0.0.1") ]
     DEFAULT_HOST = ::LogStash::Util::SafeURI.new("//127.0.0.1")
 
     def self.included(mod)
@@ -98,9 +95,14 @@ module LogStash; module Outputs; class ElasticSearch
       #     `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
       # It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
       # to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
-      # 
+      #
       # Any special characters present in the URLs here MUST be URL escaped! This means `#` should be put in as `%23` for instance.
       mod.config :hosts, :validate => :uri, :default => [ DEFAULT_HOST ], :list => true
+
+      # Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
+      #
+      # For mode details, check out the https://www.elastic.co/guide/en/logstash/current/connecting-to-cloud.html#_cloud_id[cloud documentation]
+      mod.config :cloud_id, :validate => :string
 
       # Set upsert content for update mode.s
       # Create a new document with this parameter as json string if `document_id` doesn't exists

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.2.2'
+  s.version         = '10.3.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -337,18 +337,9 @@ describe LogStash::Outputs::ElasticSearch do
 
   describe "SSL end to end" do
     let(:do_register) { false } # skip the register in the global before block, as is called here.
-    let(:manticore_double) do
-      double("manticoreX#{self.inspect}")
-    end
 
     before(:each) do
-      response_double = double("manticore response").as_null_object
-      # Allow healtchecks
-      allow(manticore_double).to receive(:head).with(any_args).and_return(response_double)
-      allow(manticore_double).to receive(:get).with(any_args).and_return(response_double)
-      allow(manticore_double).to receive(:close)
-
-      allow(::Manticore::Client).to receive(:new).and_return(manticore_double)
+      stub_manticore_client!
       subject.register
     end
 
@@ -522,6 +513,75 @@ describe LogStash::Outputs::ElasticSearch do
     end
   end
 
+  describe "cloud.id" do
+    let(:do_register) { false }
+
+    let(:valid_cloud_id) do
+      'sample:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA=='
+    end
+
+    let(:options) { { 'cloud_id' => valid_cloud_id } }
+
+    before(:each) do
+      stub_manticore_client!
+    end
+
+    it "should set host(s)" do
+      subject.register
+      es_url = subject.client.pool.urls.first
+      expect( es_url.to_s ).to eql('https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243/')
+    end
+
+    context 'invalid' do
+      let(:options) { { 'cloud_id' => 'invalid:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlv' } }
+
+      it "should fail" do
+        expect { subject.register }.to raise_error LogStash::ConfigurationError, /cloud_id.*? is invalid/
+      end
+    end
+
+    context 'hosts also set' do
+      let(:options) { { 'cloud_id' => valid_cloud_id, 'hosts' => [ 'localhost' ] } }
+
+      it "should fail" do
+        expect { subject.register }.to raise_error LogStash::ConfigurationError, /cloud_id and hosts/
+      end
+    end
+  end
+
+  describe "cloud.auth" do
+    let(:do_register) { false }
+
+    let(:options) { { 'cloud_auth' => 'elastic:my-passwd-00' } }
+
+    before(:each) do
+      stub_manticore_client!
+    end
+
+    it "should set host(s)" do
+      subject.register
+      es_url = subject.client.pool.urls.first
+      expect( es_url.user ).to eql('elastic')
+      expect( es_url.password ).to eql('my-passwd-00')
+    end
+
+    context 'invalid' do
+      let(:options) { { 'cloud_auth' => 'invalid-format' } }
+
+      it "should fail" do
+        expect { subject.register }.to raise_error LogStash::ConfigurationError, /cloud_auth.*? format/
+      end
+    end
+
+    context 'user also set' do
+      let(:options) { { 'cloud_auth' => 'elastic:my-passwd-00', 'user' => 'another' } }
+
+      it "should fail" do
+        expect { subject.register }.to raise_error LogStash::ConfigurationError, /cloud_auth and user/
+      end
+    end
+  end
+
   context 'handling elasticsearch document-level status meant for the DLQ' do
     let(:options) { { "manage_template" => false } }
 
@@ -598,4 +658,18 @@ describe LogStash::Outputs::ElasticSearch do
       end
     end
   end
+
+  @private
+
+  def stub_manticore_client!(manticore_double = nil)
+    manticore_double ||= double("manticore #{self.inspect}")
+    response_double = double("manticore response").as_null_object
+    # Allow healtchecks
+    allow(manticore_double).to receive(:head).with(any_args).and_return(response_double)
+    allow(manticore_double).to receive(:get).with(any_args).and_return(response_double)
+    allow(manticore_double).to receive(:close)
+
+    allow(::Manticore::Client).to receive(:new).and_return(manticore_double)
+  end
+
 end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -552,7 +552,7 @@ describe LogStash::Outputs::ElasticSearch do
   describe "cloud.auth" do
     let(:do_register) { false }
 
-    let(:options) { { 'cloud_auth' => 'elastic:my-passwd-00' } }
+    let(:options) { { 'cloud_auth' => LogStash::Util::Password.new('elastic:my-passwd-00') } }
 
     before(:each) do
       stub_manticore_client!


### PR DESCRIPTION
should be fairly straight-forward: 
- **cloud_id** is a substitute for the *hosts* setting (one can not use both)
- **cloud_auth** is an *user/password* alternative

resolves: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/893

~~TODO documentation for new options~~