### PR TITLE
Add example under hosts setting

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -523,6 +523,13 @@ should reference only data or client nodes in Elasticsearch.
 Any special characters present in the URLs here MUST be URL escaped! This means
 `#` should be put in as `%23` for instance.
 
+This setting supports defining an environment variable `hosts => '${ES_HOSTS:}',
+with multiple {logstash-ref}/plugin-concepts.html[whitespace-delimited URIs], e.g.:
+
+```
+ES_HOSTS="es1.example.com es2.example.com:9201 es3.example.com:9201"
+```
+
 [id="plugins-{type}s-{plugin}-http_compression"]
 ===== `http_compression`
 


### PR DESCRIPTION
Adds an example under hosts setting showing users how to use an environment variable with multiple white-space delimited hosts.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
