### PR TITLE
Fix: improve logging (not just) when ES returns invalid bulk response

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -4,7 +4,7 @@ require "logstash/environment"
 require "logstash/outputs/base"
 require "logstash/json"
 require "concurrent"
-require "stud/buffer"
+require "stud/interval"
 require "socket" # for Socket.gethostname
 require "thread" # for safe queueing
 require "uri" # for escaping user input

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -403,7 +403,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
            end
 
     if !(type.is_a?(String) || type.is_a?(Numeric))
-      @logger.warn("Bad event type! Non-string/integer type value set!", :type_class => type.class, :type_value => type.to_s, :event => event)
+      @logger.warn("Bad event type (non-string/integer type value set)", :type_class => type.class, :type_value => type, :event => event.to_hash)
     end
 
     type.to_s

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -425,6 +425,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   def install_template
     TemplateManager.install_template(self)
     @template_installed.make_true
+  rescue => e
+    @logger.error("Failed to install template", message: e.message, exception: e.class, backtrace: e.backtrace)
   end
 
   def setup_ecs_compatibility_related_defaults

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -80,7 +80,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def template_install(name, template, force=false)
       if template_exists?(name) && !force
-        @logger.debug("Found existing Elasticsearch template. Skipping template management", :name => name)
+        @logger.debug("Found existing Elasticsearch template, skipping template management", name: name)
         return
       end
       template_put(name, template)
@@ -349,7 +349,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def template_put(name, template)
       path = "#{template_endpoint}/#{name}"
-      logger.info("Installing elasticsearch template to #{path}")
+      logger.info("Installing Elasticsearch template", name: name)
       @pool.put(path, nil, LogStash::Json.dump(template))
     end
 
@@ -366,13 +366,13 @@ module LogStash; module Outputs; class ElasticSearch;
 
     # Create a new rollover alias
     def rollover_alias_put(alias_name, alias_definition)
-      logger.info("Creating rollover alias #{alias_name}")
       begin
         @pool.put(CGI::escape(alias_name), nil, LogStash::Json.dump(alias_definition))
+        logger.info("Created rollover alias", name: alias_name)
         # If the rollover alias already exists, ignore the error that comes back from Elasticsearch
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         if e.response_code == 400
-            logger.info("Rollover Alias #{alias_name} already exists. Skipping")
+            logger.info("Rollover alias already exists, skipping", name: alias_name)
             return
         end
         raise e
@@ -393,7 +393,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def ilm_policy_put(name, policy)
       path = "_ilm/policy/#{name}"
-      logger.info("Installing ILM policy #{policy} to #{path}")
+      logger.info("Installing ILM policy #{policy}", name: name)
       @pool.put(path, nil, LogStash::Json.dump(policy))
     end
 

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -1,6 +1,4 @@
 require "logstash/outputs/elasticsearch"
-require "cabin"
-require "base64"
 require 'logstash/outputs/elasticsearch/http_client/pool'
 require 'logstash/outputs/elasticsearch/http_client/manticore_adapter'
 require 'cgi'

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -15,8 +15,6 @@ module LogStash; module Outputs; class ElasticSearch
       add_ilm_settings_to_template(plugin, template) if plugin.ilm_in_use?
       plugin.logger.debug("Attempting to install template", template: template)
       install(plugin.client, template_name(plugin), template, plugin.template_overwrite)
-    rescue => e
-      plugin.logger.error("Failed to install template", message: e.message, exception: e.class, backtrace: e.backtrace)
     end
 
     private

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -13,10 +13,10 @@ module LogStash; module Outputs; class ElasticSearch
       end
 
       add_ilm_settings_to_template(plugin, template) if plugin.ilm_in_use?
-      plugin.logger.info("Attempting to install template", :manage_template => template)
+      plugin.logger.debug("Attempting to install template", template: template)
       install(plugin.client, template_name(plugin), template, plugin.template_overwrite)
     rescue => e
-      plugin.logger.error("Failed to install template.", :message => e.message, :class => e.class.name, :backtrace => e.backtrace)
+      plugin.logger.error("Failed to install template", message: e.message, exception: e.class, backtrace: e.backtrace)
     end
 
     private
