### PR TITLE
Test: get (most) specs passing on CI

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -244,7 +244,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   end
 
   def close
-    @stopping.make_true
+    @stopping.make_true if @stopping
     stop_template_installer
     @client.close if @client
   end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -547,7 +547,7 @@ describe LogStash::Outputs::ElasticSearch do
         expect { subject.register }.to raise_error LogStash::ConfigurationError, /cloud_id and hosts/
       end
     end
-  end
+  end if LOGSTASH_VERSION > '6.0'
 
   describe "cloud.auth" do
     let(:do_register) { false }
@@ -580,7 +580,7 @@ describe LogStash::Outputs::ElasticSearch do
         expect { subject.register }.to raise_error LogStash::ConfigurationError, /cloud_auth and user/
       end
     end
-  end
+  end if LOGSTASH_VERSION > '6.0'
 
   context 'handling elasticsearch document-level status meant for the DLQ' do
     let(:options) { { "manage_template" => false } }


### PR DESCRIPTION
SNAPSHOTS still failing ... but some :red_circle: introduced at https://github.com/logstash-plugins/logstash-output-elasticsearch/commit/3b6aa8556e8c5cc3a55b2fa8059a4dda8145ce02 is resolved