### PR TITLE
Updated default value ilm_policy

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -523,7 +523,7 @@ NOTE: The pattern must finish with a dash and a number that will be automaticall
 ===== `ilm_policy`
 
   * Value type is <<string,string>>
-  * Default value is `logstash`
+  * Default value is `logstash-policy`
 
 Modify this setting to use a custom Index Lifecycle Management policy, rather than the default. If this value is not set, the default policy will
 be automatically installed into Elasticsearch


### PR DESCRIPTION
If I don't provide the `ilm_policy` config. The default value is `logstash_policy`.

I created a dockerfile

```
FROM docker.elastic.co/logstash/logstash:7.8.1
RUN rm -f /usr/share/logstash/pipeline/logstash.conf
ADD pipeline/ /usr/share/logstash/pipeline/
ADD config/ /usr/share/logstash/config/
``` 

And the output from the docker file is the following 

```
Installing ILM policy {"policy"=>{"phases"=>{"hot"=>{"actions"=>{"rollover"=>{"max_size"=>"50gb", "max_age"=>"30d"}}}}}} to _ilm/policy/logstash-policy
```

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
