### PR TITLE
Fix breakage caused by external use of our internal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.6.1
+ - Fixed an issue introduced in 10.6.0 that broke Logstash Core's monitoring feature when this plugin is run in Logstash 7.7-7.8. [#953](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/953)
+
 ## 10.6.0
  - Added `ecs_compatiblity` mode, for managing ECS-compatable templates [#952](https://github.com/logstash-plugins/logstash-output-elasticsearch/issue/952)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -419,7 +419,7 @@ If you don't set a value for this option:
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)],
+Controls this plugin's compatibility with the https://www.elastic.co/guide/en/ecs/current/index.html[Elastic Common Schema (ECS)],
 including the installation of ECS-compatible index templates.
 The value of this setting affects the _default_ values of:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -419,7 +419,7 @@ If you don't set a value for this option:
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
 ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the {ecs-ref}}[Elastic Common Schema (ECS)],
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)],
 including the installation of ECS-compatible index templates.
 The value of this setting affects the _default_ values of:
 

--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -60,7 +60,14 @@ module LogStash; module Outputs; class ElasticSearch;
       !!maximum_seen_major_version
     end
 
-    def use_event_type?
+    ##
+    # WARNING: This method is overridden in a subclass in Logstash Core 7.7-7.8's monitoring,
+    #          where a `client` argument is both required and ignored. In later versions of
+    #          Logstash Core it is optional and ignored, but to make it optional here would
+    #          allow us to accidentally break compatibility with Logstashes where it was required.
+    # @param noop_required_client [nil]: required `nil` for legacy reasons.
+    # @return [Boolean]
+    def use_event_type?(noop_required_client)
       maximum_seen_major_version < 8
     end
 
@@ -74,7 +81,7 @@ module LogStash; module Outputs; class ElasticSearch;
         routing_field_name => @routing ? event.sprintf(@routing) : nil
       }
 
-      params[:_type] = get_event_type(event) if use_event_type?
+      params[:_type] = get_event_type(event) if use_event_type?(nil)
 
       if @pipeline
         params[:pipeline] = event.sprintf(@pipeline)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.6.0'
+  s.version         = '10.6.1'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"


### PR DESCRIPTION
Because Logstash Core v7.7.0-v7.8.x override the `use_event_type?` in a
monitoring implelentation's subclass with a required (and ignored) `client`
argument, when we send `use_event_type?` internally, we must send an argument
or else we break compatibility with those versions of Logstash.
    
This change re-adds the required argument and modifies our call-site to send
with an arity of 1, re-names the resulting local variable to be descriptive
of our intent, and adds commentary to prevent future accidental breakage.
