### PR TITLE
deprecate script_type inline and add source

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -261,7 +261,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-routing>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-script>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-script_lang>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-script_type>> |<<string,string>>, one of `["inline", "indexed", "file"]`|No
+| <<plugins-{type}s-{plugin}-script_type>> |<<string,string>>, one of `["inline", "indexed", "file", "source"]`|No
 | <<plugins-{type}s-{plugin}-script_var_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-scripted_upsert>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-sniffing>> |<<boolean,boolean>>|No
@@ -679,11 +679,12 @@ When using indexed (stored) scripts on Elasticsearch 6 and higher, you must set 
 [id="plugins-{type}s-{plugin}-script_type"]
 ===== `script_type` 
 
-  * Value can be any of: `inline`, `indexed`, `file`
+  * Value can be any of: `inline`, `source`, `indexed`, `file`
   * Default value is `["inline"]`
 
 Define the type of script referenced by "script" variable
- inline : "script" contains inline script
+ inline : "script" contains inline script (ES 5.x)
+ source : "script" contains inline script (ES +6.0)
  indexed : "script" contains the name of script directly indexed in elasticsearch
  file    : "script" contains the name of script stored in elasticsearch's config directory
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -9,6 +9,7 @@ require "socket" # for Socket.gethostname
 require "thread" # for safe queueing
 require "uri" # for escaping user input
 require "forwardable"
+require 'logstash/plugin_mixins/deprecation_logger_support'
 
 # .Compatibility Note
 # [NOTE]

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -109,10 +109,11 @@ module LogStash; module Outputs; class ElasticSearch
       mod.config :script, :validate => :string, :default => ""
 
       # Define the type of script referenced by "script" variable
-      #  inline : "script" contains inline script
+      #  inline : "script" contains inline script (ES 5.x)
+      #  source : "script" contains inline script (ES +6.0)
       #  indexed : "script" contains the name of script directly indexed in elasticsearch
       #  file    : "script" contains the name of script stored in elasticseach's config directory
-      mod.config :script_type, :validate => ["inline", 'indexed', "file"], :default => ["inline"]
+      mod.config :script_type, :validate => ["inline", 'indexed', "file", "source"], :default => ["inline"]
 
       # Set the language of the used script. If not set, this defaults to painless in ES 5.0
       mod.config :script_lang, :validate => :string, :default => "painless"

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -416,6 +416,8 @@ module LogStash; module Outputs; class ElasticSearch;
           source['script']['file'] = args.delete(:_script)
         when 'inline'
           source['script']['inline'] = args.delete(:_script)
+        when 'source'
+          source['script']['source'] = args.delete(:_script)
         end
         source['script']['lang'] = @options[:script_lang] if @options[:script_lang] != ''
       else

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -2,6 +2,9 @@ require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch;
   module HttpClientBuilder
+    include LogStash::Util::Loggable
+    include LogStash::PluginMixins::DeprecationLoggerSupport
+
     def self.build(logger, hosts, params)
       client_settings = {
         :pool_max => params["pool_max"],
@@ -75,6 +78,10 @@ module LogStash; module Outputs; class ElasticSearch;
       raise( LogStash::ConfigurationError,
         "doc_as_upsert and scripted_upsert are mutually exclusive."
       ) if params["doc_as_upsert"] and params["scripted_upsert"]
+
+      if params['action'] == 'update' && params['script_type'] == 'inline'
+        deprecation_logger.deprecated("The 'inline' value for script type is deprecated and won't be supported in Elasticsearch 8.0. Please use 'source' instead.")
+      end
 
       raise(
         LogStash::ConfigurationError,

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
 
   s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'logstash-devutils'

--- a/spec/integration/outputs/painless_update_spec.rb
+++ b/spec/integration/outputs/painless_update_spec.rb
@@ -67,6 +67,18 @@ if ESHelper.es_version_satisfies?(">= 5")
         expect(r["_source"]["counter"]).to eq(4)
       end
 
+      it "should increment a counter with event/doc 'count' variable with source script" do
+        subject = get_es_output({
+          'document_id' => "123",
+          'script' => 'ctx._source.counter += params.event.counter',
+          'script_type' => 'source'
+        })
+        subject.register
+        subject.multi_receive([LogStash::Event.new("counter" => 3 )])
+        r = @es.get(:index => 'logstash-update', :type => doc_type, :id => "123", :refresh => true)
+        expect(r["_source"]["counter"]).to eq(4)
+      end
+
       it "should increment a counter with event/doc 'count' variable with event/doc as upsert and inline script" do
         subject = get_es_output({
           'document_id' => "123",


### PR DESCRIPTION
fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/896

Also log to deprecation logger if inline is used:

```
❯ tail -F logstash-deprecation.log
[2020-02-14T12:08:19,853][WARN ][deprecation.logstash.outputs.elasticsearch.httpclientbuilder][main] The 'inline' value for script type is deprecated and won't be supported in Elasticsearch 8.0. Please use 'source' instead.
```