### PR TITLE
common code refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
  - Refactored configuration options into specific and shared in PluginMixins namespace [#973](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/973)
+ - Refactored common methods into specific and shared in PluginMixins namespace [#976](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/976)
 
 ## 10.7.3
  - Added composable index template support for elasticsearch version 8 [#980](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/980)

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -286,6 +286,7 @@ module LogStash; module Outputs; class ElasticSearch;
       adapter = build_adapter(options)
 
       pool_options = {
+        :license_checker => options[:license_checker],
         :sniffing => sniffing,
         :sniffer_delay => options[:sniffer_delay],
         :sniffing_path => options[:sniffing_path],

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -15,6 +15,7 @@ module LogStash; module Outputs; class ElasticSearch;
       client_settings[:proxy] = params["proxy"] if params["proxy"]
       
       common_options = {
+        :license_checker => params["license_checker"],
         :client_settings => client_settings,
         :metric => params["metric"],
         :resurrect_delay => params["resurrect_delay"]

--- a/lib/logstash/outputs/elasticsearch/ilm.rb
+++ b/lib/logstash/outputs/elasticsearch/ilm.rb
@@ -5,10 +5,10 @@ module LogStash; module Outputs; class ElasticSearch
 
     def setup_ilm
       return unless ilm_in_use?
-        logger.warn("Overwriting supplied index #{@index} with rollover alias #{@ilm_rollover_alias}") unless default_index?(@index)
-        @index = @ilm_rollover_alias
-        maybe_create_rollover_alias
-        maybe_create_ilm_policy
+      logger.warn("Overwriting supplied index #{@index} with rollover alias #{@ilm_rollover_alias}") unless default_index?(@index)
+      @index = @ilm_rollover_alias
+      maybe_create_rollover_alias
+      maybe_create_ilm_policy
     end
 
     def default_rollover_alias?(rollover_alias)
@@ -75,6 +75,10 @@ module LogStash; module Outputs; class ElasticSearch
 
     private
 
+    def default_index?(index)
+      index == @default_index
+    end
+
     def ilm_policy_default?
       ilm_policy == LogStash::Outputs::ElasticSearch::DEFAULT_POLICY
     end
@@ -110,4 +114,4 @@ module LogStash; module Outputs; class ElasticSearch
       LogStash::Json.load(::IO.read(policy_path))
     end
   end
- end end end
+end; end; end

--- a/lib/logstash/outputs/elasticsearch/license_checker.rb
+++ b/lib/logstash/outputs/elasticsearch/license_checker.rb
@@ -1,0 +1,47 @@
+module LogStash; module Outputs; class ElasticSearch
+  class LicenseChecker
+
+    def initialize(logger)
+      @logger = logger
+    end
+
+    # Figure out if the provided license is appropriate or not
+    # The appropriate_license? methods is the method called from LogStash::Outputs::ElasticSearch::HttpClient::Pool#healthcheck!
+    # @param url [LogStash::Util::SafeURI] ES node URL
+    # @param license [Hash] ES node deserialized licence document
+    # @return [Boolean] true if provided license is deemed appropriate
+    def appropriate_license?(pool, url)
+      return true if oss?
+
+      license = pool.get_license(url)
+      if valid_es_license?(license)
+        true
+      else
+        # As this version is to be shipped with Logstash 7.x we won't mark the connection as unlicensed
+        #
+        #  @logger.error("Cannot connect to the Elasticsearch cluster configured in the Elasticsearch output. Logstash requires the default distribution of Elasticsearch. Please update to the default distribution of Elasticsearch for full access to all free features, or switch to the OSS distribution of Logstash.", :url => url.sanitized.to_s)
+        #  meta[:state] = :unlicensed
+        #
+        # Instead we'll log a deprecation warning and mark it as alive:
+        #
+        log_license_deprecation_warn(url)
+        true
+      end
+    end
+
+    # Note that oss? could be private but is used by the Pool specs
+    def oss?
+      LogStash::OSS
+    end
+
+    # Note that valid_es_license? could be private but is used by the Pool specs
+    def valid_es_license?(license)
+      license.fetch("license", {}).fetch("status", nil) == "active"
+    end
+
+    # Note that log_license_deprecation_warn could be private but is used by the Pool specs
+    def log_license_deprecation_warn(url)
+      @logger.warn("DEPRECATION WARNING: Connecting to an OSS distribution of Elasticsearch using the default distribution of Logstash will stop working in Logstash 8.0.0. Please upgrade to the default distribution of Elasticsearch, or use the OSS distribution of Logstash", :url => url.sanitized.to_s)
+    end
+  end
+end; end; end

--- a/lib/logstash/plugin_mixins/elasticsearch/noop_license_checker.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/noop_license_checker.rb
@@ -1,0 +1,9 @@
+module LogStash; module PluginMixins; module ElasticSearch
+  class NoopLicenseChecker
+    INSTANCE = self.new
+
+    def appropriate_license?(pool, url)
+      true
+    end
+  end
+end; end; end

--- a/spec/unit/outputs/license_check_spec.rb
+++ b/spec/unit/outputs/license_check_spec.rb
@@ -1,0 +1,41 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/elasticsearch/http_client"
+require "logstash/outputs/elasticsearch/license_checker"
+
+describe LogStash::Outputs::ElasticSearch::LicenseChecker do
+
+  # Note that the actual license checking logic is spec'ed in pool_spec.rb
+
+  context "LicenseChecker API required by Pool class" do
+    subject { described_class }
+
+    it "defines the appropriate_license? methods" do
+      expect(subject.instance_methods).to include(:appropriate_license?)
+    end
+  end
+
+  context "LicenseChecker API required by Pool specs" do
+    subject { described_class }
+
+    it "defines the oss? method" do
+      expect(subject.instance_methods).to include(:oss?)
+    end
+
+    it "defines the valid_es_license? method" do
+      expect(subject.instance_methods).to include(:valid_es_license?)
+    end
+
+    it "defines the log_license_deprecation_warn method" do
+      expect(subject.instance_methods).to include(:log_license_deprecation_warn)
+    end
+  end
+
+  context "Pool class API required by the LicenseChecker" do
+    subject { LogStash::Outputs::ElasticSearch::HttpClient::Pool }
+
+    it "contains the get_license method" do
+      expect(LogStash::Outputs::ElasticSearch::HttpClient::Pool.instance_methods).to include(:get_license)
+    end
+  end
+end
+


### PR DESCRIPTION
This is work toward Data Streams integration elastic/logstash#12178

Specific elasticsearch methods are now into the main elasticsearch class file and shared methods have been moved into the PluginMixins::ElasticSearch::Common namespace. The license checking code has been externalized and can now be specified as argument to the `build_client` method.
    
This is code refactorting that has no end-user impact.