@@ -38,7 +38,7 @@ module LogStash; module Outputs; class ElasticSearch
       template['index_patterns'] = "#{plugin.ilm_rollover_alias}-*"
       settings = template_settings(plugin, template)
       if settings && (settings['index.lifecycle.name'] || settings['index.lifecycle.rollover_alias'])
-        plugin.logger.info("Overwriting index lifecycle name and rollover alias as ILM is enabled.")
+        plugin.logger.info("Overwriting index lifecycle name and rollover alias as ILM is enabled")
       end
       settings.update({ 'index.lifecycle.name' => plugin.ilm_policy, 'index.lifecycle.rollover_alias' => plugin.ilm_rollover_alias})
     end
@@ -61,7 +61,7 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.read_template_file(template_path)
-      raise ArgumentError, "Template file '#{template_path}' could not be found!" unless ::File.exists?(template_path)
+      raise ArgumentError, "Template file '#{template_path}' could not be found" unless ::File.exists?(template_path)
       template_data = ::IO.read(template_path)
       LogStash::Json.load(template_data)
     end

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -130,9 +130,8 @@ module LogStash; module PluginMixins; module ElasticSearch
       Thread.new do
         sleep_interval = @retry_initial_interval
         until successful_connection? || @stopping.true?
-          @logger.debug("Waiting for connectivity to Elasticsearch cluster. Retrying in #{sleep_interval}s")
-          Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
-          sleep_interval = next_sleep_interval(sleep_interval)
+          @logger.debug("Waiting for connectivity to Elasticsearch cluster, retrying in #{sleep_interval}s")
+          sleep_interval = sleep_for_interval(sleep_interval)
         end
         block.call if successful_connection?
       end
@@ -159,13 +158,11 @@ module LogStash; module PluginMixins; module ElasticSearch
         begin
           submit_actions = submit(submit_actions)
           if submit_actions && submit_actions.size > 0
-            @logger.info("Retrying individual bulk actions that failed or were rejected by the previous bulk request.", :count => submit_actions.size)
+            @logger.info("Retrying individual bulk actions that failed or were rejected by the previous bulk request", count: submit_actions.size)
           end
         rescue => e
-          @logger.error("Encountered an unexpected error submitting a bulk request! Will retry.",
-                       :error_message => e.message,
-                       :class => e.class.name,
-                       :backtrace => e.backtrace)
+          @logger.error("Encountered an unexpected error submitting a bulk request, will retry",
+                        message: e.message, exception: e.class, backtrace: e.backtrace)
         end
 
         # Everything was a success!
@@ -173,20 +170,40 @@ module LogStash; module PluginMixins; module ElasticSearch
 
         # If we're retrying the action sleep for the recommended interval
         # Double the interval for the next time through to achieve exponential backoff
-        Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
-        sleep_interval = next_sleep_interval(sleep_interval)
+        sleep_interval = sleep_for_interval(sleep_interval)
       end
     end
 
     def sleep_for_interval(sleep_interval)
-      Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
+      stoppable_sleep(sleep_interval)
       next_sleep_interval(sleep_interval)
+    end
+
+    def stoppable_sleep(interval)
+      Stud.stoppable_sleep(interval) { @stopping.true? }
     end
 
     def next_sleep_interval(current_interval)
       doubled = current_interval * 2
       doubled > @retry_max_interval ? @retry_max_interval : doubled
     end
+
+    def handle_dlq_status(message, action, status, response)
+      # To support bwc, we check if DLQ exists. otherwise we log and drop event (previous behavior)
+      if @dlq_writer
+        # TODO: Change this to send a map with { :status => status, :action => action } in the future
+        @dlq_writer.write(action[2], "#{message} status: #{status}, action: #{action}, response: #{response}")
+      else
+        if dig_value(response, 'index', 'error', 'type') == 'invalid_index_name_exception'
+          level = :error
+        else
+          level = :warn
+        end
+        @logger.send level, message, status: status, action: action, response: response
+      end
+    end
+
+    private
 
     def submit(actions)
       bulk_response = safe_bulk(actions)
@@ -209,7 +226,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         action_type, action_props = response.first
 
         status = action_props["status"]
-        failure  = action_props["error"]
+        error  = action_props["error"]
         action = actions[idx]
         action_params = action[1]
 
