### PR TITLE
Replace link to Cloud trial with attribute and bump to v10.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 10.3.3
+ - [DOC] Replaced link to Elastic Cloud trial with attribute, and fixed a comma splice [#tbd](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/tbd)
+
 ## 10.3.2
  - [DOC] Replaced setting name with correct value [#919](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/919)
- - Fix integration tests for Elasticsearch 7.6+ [#922](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/922)
- - Fix integration tests for Elasticsearch API `7.5.0` [#923](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/923)
+ - Fixed integration tests for Elasticsearch 7.6+ [#922](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/922)
+ - Fixed integration tests for Elasticsearch API `7.5.0` [#923](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/923)
 
 ## 10.3.1
  - Fix: handle proxy => '' as if none was set [#912](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/912)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 10.3.3
- - [DOC] Replaced link to Elastic Cloud trial with attribute, and fixed a comma splice [#tbd](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/tbd)
+ - [DOC] Replaced link to Elastic Cloud trial with attribute, and fixed a comma splice [#926](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/926)
 
 ## 10.3.2
  - [DOC] Replaced setting name with correct value [#919](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/919)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -623,8 +623,7 @@ which is bad.
   * There is no default value for this setting.
 
 Set the address of a forward HTTP proxy.
-This used to accept hashes as arguments but now only accepts
-arguments of the URI type to prevent leaking credentials.
+This setting accepts only URI arguments to prevent leaking credentials.
 An empty string is treated as if proxy was not set. This is useful when using
 environment variables e.g. `proxy => '${LS_PROXY:}'`.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -38,8 +38,7 @@ Elasticsearch.
 TIP: You can run Elasticsearch on your own hardware, or use our
 https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
 Elastic Cloud. The Elasticsearch Service is available on both AWS and GCP.
-https://www.elastic.co/cloud/elasticsearch-service/signup[Try the {es} Service
-for free].
+{ess-trial}[Try the {es} Service for free].
 
 This output only speaks the HTTP protocol. HTTP is the preferred protocol for interacting with Elasticsearch as of Logstash 2.0.
 We strongly encourage the use of HTTP over the node protocol for a number of reasons. HTTP is only marginally slower,

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -626,7 +626,7 @@ which is bad.
 Set the address of a forward HTTP proxy.
 This used to accept hashes as arguments but now only accepts
 arguments of the URI type to prevent leaking credentials.
-An empty string is treated as if proxy was not set, this is useful when using
+An empty string is treated as if proxy was not set. This is useful when using
 environment variables e.g. `proxy => '${LS_PROXY:}'`.
 
 [id="plugins-{type}s-{plugin}-resurrect_delay"]

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.3.2'
+  s.version         = '10.3.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Contains cherry-picks from #921 and adds a version bump
