### PR TITLE
support giving up on failed individual bulk requests after a number of retries

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -229,6 +229,8 @@ module LogStash; module Outputs; class ElasticSearch;
 
       sleep_interval = @retry_initial_interval
 
+      failed_retries = 0
+
       while submit_actions && submit_actions.length > 0
 
         # We retry with whatever is didn't succeed
@@ -246,6 +248,16 @@ module LogStash; module Outputs; class ElasticSearch;
 
         # Everything was a success!
         break if !submit_actions || submit_actions.empty?
+
+        failed_retries += 1
+
+        if @retry_max_failures > 0 && failed_retries == @retry_max_failures
+          @logger.warn("Giving up on individual bulk actions that failed or were rejected by the previous bulk request.",
+                      :actions => submit_actions.map { |action_type, params, event| [action_type, params, event.to_s] },
+                      :retries => failed_retries,
+                      :count => submit_actions.size)
+          break
+        end
 
         # If we're retrying the action sleep for the recommended interval
         # Double the interval for the next time through to achieve exponential backoff

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -136,6 +136,9 @@ module LogStash; module Outputs; class ElasticSearch
       # Set max interval in seconds between bulk retries.
       mod.config :retry_max_interval, :validate => :number, :default => 64
 
+      # The number of times we should retry on failed individual bulk actions (0 = infinity)
+      mod.config :retry_max_failures, :validate => :number, :default => 0
+
       # The number of times Elasticsearch should internally retry an update/upserted document
       # See the https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html[partial updates]
       # for more info


### PR DESCRIPTION
This commit adds a new config parameter `retry_max_failures` that controls the maximum number of retries that should be attempted for failed individual bulk requests (0 means infinity).

Resolves #795 #806 