@@ -222,7 +239,7 @@ module LogStash; module PluginMixins; module ElasticSearch
           next
         elsif DOC_CONFLICT_CODE == status
           @document_level_metrics.increment(:non_retryable_failures)
-          @logger.warn "Failed action.", status: status, action: action, response: response if !failure_type_logging_whitelist.include?(failure["type"])
+          @logger.warn "Failed action", status: status, action: action, response: response if log_failure_type?(error)
           next
         elsif DOC_DLQ_CODES.include?(status)
           handle_dlq_status("Could not index event to Elasticsearch.", action, status, response)
@@ -231,7 +248,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         else
           # only log what the user whitelisted
           @document_level_metrics.increment(:retryable_failures)
-          @logger.info "retrying failed action with response code: #{status} (#{failure})" if !failure_type_logging_whitelist.include?(failure["type"])
+          @logger.info "Retrying failed action", status: status, action: action, error: error if log_failure_type?(error)
           actions_to_retry << action
         end
       end
@@ -239,20 +256,8 @@ module LogStash; module PluginMixins; module ElasticSearch
       actions_to_retry
     end
 
-    def handle_dlq_status(message, action, status, response)
-      # To support bwc, we check if DLQ exists. otherwise we log and drop event (previous behavior)
-      if @dlq_writer
-        # TODO: Change this to send a map with { :status => status, :action => action } in the future
-        @dlq_writer.write(action[2], "#{message} status: #{status}, action: #{action}, response: #{response}")
-      else
-        error_type = response.fetch('index', {}).fetch('error', {})['type']
-        if 'invalid_index_name_exception' == error_type
-          level = :error
-        else
-          level = :warn
-        end
-        @logger.send level, message, status: status, action: action, response: response
-      end
+    def log_failure_type?(failure)
+      !failure_type_logging_whitelist.include?(failure["type"])
     end
 
     # Rescue retryable errors during bulk submission
@@ -260,19 +265,15 @@ module LogStash; module PluginMixins; module ElasticSearch
       sleep_interval = @retry_initial_interval
       begin
         es_actions = actions.map {|action_type, params, event| [action_type, params, event.to_hash]}
-        response = @client.bulk(es_actions)
-        response
+        @client.bulk(es_actions) # return response
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError => e
         # If we can't even connect to the server let's just print out the URL (:hosts is actually a URL)
         # and let the user sort it out from there
         @logger.error(
-          "Attempted to send a bulk request to elasticsearch'"+
-            " but Elasticsearch appears to be unreachable or down!",
-          :error_message => e.message,
-          :class => e.class.name,
-          :will_retry_in_seconds => sleep_interval
+          "Attempted to send a bulk request but Elasticsearch appears to be unreachable or down",
+          message: e.message, exception: e.class, will_retry_in_seconds: sleep_interval
         )
-        @logger.debug("Failed actions for last bad bulk request!", :actions => actions)
+        @logger.debug? && @logger.debug("Failed actions for last bad bulk request", :actions => actions)
 
         # We retry until there are no errors! Errors should all go to the retry queue
         sleep_interval = sleep_for_interval(sleep_interval)
@@ -280,20 +281,19 @@ module LogStash; module PluginMixins; module ElasticSearch
         retry unless @stopping.true?
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::NoConnectionAvailableError => e
         @logger.error(
-          "Attempted to send a bulk request to elasticsearch, but no there are no living connections in the connection pool. Perhaps Elasticsearch is unreachable or down?",
-          :error_message => e.message,
-          :class => e.class.name,
-          :will_retry_in_seconds => sleep_interval
+          "Attempted to send a bulk request but there are no living connections in the pool " +
+          "(perhaps Elasticsearch is unreachable or down?)",
+          message: e.message, exception: e.class, will_retry_in_seconds: sleep_interval
         )
-        Stud.stoppable_sleep(sleep_interval) { @stopping.true? }
-        sleep_interval = next_sleep_interval(sleep_interval)
+
+        sleep_interval = sleep_for_interval(sleep_interval)
         @bulk_request_metrics.increment(:failures)
         retry unless @stopping.true?
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         @bulk_request_metrics.increment(:failures)
         log_hash = {:code => e.response_code, :url => e.url.sanitized.to_s}
         log_hash[:body] = e.response_body if @logger.debug? # Generally this is too verbose
