### PR TITLE
bump rake version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ if Dir.exist?(logstash_path) && use_logstash_source
 end
 
 if RUBY_VERSION == "1.9.3"
-  gem 'rake', '12.2.1'
+  gem 'rake', '12.3.3'
 end


### PR DESCRIPTION
This commit bump rake version to 12.3.3 to fix severity CVE-2020-8130[0]

[0]: https://github.com/advisories/GHSA-jppv-gw3r-w3q8