### PR TITLE
index template updates

### DIFF
--- a/lib/logstash/outputs/elasticsearch/common_configs.rb
+++ b/lib/logstash/outputs/elasticsearch/common_configs.rb
@@ -50,6 +50,12 @@ module LogStash; module Outputs; class ElasticSearch
       # If not set, the included template will be used.
       mod.config :template, :validate => :path
 
+      # The legacy_template option will use the old /_template (ELK >7.7) 
+      # path for creating index templates.
+      # It will also construct the ilm configurations for the template in a manner
+      # which is compatible with legacy templates
+      mod.config :legacy_template, :validate => :boolean, :default => false
+
       # The template_overwrite option will always overwrite the indicated template
       # in Elasticsearch with either the one indicated by template or the included one.
       # This option is set to false by default. If you always want to stay up to date

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -252,6 +252,10 @@ module LogStash; module Outputs; class ElasticSearch;
       client_settings.fetch(:http_compression, false)
     end
 
+    def legacy_template
+      client_settings.fetch(:legacy)
+    end
+
     def build_adapter(options)
       timeout = options[:timeout] || 0
       
@@ -343,11 +347,19 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def template_exists?(name)
-      exists?("/_template/#{name}")
+      if legacy_template
+        exists?("/_template/#{name}")
+      else
+        exists?("/_index_template/#{name}")
+      end
     end
 
     def template_put(name, template)
-      path = "_template/#{name}"
+      if legacy_template
+        path = "_template/#{name}"
+      else
+        path = "_index_template/#{name}"
+      end
       logger.info("Installing elasticsearch template to #{path}")
       @pool.put(path, nil, LogStash::Json.dump(template))
     end

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -9,7 +9,8 @@ module LogStash; module Outputs; class ElasticSearch;
         :pool_max_per_route => params["pool_max_per_route"],
         :check_connection_timeout => params["validate_after_inactivity"],
         :http_compression => params["http_compression"],
-        :headers => params["custom_headers"] || {}
+        :headers => params["custom_headers"] || {},
+        :legacy => params["legacy_template"]
       }
       
       client_settings[:proxy] = params["proxy"] if params["proxy"]


### PR DESCRIPTION
#958 
Adds support for new index template schema
Adds handling for adding ilm configurations when settings hash doesn't exist
Only overwrites index_patterns from template when absolutely necessary
Adds legacy_template option (boolean), which will change paths between _index_template and _template, and also configure ilm fields appropriately

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
