### PR TITLE
Fix: DLQ expects us to pass down an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.0.1
+ - Fix: DLQ regression shipped in 11.0.0 [#1012](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1012)
+
 ## 11.0.0
  - Feat: Data stream support [#988](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/988)
  - Refactor: reviewed logging format + restored ES (initial) setup error logging

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -392,7 +392,21 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     params[:version] = event.sprintf(@version) if @version
     params[:version_type] = event.sprintf(@version_type) if @version_type
 
-    [action, params, event.to_hash]
+    EventActionTuple.new(action, params, event)
+  end
+
+  class EventActionTuple < Array # TODO: acting as an array for compatibility
+
+    def initialize(action, params, event, event_data = nil)
+      super(3)
+      self[0] = action
+      self[1] = params
+      self[2] = event_data || event.to_hash
+      @event = event
+    end
+
+    attr_reader :event
+
   end
 
   # @return Hash (initial) parameters for given event

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -146,7 +146,7 @@ module LogStash module Outputs class ElasticSearch
     def data_stream_event_action_tuple(event)
       event_data = event.to_hash
       data_stream_event_sync(event_data) if data_stream_sync_fields
-      ['create', common_event_params(event), event_data] # action always 'create'
+      EventActionTuple.new('create', common_event_params(event), event, event_data)
     end
 
     DATA_STREAM_SYNC_FIELDS = [ 'type', 'dataset', 'namespace' ].freeze

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -200,8 +200,9 @@ module LogStash; module PluginMixins; module ElasticSearch
     def handle_dlq_status(message, action, status, response)
       # To support bwc, we check if DLQ exists. otherwise we log and drop event (previous behavior)
       if @dlq_writer
+        event, action = action.event, [action[0], action[1], action[2]]
         # TODO: Change this to send a map with { :status => status, :action => action } in the future
-        @dlq_writer.write(action[2], "#{message} status: #{status}, action: #{action}, response: #{response}")
+        @dlq_writer.write(event, "#{message} status: #{status}, action: #{action}, response: #{response}")
       else
         if dig_value(response, 'index', 'error', 'type') == 'invalid_index_name_exception'
           level = :error

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.0.0'
+  s.version         = '11.0.1'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -847,7 +847,7 @@ describe LogStash::Outputs::ElasticSearch do
         subject.send(:submit, event_action_tuples)
       end
 
-    end
+    end if LOGSTASH_VERSION > '7.0'
   end
 
   describe "custom headers" do


### PR DESCRIPTION
since [Data Streams](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/988), we refactored to pass down event data directly instead of the [previous `event.to_hash` mapping in `safe_bulk`](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/988/files#diff-221ddb62bde6d62966fab1051387ded7513fffd575cf0706a5f3a94ad2d31307L270) (doing so potentially on every retry)

there seemed to have been no reason to keep the original event around (well turns except with DLQ).

besides practical reasons the early `event.to_hash` also addressed a requirement to ... [sync data stream fields without effecting the original event](https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/v11.0.0/lib/logstash/outputs/elasticsearch/data_stream_support.rb#L148).

unfortunately this broke DLQ support, which expects a `LS::Event` passed on [`write(event, reason)`](https://github.com/elastic/logstash/blob/v7.12.0/logstash-core/src/main/java/org/logstash/common/AbstractDeadLetterQueueWriterExt.java#L195-L202)


resolves https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1013