### PR TITLE
avoid retry loop caused by sending empty bulk requests to Elasticsearch

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common.rb
+++ b/lib/logstash/outputs/elasticsearch/common.rb
@@ -33,7 +33,7 @@ module LogStash; module Outputs; class ElasticSearch;
       until @template_installed.true?
         sleep 1
       end
-      retrying_submit(events.map {|e| event_action_tuple(e)})
+      retrying_submit(events.map {|e| event_action_tuple(e)}) unless events.empty?
     end
 
     def setup_after_successful_connection


### PR DESCRIPTION
Under Logstash 7.x's Java Execution Engine, empty batches can be sent to this
output's `multi_receive`, and because Elasticsearch emits an HTTP 400-level
error when it receives an empty bulk request, this plugin ends up in an
unescapable retry loop when it receives an empty batch.