-        message = "Encountered a retryable error. Will Retry with exponential backoff "
+        message = "Encountered a retryable error (will retry with exponential backoff)"
 
         # We treat 429s as a special case because these really aren't errors, but
         # rather just ES telling us to back off a bit, which we do.
@@ -307,17 +307,12 @@ module LogStash; module PluginMixins; module ElasticSearch
 
         sleep_interval = sleep_for_interval(sleep_interval)
         retry
-      rescue => e
-        # Stuff that should never happen
-        # For all other errors print out full connection issues
+      rescue => e # Stuff that should never happen - print out full connection issues
         @logger.error(
-          "An unknown error occurred sending a bulk request to Elasticsearch. We will retry indefinitely",
-          :error_message => e.message,
-          :error_class => e.class.name,
-          :backtrace => e.backtrace
+          "An unknown error occurred sending a bulk request to Elasticsearch (will retry indefinitely)",
+          message: e.message, exception: e.class, backtrace: e.backtrace
         )
-
-        @logger.debug("Failed actions for last bad bulk request!", :actions => actions)
+        @logger.debug? && @logger.debug("Failed actions for last bad bulk request", :actions => actions)
 
         sleep_interval = sleep_for_interval(sleep_interval)
         @bulk_request_metrics.increment(:failures)
@@ -330,6 +325,16 @@ module LogStash; module PluginMixins; module ElasticSearch
       # See more in: https://github.com/elastic/logstash/issues/8064
       respond_to?(:execution_context) && execution_context.respond_to?(:dlq_writer) &&
         !execution_context.dlq_writer.inner_writer.is_a?(::LogStash::Util::DummyDeadLetterQueueWriter)
+    end
+
+    EMPTY_HASH = {}.freeze
+
+    def dig_value(val, *keys)
+      keys.each do |key|
+        val = val.fetch(key, EMPTY_HASH)
+        return nil if val == EMPTY_HASH
+      end
+      val
     end
   end
 end; end; end

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -220,8 +220,15 @@ module LogStash; module PluginMixins; module ElasticSearch
         return
       end
 
+      responses = bulk_response["items"]
+      if responses.size != actions.size # can not map action -> response reliably
+        msg = "Sent #{actions.size} documents but Elasticsearch returned #{responses.size} responses"
+        @logger.debug? && @logger.debug(msg, actions: actions, responses: responses)
+        fail("#{msg} (likely a bug with _bulk endpoint)")
+      end
+
       actions_to_retry = []
-      bulk_response["items"].each_with_index do |response,idx|
+      responses.each_with_index do |response,idx|
         action_type, action_props = response.first
 
         status = action_props["status"]

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -142,8 +142,7 @@ module LogStash; module PluginMixins; module ElasticSearch
       cluster_info = client.get('/')
       plugin_metadata.set(:cluster_uuid, cluster_info['cluster_uuid'])
     rescue => e
-      # TODO introducing this logging message breaks many tests that need refactoring
-      # @logger.error("Unable to retrieve elasticsearch cluster uuid", error => e.message)
+      @logger.error("Unable to retrieve Elasticsearch cluster uuid", message: e.message, exception: e.class, backtrace: e.backtrace)
     end
 
     def retrying_submit(actions)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -23,13 +23,13 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "manticore", '>= 0.5.4', '< 1.0.0'
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
-  s.add_runtime_dependency 'cabin', ['~> 0.6']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.0'
 
   s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'flores'
+  s.add_development_dependency 'cabin', ['~> 0.6']
   # Still used in some specs, we should remove this ASAP
   s.add_development_dependency 'elasticsearch'
 end

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -8,6 +8,7 @@ require_relative "support/elasticsearch/api/actions/get_ilm_policy"
 require_relative "support/elasticsearch/api/actions/put_ilm_policy"
 
 require 'json'
+require 'cabin'
 
 unless defined?(LogStash::OSS)
   LogStash::OSS = ENV['DISTRIBUTION'] != "default"

