### PR TITLE
doc: fix formatting of list for asciidoc rendering

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -425,11 +425,13 @@ If you have custom firewall rules you may need to change this
 
 Sets the host(s) of the remote instance. If given an array it will load balance requests across the hosts specified in the `hosts` parameter.
 Remember the `http` protocol uses the http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[http] address (eg. 9200, not 9300).
-    `"127.0.0.1"`
-    `["127.0.0.1:9200","127.0.0.2:9200"]`
-    `["http://127.0.0.1"]`
-    `["https://127.0.0.1:9200"]`
-    `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
+
+   * `"127.0.0.1"`
+   * `["127.0.0.1:9200","127.0.0.2:9200"]`
+   * `["http://127.0.0.1"]`
+   * `["https://127.0.0.1:9200"]`
+   * `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
+
 It is important to exclude http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html[dedicated master nodes] from the `hosts` list
 to prevent LS from sending bulk requests to the master nodes.  So this parameter should only reference either data or client nodes in Elasticsearch.
 


### PR DESCRIPTION
The list of examples for the `hosts` option needs bullet points to correctly render as a list with asciidoctor.