### PR TITLE
[Doc]Fix default value for index and bump to v.10.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.4.0
+ - Fixed default index value [#927](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/927)
+
 ## 10.3.3
  - [DOC] Replaced link to Elastic Cloud trial with attribute, and fixed a comma splice [#926](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/926)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -501,7 +501,7 @@ NOTE: `ilm_rollover_alias` does NOT support dynamic variable substitution as `in
 ===== `index` 
 
   * Value type is <<string,string>>
-  * Default value is `"logstash-%{+YYYY.MM.dd}"`
+  * Default value is `"logstash-%{+yyyy.MM.dd}"`
 
 The index to write events to. This can be dynamic using the `%{foo}` syntax.
 The default value will partition your indices by day so you can more easily

--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -3,7 +3,7 @@ require 'forwardable' # Needed for logstash core SafeURI. We need to patch this 
 module LogStash; module Outputs; class ElasticSearch
   module CommonConfigs
 
-    DEFAULT_INDEX_NAME = "logstash-%{+YYYY.MM.dd}"
+    DEFAULT_INDEX_NAME = "logstash-%{+yyyy.MM.dd}"
     DEFAULT_POLICY = "logstash-policy"
     DEFAULT_ROLLOVER_ALIAS = 'logstash'
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.3.3'
+  s.version         = '10.4.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Resolves #876 
Default value listed for `index` was listed as `logstash-%{+YYYY.MM.dd}`
This PR corrects the default value to `logstash-%{+yyyy.MM.dd}`