--- a/spec/integration/outputs/sniffer_spec.rb
+++ b/spec/integration/outputs/sniffer_spec.rb
@@ -1,4 +1,3 @@
-require "logstash/devutils/rspec/spec_helper"
 require_relative "../../../spec/es_spec_helper"
 require "logstash/outputs/elasticsearch/http_client"
 require "json"

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -1,5 +1,6 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/elasticsearch/http_client"
+require 'cabin'
 
 describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
   let(:logger) { Cabin::Channel.get }

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -1,6 +1,6 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/elasticsearch/http_client"
-require "json"
+require 'cabin'
 
 describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   let(:logger) { Cabin::Channel.get }

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -311,7 +311,7 @@ describe LogStash::Outputs::ElasticSearch do
 
     before do
       # Expect a timeout to be logged.
-      expect(subject.logger).to receive(:error).with(/Attempted to send a bulk request to Elasticsearch/i, anything).at_least(:once)
+      expect(subject.logger).to receive(:error).with(/Attempted to send a bulk request/i, anything).at_least(:once)
       expect(subject.client).to receive(:bulk).at_least(:twice).and_call_original
     end
 
@@ -331,7 +331,7 @@ describe LogStash::Outputs::ElasticSearch do
       let(:event) { LogStash::Event.new("myactionfield" => "update", "message" => "blah") }
 
       it "should interpolate the requested action value when creating an event_action_tuple" do
-        expect(subject.event_action_tuple(event).first).to eql("update")
+        expect(subject.send(:event_action_tuple, event).first).to eql("update")
       end
     end
 
@@ -341,7 +341,7 @@ describe LogStash::Outputs::ElasticSearch do
       let(:event) { LogStash::Event.new("myactionfield" => "update", "message" => "blah") }
 
       it "should obtain specific action's params from event_action_tuple" do
-        expect(subject.event_action_tuple(event)[1]).to include(:_upsert)
+        expect(subject.send(:event_action_tuple, event)[1]).to include(:_upsert)
       end
     end
 
@@ -362,7 +362,7 @@ describe LogStash::Outputs::ElasticSearch do
       let(:event) { LogStash::Event.new("pipeline" => "my-ingest-pipeline") }
 
       it "should interpolate the pipeline value and set it" do
-        expect(subject.event_action_tuple(event)[1]).to include(:pipeline => "my-ingest-pipeline")
+        expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
       end
     end
 
@@ -372,7 +372,7 @@ describe LogStash::Outputs::ElasticSearch do
       let(:event) { LogStash::Event.new("pipeline" => "") }
 
       it "should interpolate the pipeline value but not set it because it is empty" do
-        expect(subject.event_action_tuple(event)[1]).not_to include(:pipeline)
+        expect(subject.send(:event_action_tuple, event)[1]).not_to include(:pipeline)
       end
     end
   end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -325,6 +325,11 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   describe "the action option" do
+
+    before do
+      allow(subject).to receive(:install_template)
+    end
+
     context "with a sprintf action" do
       let(:options) { {"action" => "%{myactionfield}" } }
 
@@ -356,6 +361,11 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   describe "the pipeline option" do
+
+    before do
+      allow(subject).to receive(:install_template)
+    end
+
     context "with a sprintf and set pipeline" do
       let(:options) { {"pipeline" => "%{pipeline}" } }
 
@@ -409,6 +419,10 @@ describe LogStash::Outputs::ElasticSearch do
     let(:event) { LogStash::Event.new("myactionfield" => "update", "message" => "blah") }
     let(:options) { { 'retry_on_conflict' => num_retries } }
 
+    before do
+      allow(subject).to receive(:install_template)
+    end
+
     context "with a regular index" do
       let(:options) { super.merge("action" => "index") }
 
@@ -443,6 +457,10 @@ describe LogStash::Outputs::ElasticSearch do
     let(:retry_max_interval) { 64 }
     let(:options) { { "retry_max_interval" => retry_max_interval } }
 
+    before do
+      allow(subject).to receive(:install_template)
+    end
+
     it "should double the given value" do
       expect(subject.next_sleep_interval(2)).to eql(4)
       expect(subject.next_sleep_interval(32)).to eql(64)
@@ -463,6 +481,8 @@ describe LogStash::Outputs::ElasticSearch do
     let(:do_register) { false }
 
     before :each do
+      allow(subject).to receive(:install_template)
+
       allow(::Manticore::Client).to receive(:new).with(any_args).and_call_original
     end
 
