### PR TITLE
Added detail about pipeline.batch.size corresponding to elasticsearch…

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -77,7 +77,7 @@ Each Elasticsearch output is a new client connected to the cluster:
  * it has to initialize the client and connect to Elasticsearch (restart time is longer if you have more clients)
  * it has an associated connection pool
 
-In order to minimize the number of open connections to Elasticsearch, maximize the bulk size and reduce the number of "small" bulk requests (which could easily fill up the queue), it is usually more efficient to have a single Elasticsearch output.
+In order to minimize the number of open connections to Elasticsearch, maximize the bulk size and reduce the number of "small" bulk requests (which could easily fill up the queue), it is usually more efficient to have a single Elasticsearch output.  Bulk request size is set with the logstash configuration `pipeline.batch.size`.
 
 Example:
 [source,ruby]


### PR DESCRIPTION
… batch size.  Have added this because it is not clearly visible how in the elasticsearch output to influence the bulk size with a parameter.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
