### PR TITLE
More fixes to Elasticsearch output build

### DIFF
--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -139,7 +139,7 @@ module ESHelper
   end
 
   def clean_ilm(client)
-    client.get_ilm_policy.each_key { |key| client.delete_ilm_policy(name: key)  unless key =~ /history-ilm-policy/ }
+    client.get_ilm_policy.each_key { |key| client.delete_ilm_policy(name: key)  if key =~ /logstash-policy/ }
   end
 
   def supports_ilm?(client)


### PR DESCRIPTION
Later versions of the Elasticsearch mandate a `name` parameter to the
`exists_alias` method. This commit updates the tests to include that
parameter.

Additionally, there are some fixes to move towards an "inclusion" list
of policies to delete, rather than an "exclusion" list.
