### PR TITLE
[DOC] Clarify how the event is sent in scripts

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -729,7 +729,10 @@ Define the type of script referenced by "script" variable
   * Value type is <<string,string>>
   * Default value is `"event"`
 
-Set variable name passed to script (scripted update)
+Set variable name passed to script (scripted update).
+
+Logstash will send the content of the event in a variable inside the `params`.
+See https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting-using.html#_script_parameters
 
 [id="plugins-{type}s-{plugin}-scripted_upsert"]
 ===== `scripted_upsert` 


### PR DESCRIPTION
Following this https://discuss.elastic.co/t/script-params-via-logstash-is-it-possible/226586/3?u=luca_belluccini, I've opened change to clarify the whole event is passed as variable inside the `params`.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