@@ -507,6 +527,10 @@ describe LogStash::Outputs::ElasticSearch do
     end
 
     context "using url hosts" do
+
+      before do
+        allow(subject).to receive(:install_template)
+      end
 
       context "with embedded query parameters" do
         let(:options) {
@@ -692,7 +716,11 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   describe "custom headers" do
-    let(:manticore_options) { subject.client.pool.adapter.manticore.instance_variable_get(:@options) } 
+    let(:manticore_options) { subject.client.pool.adapter.manticore.instance_variable_get(:@options) }
+
+    before do
+      allow(subject).to receive(:install_template)
+    end
 
     context "when set" do
       let(:headers) { { "X-Thing" => "Test" } }
@@ -713,6 +741,10 @@ describe LogStash::Outputs::ElasticSearch do
     let(:manticore_options) { subject.client.pool.adapter.manticore.instance_variable_get(:@options) }
     let(:api_key) { "some_id:some_api_key" }
     let(:base64_api_key) { "ApiKey c29tZV9pZDpzb21lX2FwaV9rZXk=" }
+
+    before do
+      allow(subject).to receive(:install_template)
+    end
 
     context "when set without ssl" do
       let(:do_register) { false } # this is what we want to test, so we disable the before(:each) call

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1,6 +1,7 @@
 require_relative "../../../spec/es_spec_helper"
 require "base64"
 require "flores/random"
+require 'concurrent/atomic/count_down_latch'
 require "logstash/outputs/elasticsearch"
 
 describe LogStash::Outputs::ElasticSearch do
@@ -795,6 +796,35 @@ describe LogStash::Outputs::ElasticSearch do
         expect { subject.register }.to raise_error LogStash::ConfigurationError, /Multiple authentication options are specified/
       end
     end
+  end
+
+  describe "post-register logging" do
+    let(:do_register) { false }
+    let(:logger) { subject.logger }
+
+    before do
+      allow(logger).to receive(:error) # expect tracking
+      # emulate 'successful' ES connection on the same thread
+      expect(subject).to receive(:after_successful_connection) { |&block| block.call }
+      allow(subject).to receive(:stop_after_successful_connection_thread)
+    end
+
+    it "logs inability to retrieve uuid" do
+      allow(subject).to receive(:install_template)
+      allow(subject).to receive(:ilm_in_use?).and_return nil
+      subject.register
+
+      expect(logger).to have_received(:error).with(/Unable to retrieve Elasticsearch cluster uuid/i, anything)
+    end if LOGSTASH_VERSION >= '7.0.0'
+
+    it "logs template install failure" do
+      allow(subject).to receive(:discover_cluster_uuid)
+      allow(subject).to receive(:ilm_in_use?).and_return nil
+      subject.register
+
+      expect(logger).to have_received(:error).with(/Failed to install template/i, anything)
+    end
+
   end
 
   @private

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -12,6 +12,7 @@ describe "whitelisting error types in expected behavior" do
   before :each do
     allow(subject.logger).to receive(:warn)
     allow(subject).to receive(:maximum_seen_major_version).and_return(0)
+    allow(subject).to receive(:install_template)
 
     subject.register
 

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -39,7 +39,7 @@ describe "whitelisting error types in expected behavior" do
 
   describe "when failure logging is enabled for everything" do
     it "should log a failure on the action" do
-      expect(subject.logger).to have_received(:warn).with("Failed action.", anything)
+      expect(subject.logger).to have_received(:warn).with("Failed action", anything)
     end
   end
 
@@ -47,7 +47,7 @@ describe "whitelisting error types in expected behavior" do
     let(:settings) { super.merge("failure_type_logging_whitelist" => ["document_already_exists_exception"]) }
 
     it "should log a failure on the action" do
-      expect(subject.logger).not_to have_received(:warn).with("Failed action.", anything)
+      expect(subject.logger).not_to have_received(:warn).with("Failed action", anything)
     end
   end
 


### PR DESCRIPTION
- re-invent error logging (disabled previously) `happening after successful_connection` (from install template etc.)
- unified logging syntax - use Capitalized messages without `.` or `!` logical ends 
(might be just me but I never appreciate logs 'screaming' at me with `!`)
- improved logging when ES returns invalid bulk response (fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/989)