### PR TITLE
Support TLS certificate & key pair

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -333,7 +333,9 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-ilm_policy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ilm_rollover_alias>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-tls_certificate>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-tls_private_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-manage_template>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-parameters>> |<<hash,hash>>|No
@@ -737,6 +739,24 @@ For weekly indexes ISO 8601 format is recommended, eg. logstash-%{+xxxx.ww}.
 Logstash uses
 http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[Joda
 formats] for the index pattern from event timestamp.
+
+[id="plugins-{type}s-{plugin}-tls_certificate"]
+===== `tls_certificate`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+The tls_certificate used to present a client certificate to the server.
+It accepts .pem formatted files
+
+[id="plugins-{type}s-{plugin}-tls_private_key"]
+===== `tls_private_key`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+The tls_private_key used to present a client private key to the server, to be used in conjunction with tls_certificate.
+It accepts .pkcs8 formatted files
 
 
 [id="plugins-{type}s-{plugin}-keystore"]

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -66,6 +66,11 @@ module LogStash; module PluginMixins; module ElasticSearch
         # Set the keystore password
         :keystore_password => { :validate => :password },
 
+        # The certificate to present to the server. (only pem format supported)
+        :tls_certificate => { :validate => :path },
+        # The private key to present to the server. (only pkcs8 format supported)
+        :tls_private_key => { :validate => :path },
+
         # This setting asks Elasticsearch for the list of all cluster nodes and adds them to the hosts list.
         # Note: This will return ALL nodes with HTTP enabled (including master nodes!). If you use
         # this with master nodes, you probably want to disable HTTP on them by setting

--- a/spec/unit/outputs/elasticsearch_ssl_spec.rb
+++ b/spec/unit/outputs/elasticsearch_ssl_spec.rb
@@ -76,6 +76,121 @@ describe "SSL option" do
       end.and_call_original
       subject.register
     end
+  end
 
+  context "when using ssl with pem-encoded client certificates" do
+    let(:tls_certificate) { Stud::Temporary.file.path }
+    let(:tls_private_key) { Stud::Temporary.file.path }
+    before do
+      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{tls_private_key} -out #{tls_certificate}`
+    end
+
+    after :each do
+      File.delete(tls_certificate)
+      File.delete(tls_private_key)
+      subject.close
+    end
+
+    subject do
+      settings = {
+        "hosts" => "node01",
+        "ssl" => true,
+        "tls_certificate" => tls_certificate,
+        "tls_private_key" => tls_private_key
+      }
+      next LogStash::Outputs::ElasticSearch.new(settings)
+    end
+
+    it "should pass the pem certificate parameters to the ES client" do
+      expect(::Manticore::Client)
+        .to receive(:new) { |args| expect(args[:ssl]).to include(:client_cert => tls_certificate, :client_key => tls_private_key) }
+        .and_return(manticore_double)
+      subject.register
+    end
+
+  end
+  
+  context "when using both pem-encoded and jks-encoded client certificates" do
+    let(:tls_certificate) { Stud::Temporary.file.path }
+    let(:tls_private_key) { Stud::Temporary.file.path }
+    before do
+      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{tls_private_key} -out #{tls_certificate}`
+    end
+
+    after :each do
+      File.delete(tls_private_key)
+      File.delete(tls_certificate)
+      subject.close
+    end
+
+    subject do
+      settings = {
+        "hosts" => "node01",
+        "ssl" => true,
+        "tls_certificate" => tls_certificate,
+        "tls_private_key" => tls_private_key,
+        # just any file will do for this test
+        "keystore" => tls_certificate
+      }
+      next LogStash::Outputs::ElasticSearch.new(settings)
+    end
+
+    it "should fail to load the plugin" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+  
+  context "when configuring only tls_certificate but ommitting the private_key" do
+    let(:tls_certificate) { Stud::Temporary.file.path }
+    let(:tls_private_key) { Stud::Temporary.file.path }
+    before do
+      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{tls_private_key} -out #{tls_certificate}`
+    end
+
+    after :each do
+      File.delete(tls_private_key)
+      File.delete(tls_certificate)
+      subject.close
+    end
+
+    subject do
+      settings = {
+        "hosts" => "node01",
+        "ssl" => true,
+        "tls_certificate" => tls_certificate,
+      }
+      next LogStash::Outputs::ElasticSearch.new(settings)
+    end
+
+    it "should fail to load the plugin" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  context "when configuring only private_key but ommitting the tls_certificate" do
+    let(:tls_certificate) { Stud::Temporary.file.path }
+    let(:tls_private_key) { Stud::Temporary.file.path }
+    before do
+      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{tls_private_key} -out #{tls_certificate}`
+    end
+
+    after :each do
+      File.delete(tls_private_key)
+      File.delete(tls_certificate)
+      subject.close
+    end
+
+    subject do
+      settings = {
+        "hosts" => "node01",
+        "ssl" => true,
+        "tls_private_key" => tls_private_key,
+      }
+      next LogStash::Outputs::ElasticSearch.new(settings)
+    end
+
+    it "should fail to load the plugin" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
   end
 end


### PR DESCRIPTION
Integrated the support for a "regular" certificate & key pair (since it is supported on Manticore)
The certificate only supports PEM, the private key only support PKCS#8

_**Background info:** My use case is to predominantly use this in combination with Hashicorp Vault, where the creation of both these (a pem cert and pkcs8 key) comes out of the box_ 

Addresses https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/672 to some extend