### PR TITLE
Fix integration tests for Elasticsearch 7.6+

### DIFF
--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -139,7 +139,7 @@ module ESHelper
   end
 
   def clean_ilm(client)
-    client.get_ilm_policy.each_key {|key| client.delete_ilm_policy(name: key)}
+    client.get_ilm_policy.each_key { |key| client.delete_ilm_policy(name: key)  unless key =~ /history-ilm-policy/ }
   end
 
   def supports_ilm?(client)

--- a/spec/integration/outputs/create_spec.rb
+++ b/spec/integration/outputs/create_spec.rb
@@ -34,7 +34,7 @@ describe "client create actions", :integration => true do
       @es.indices.refresh
       # Wait or fail until everything's indexed.
       Stud::try(3.times) do
-        r = @es.search
+        r = @es.search(index: 'logstash-*')
         expect(r).to have_hits(1)
       end
     end

--- a/spec/integration/outputs/ilm_spec.rb
+++ b/spec/integration/outputs/ilm_spec.rb
@@ -37,10 +37,10 @@ shared_examples_for 'an ILM enabled Logstash' do
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search
+        r = @es.search(index: "#{expected_index}-*")
         expect(r).to have_hits(9)
       end
-      indexes_written = @es.search['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
+      indexes_written = @es.search(index: "#{expected_index}-*")['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
         index_written = x['_index']
         res[index_written] += 1
       end
@@ -78,10 +78,10 @@ shared_examples_for 'an ILM enabled Logstash' do
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search
+        r = @es.search(index: "#{expected_index}-*")
         expect(r).to have_hits(6)
       end
-      indexes_written = @es.search['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
+      indexes_written = @es.search(index: "#{expected_index}-*")['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
         index_written = x['_index']
         res[index_written] += 1
       end
@@ -93,10 +93,10 @@ end
 
 shared_examples_for 'an ILM disabled Logstash' do
   it 'should not create a rollover alias' do
-    expect(@es.get_alias).to be_empty
+    expect(@es.indices.exists_alias(index: "logstash")).to be_falsey
     subject.register
     sleep(1)
-    expect(@es.get_alias).to be_empty
+    expect(@es.indices.exists_alias(index: "logstash")).to be_falsey
   end
 
   it 'should not install the default policy' do
@@ -139,10 +139,10 @@ shared_examples_for 'an ILM disabled Logstash' do
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search
+        r = @es.search(index: 'logstash-*')
         expect(r).to have_hits(6)
       end
-      indexes_written = @es.search['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
+      indexes_written = @es.search(index: 'logstash-*')['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
         index_written = x['_index']
         res[index_written] += 1
       end
@@ -328,10 +328,10 @@ if ESHelper.es_version_satisfies?(">= 6.6")
 
           # Wait or fail until everything's indexed.
           Stud::try(20.times) do
-            r = @es.search
+            r = @es.search(index: "logstash-*")
             expect(r).to have_hits(6)
           end
-          indexes_written = @es.search['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
+          indexes_written = @es.search(index: "logstash-*")['hits']['hits'].each_with_object(Hash.new(0)) do |x, res|
             index_written = x['_index']
             res[index_written] += 1
           end

--- a/spec/integration/outputs/ingest_pipeline_spec.rb
+++ b/spec/integration/outputs/ingest_pipeline_spec.rb
@@ -53,7 +53,7 @@ if ESHelper.es_version_satisfies?(">= 5")
 
       #Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search
+        r = @es.search(index: 'logstash-*')
         expect(r).to have_hits(1)
       end
     end

--- a/spec/integration/outputs/no_es_on_startup_spec.rb
+++ b/spec/integration/outputs/no_es_on_startup_spec.rb
@@ -38,7 +38,7 @@ describe "elasticsearch is down on startup", :integration => true do
     allow_any_instance_of(LogStash::Outputs::ElasticSearch::HttpClient::Pool).to receive(:get_es_version).and_return(ESHelper.es_version)
     subject.multi_receive([event1, event2])
     @es.indices.refresh
-    r = @es.search
+    r = @es.search(index: 'logstash-*')
     expect(r).to have_hits(2)
   end
 
@@ -51,7 +51,7 @@ describe "elasticsearch is down on startup", :integration => true do
     end
     subject.multi_receive([event1, event2])
     @es.indices.refresh
-    r = @es.search
+    r = @es.search(index: 'logstash-*')
     expect(r).to have_hits(2)
   end
 

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -142,7 +142,7 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.close
 
     @es.indices.refresh
-    r = @es.search
+    r = @es.search(index: 'logstash-*')
     expect(r).to have_hits(0)
   end
 
@@ -153,7 +153,7 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.multi_receive([event1])
     subject.close
     @es.indices.refresh
-    r = @es.search
+    r = @es.search(index: 'logstash-*')
     expect(r).to have_hits(1)
   end
 
@@ -163,7 +163,7 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.close
 
     @es.indices.refresh
-    r = @es.search
+    r = @es.search(index: 'logstash-*')
     expect(r).to have_hits(1)
   end
 end

--- a/spec/integration/outputs/templates_5x_spec.rb
+++ b/spec/integration/outputs/templates_5x_spec.rb
@@ -40,7 +40,7 @@ if ESHelper.es_version_satisfies?(">= 5")
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search
+        r = @es.search(index: 'logstash-*')
         expect(r).to have_hits(8)
       end
     end

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -40,7 +40,7 @@ if ESHelper.es_version_satisfies?("< 5")
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search
+        r = @es.search(index: 'logstash-*')
         expect(r).to have_hits(8)
       end
     end


### PR DESCRIPTION
Elasticsearch `7.6` introduced an `ilm-history` which caused a number of
tests to fail. Certain ILM tests were failing because they were trying to
delete ILM policies tied to histories, while others were failing due to the
search query being applied across all indices, rather than being targeted.

This commit fixes the search criteria across a number of tests, and avoids
trying to delete any `ilm-history` policies, which is not allowed due to items
existing in the associated history indices.
