### PR TITLE
[doc] remove pem certificate mention as it doesn't seem to be supported

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -333,7 +333,7 @@ this defaults to a concatenation of the path parameter and "_bulk"
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-The .cer or .pem file to validate the server's certificate
+The .cer or .crt file to validate the server's certificate
 
 [id="plugins-{type}s-{plugin}-cloud_auth"]
 ===== `cloud_auth`

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -156,7 +156,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
   config :ssl_certificate_verification, :validate => :boolean, :default => true
 
-  # The .cer or .pem file to validate the server's certificate
+  # The .cer or .crt file to validate the server's certificate
   config :cacert, :validate => :path
 
   # The JKS truststore to validate the server's certificate.


### PR DESCRIPTION
Regarding https://github.com/elastic/helm-charts/issues/587#issuecomment-621784754, https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/929 and https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/676, logstash-output-elasticsearch doesn't seem to accept `.pem` certificates despite being mentionned in the [doc](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-cacert).

Note that a `.pem` certificate is also mentionned in `when using ssl with client certificates`. I don't know if this test is passing and if it should be removed.

https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/612e52ecbb0e08ec3dbae871a0edec1b37581a86/spec/unit/outputs/elasticsearch_ssl_spec.rb#L56