### PR TITLE
Remove `type` when connecting to ES 7 and user doesn't specify it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.8.3
+ - Avoid to implicitly set deprecated type to `_doc` when connects to Elasticsearch version 7.x  [#994](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/994)
+
 ## 10.8.2
  - [DOC] Update links to use shared attributes [#985](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/985)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,7 +40,8 @@ the website landing page or in the {ref}[Elasticsearch documentation].
 [NOTE]
 ================================================================================
 When connected to Elasticsearch 7.x, modern versions of this plugin
-use the required `_doc` document-type when inserting documents.
+don't use the document-type when inserting documents, unless the user
+explicitly sets <<plugins-{type}s-{plugin}-document_type>>.
 
 If you are using an earlier version of Logstash and wish to connect to
 Elasticsearch 7.x, first upgrade Logstash to version 6.8 to ensure it

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -417,7 +417,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # @param noop_required_client [nil]: required `nil` for legacy reasons.
   # @return [Boolean]
   def use_event_type?(noop_required_client)
-    maximum_seen_major_version < 8
+    # always set type for ES <= 6
+    # for ES 7 only set it if the user defined it
+    (maximum_seen_major_version < 7) || (maximum_seen_major_version == 7 && @document_type)
   end
 
   def install_template

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '10.8.2'
+  s.version         = '10.8.3'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -4,9 +4,21 @@ require_relative "../../../spec/es_spec_helper"
 describe "failures in bulk class expected behavior", :integration => true do
   let(:template) { '{"template" : "not important, will be updated by :index"}' }
   let(:event1) { LogStash::Event.new("somevalue" => 100, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
-  let(:action1) { ESHelper.action_for_version(["index", {:_id=>nil, routing_field_name =>nil, :_index=>"logstash-2014.11.17", :_type=> doc_type }, event1]) }
+  let(:action1) do
+    if ESHelper.es_version_satisfies?(">= 6", "< 7")
+      ESHelper.action_for_version(["index", {:_id=>nil, routing_field_name =>nil, :_index=>"logstash-2014.11.17", :_type=> doc_type }, event1])
+    else
+      ESHelper.action_for_version(["index", {:_id=>nil, routing_field_name =>nil, :_index=>"logstash-2014.11.17" }, event1])
+    end
+  end
   let(:event2) { LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0] }, "@timestamp" => "2014-11-17T20:37:17.223Z", "@metadata" => {"retry_count" => 0}) }
-  let(:action2) { ESHelper.action_for_version(["index", {:_id=>nil, routing_field_name =>nil, :_index=>"logstash-2014.11.17", :_type=> doc_type }, event2]) }
+  let(:action2) do
+    if ESHelper.es_version_satisfies?(">= 6", "< 7")
+      ESHelper.action_for_version(["index", {:_id=>nil, routing_field_name =>nil, :_index=>"logstash-2014.11.17", :_type=> doc_type }, event2])
+    else
+      ESHelper.action_for_version(["index", {:_id=>nil, routing_field_name =>nil, :_index=>"logstash-2014.11.17" }, event2])
+    end
+  end
   let(:invalid_event) { LogStash::Event.new("geoip" => { "location" => "notlatlon" }, "@timestamp" => "2014-11-17T20:37:17.223Z") }
 
   def mock_actions_with_response(*resp)

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -80,10 +80,10 @@ describe LogStash::Outputs::ElasticSearch do
     describe "building an event action tuple" do
       context "for 7.x elasticsearch clusters" do
         let(:maximum_seen_major_version) { 7 }
-        it "should include '_type'" do
+        it "should not include '_type' when 'document_type' is not explicitly defined" do
           action_tuple = subject.send(:event_action_tuple, LogStash::Event.new("type" => "foo"))
           action_params = action_tuple[1]
-          expect(action_params).to include(:_type => "_doc")
+          expect(action_params).not_to include(:_type => "_doc")
         end
 
         context "with 'document type set'" do


### PR DESCRIPTION
With ES 7.10.0 a deprecation log line about types removal is printed for each request (index/bulk) that contains the deprecated index `_type`.
This led to possible flood of deprecation logs on Elasticsearch, tracked in https://github.com/elastic/elasticsearch/issues/69188.

This commit removes the implicit set of type when connected to ES7 unless the user doesn't specify explicitly the type.

Related to #915 