### PR TITLE
[Doc]Replace free text with attribute for cloud trial

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -53,10 +53,7 @@ connecting to Elasticsearch 7.x.
 
 ===== Hosted {es} Service on Elastic Cloud
 
-You can run Elasticsearch on your own hardware, or use our
-https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
-Elastic Cloud. The Elasticsearch Service is available on AWS, Google Cloud
-Platform, and Microsoft Azure. {ess-trial}[Try the {es} Service for free].
+{ess-leadin}
 
 ==== Writing to different indices: best practices
 


### PR DESCRIPTION
Replaces free text with an attribute to help keep content up-to-date and consistent across documents.

~DO NOT MERGE until after elastic/docs#1815 has been merged.~  DONE 
