### PR TITLE
Fix: handle proxy => '' as if none was set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.3.1
+ - Fix: handle proxy => '' as if none was set [#912](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/912)
+
 ## 10.3.0
   - Feat: Added support for cloud_id and cloud_auth [#906](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/906)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -626,6 +626,8 @@ which is bad.
 Set the address of a forward HTTP proxy.
 This used to accept hashes as arguments but now only accepts
 arguments of the URI type to prevent leaking credentials.
+An empty string is treated as if proxy was not set, this is useful when using
+environment variables e.g. `proxy => '${LS_PROXY:}'`.
 
 [id="plugins-{type}s-{plugin}-resurrect_delay"]
 ===== `resurrect_delay` 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -244,7 +244,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     if proxy.is_a?(String)
       # environment variables references aren't yet resolved
       proxy = deep_replace(proxy)
-      if proxy.eql?('')
+      if proxy.empty?
         params.delete('proxy')
         @proxy = ''
       else

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.3.0'
+  s.version         = '10.3.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
a convenient feature when users are using env variables for proxy
e.g. `proxy => ${LS_PROXY:}`. 
empty proxy host settings are common to be ignored by libraries ...
