### PR TITLE
fix rake vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ if Dir.exist?(logstash_path) && use_logstash_source
 end
 
 if RUBY_VERSION == "1.9.3"
-  gem 'rake', '12.2.1'
+  gem 'rake', '12.3.3'
 end


### PR DESCRIPTION
This PR upgrade the rake lib due to a vulnerability report. GitHub is warning "We found a potential security vulnerability in one of your dependencies." and suggest to use rake >= 12.3.3
The latest plugin 10.7.3 was unable to publish through jarivs
