### PR TITLE
make credentail and host setup happen in build_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.4.2
+ - Changed cloud id, credential and host setup to happen in `build_client` [#939](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/939)
+
 ## 10.4.1
  - [DOC] Added note about `_type` setting change from `doc` to `_doc` [#884](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/884)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -255,6 +255,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   end
 
   def build_client
+    fill_user_password_from_cloud_auth
+    fill_hosts_from_cloud_id
+    setup_hosts
+
     params["metric"] = metric
     if @proxy.eql?('')
       @logger.warn "Supplied proxy setting (proxy => '') has no effect"

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -21,9 +21,6 @@ module LogStash; module Outputs; class ElasticSearch;
       # To support BWC, we check if DLQ exists in core (< 5.4). If it doesn't, we use nil to resort to previous behavior.
       @dlq_writer = dlq_enabled? ? execution_context.dlq_writer : nil
 
-      fill_hosts_from_cloud_id
-      fill_user_password_from_cloud_auth
-      setup_hosts # properly sets @hosts
       build_client
       setup_after_successful_connection
       check_action_validity

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.4.1'
+  s.version         = '10.4.2'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"


### PR DESCRIPTION
Related to #934 and https://github.com/elastic/logstash/pull/11818

This patch release is intended essentially to solve the `cloud_id` problem reverted fix  https://github.com/elastic/logstash/pull/11800 for 7.6 and 7.7. 