### PR TITLE
docs: eliminate confusing and obsolete http compression details

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -233,16 +233,11 @@ not reevaluate its DNS value while the keepalive is in effect.
 
 ==== HTTP Compression
 
-This plugin supports request and response compression. Response compression is
-enabled by default for HTTP and for Elasticsearch versions 5.0 and later.
+This plugin supports request compression, and will handle compressed responses
+from Elasticsearch.
 
-You don't have to set any configs in Elasticsearch for it to send back a
-compressed response. For versions before 5.0, or if HTTPS is enabled,
-`http.compression` must be set to `true` {ref}/modules-http.html#modules-http[in
-Elasticsearch] to take advantage of response compression when using this plugin.
-
-For requests compression, regardless of the Elasticsearch version, enable the
-`http_compression` setting in the Logstash config file.
+To enable request compression, use the <<plugins-{type}s-{plugin}-http_compression>>
+setting on this plugin.
 
 ==== Authentication
 


### PR DESCRIPTION
The "HTTP Compression" section of the docs leaks a lot of obsolete details about how Elasticsearch needs to be configured, which obscures how this plugin is used.