### PR TITLE
[Doc] Update http compression in Elasticsearch

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -204,9 +204,9 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 ==== HTTP Compression
 
-This plugin supports request and response compression. Response compression is enabled by default and 
+This plugin supports request and response compression. Response compression is enabled by default for HTTP and 
 for Elasticsearch versions 5.0 and later, the user doesn't have to set any configs in Elasticsearch for 
-it to send back compressed response. For versions before 5.0, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in 
+it to send back compressed response. For versions before 5.0, or if HTTPS is enabled, `http.compression` must be set to `true` https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#modules-http[in 
 Elasticsearch] to take advantage of response compression when using this plugin
 
 For requests compression, regardless of the Elasticsearch version, users have to enable `http_compression` 


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/pull/56899, Elasticsearch disables compression if HTTPS is enabled.

