### PR TITLE
[DOC] Fix formatting of hosts examples

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -510,11 +510,11 @@ requests across the hosts specified in the `hosts` parameter. Remember the
 
 Examples:
 
-    `"127.0.0.1"`
-    `["127.0.0.1:9200","127.0.0.2:9200"]`
-    `["http://127.0.0.1"]`
-    `["https://127.0.0.1:9200"]`
-    `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
+  * `"127.0.0.1"`
+  * `["127.0.0.1:9200","127.0.0.2:9200"]`
+  * `["http://127.0.0.1"]`
+  * `["https://127.0.0.1:9200"]`
+  * `["https://127.0.0.1:9200/mypath"]` (If using a proxy on a subpath)
 
 Exclude {ref}/modules-node.html[dedicated master nodes] from the `hosts` list to
 prevent Logstash from sending bulk requests to the master nodes. This parameter


### PR DESCRIPTION
The 4-space formatting created a code block, which meant the backticks showed up in the output instead of indicating code formatting for each individual example, which made it appear that the backticks had syntactical meaning in the configuration file.
