### PR TITLE
Add preflight check on Elasticsearch before connecting

### DIFF
--- a/.ci/Dockerfile.elasticsearch
+++ b/.ci/Dockerfile.elasticsearch
@@ -11,6 +11,8 @@ RUN rm -f $es_path/config/scripts
 COPY --chown=elasticsearch:elasticsearch spec/fixtures/test_certs/* $es_path/config/test_certs/
 COPY --chown=elasticsearch:elasticsearch .ci/elasticsearch-run.sh $es_path/
 
+RUN echo "xpack.security.enabled: false" >> $es_yml
+
 RUN if [ "$SECURE_INTEGRATION" = "true" ] ; then echo "xpack.security.http.ssl.enabled: $SECURE_INTEGRATION" >> $es_yml; fi
 RUN if [ "$SECURE_INTEGRATION" = "true" ] ; then echo "xpack.security.http.ssl.key: $es_path/config/test_certs/test.key" >> $es_yml; fi
 RUN if [ "$SECURE_INTEGRATION" = "true" ] ; then echo "xpack.security.http.ssl.certificate: $es_path/config/test_certs/test.crt" >> $es_yml; fi

--- a/.ci/Dockerfile.elasticsearch
+++ b/.ci/Dockerfile.elasticsearch
@@ -11,8 +11,6 @@ RUN rm -f $es_path/config/scripts
 COPY --chown=elasticsearch:elasticsearch spec/fixtures/test_certs/* $es_path/config/test_certs/
 COPY --chown=elasticsearch:elasticsearch .ci/elasticsearch-run.sh $es_path/
 
-RUN echo "xpack.security.enabled: false" >> $es_yml
-
 RUN if [ "$SECURE_INTEGRATION" = "true" ] ; then echo "xpack.security.http.ssl.enabled: $SECURE_INTEGRATION" >> $es_yml; fi
 RUN if [ "$SECURE_INTEGRATION" = "true" ] ; then echo "xpack.security.http.ssl.key: $es_path/config/test_certs/test.key" >> $es_yml; fi
 RUN if [ "$SECURE_INTEGRATION" = "true" ] ; then echo "xpack.security.http.ssl.certificate: $es_path/config/test_certs/test.crt" >> $es_yml; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.2.0
+ - Added preflight checks on Elasticsearch [#1026](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1026)
+
 ## 11.1.0
  - Feat: add `user-agent` header passed to the Elasticsearch HTTP connection [#1038](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1038)
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -251,7 +251,12 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
             end
           else
             logger.info("URL doesn't point to Elasticsearch service", url: url.sanitized.to_s )
-            @state_mutex.synchronize { meta[:state] = :dead }
+            es_version = get_es_version(url)
+            @state_mutex.synchronize do
+              meta[:version] = es_version
+              set_last_es_version(es_version, url)
+              meta[:state] = :dead
+            end
           end
         rescue HostUnreachableError, BadResponseCodeError => e
           logger.warn("Attempted to resurrect connection to dead ES instance, but got an error", url: url.sanitized.to_s, exception: e.class, message: e.message)

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -281,8 +281,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       if version >= Gem::Version.new('6.0.0') && version < Gem::Version.new('7.0.0')
         return valid_tagline?(version_info)
       elsif version >= Gem::Version.new('7.0.0') && version < Gem::Version.new('7.14.0')
-        build_flavour = version_info["version"]['build_flavour']
-        return false if build_flavour.nil? || build_flavour != 'default' || !valid_tagline?(version_info)
+        build_flavor = version_info["version"]['build_flavor']
+        return false if build_flavor.nil? || build_flavor != 'default' || !valid_tagline?(version_info)
       else
         # case >= 7.14
         lower_headers = response.headers.transform_keys {|key| key.to_s.downcase }

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -297,7 +297,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
     def valid_tagline?(version_info)
       tagline = version_info['tagline']
-     tagline == "You Know, for Search"
+      tagline == "You Know, for Search"
     end
 
     def stop_resurrectionist

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -287,7 +287,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         # case >= 7.14
         lower_headers = response.headers.transform_keys {|key| key.to_s.downcase }
         product_header = lower_headers['x-elastic-product']
-        return false if product_header.nil? || product_header != 'Elasticsearch'
+        return false if product_header != 'Elasticsearch'
       end
       return true
     rescue => e

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -297,8 +297,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
     def valid_tagline?(version_info)
       tagline = version_info['tagline']
-      return false if tagline.nil? || tagline != "You Know, for Search"
-      true
+     tagline == "You Know, for Search"
     end
 
     def stop_resurrectionist

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -291,7 +291,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       end
       return true
     rescue => e
-      logger.error("Unable to version version information", url: url.sanitized.to_s, exception: e.class, message: e.message)
+      logger.error("Unable to retrieve Elasticsearch version", url: url.sanitized.to_s, exception: e.class, message: e.message)
       false
     end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -244,7 +244,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           # when called from resurrectionist skip the product check done during register phase
           if register_phase
             if !elasticsearch?(url)
-              raise LogStash::ConfigurationError, "Not a valid Elasticsearch"
+              raise LogStash::ConfigurationError, "Could not connect to a compatible version of Elasticsearch"
             end
           end
           # If no exception was raised it must have succeeded!

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -37,6 +37,9 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     ROOT_URI_PATH = '/'.freeze
     LICENSE_PATH = '/_license'.freeze
 
+    VERSION_6_TO_7 = Gem::Requirement.new([">= 6.0.0", "< 7.0.0"])
+    VERSION_7_TO_7_14 = Gem::Requirement.new([">= 7.0.0", "< 7.14.0"])
+
     DEFAULT_OPTIONS = {
       :healthcheck_path => ROOT_URI_PATH,
       :sniffing_path => "/_nodes/http",
@@ -263,7 +266,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
     def elasticsearch?(url)
       begin
-        response = perform_request_to_url(url, :get, "/")
+        response = perform_request_to_url(url, :get, ROOT_URI_PATH)
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         return false if response.code == 401 || response.code == 403
         raise e
@@ -275,9 +278,9 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       version = Gem::Version.new(version_info["version"]['number'])
       return false if version < Gem::Version.new('6.0.0')
 
-      if version >= Gem::Version.new('6.0.0') && version < Gem::Version.new('7.0.0')
+      if VERSION_6_TO_7.satisfied_by?(version)
         return valid_tagline?(version_info)
-      elsif version >= Gem::Version.new('7.0.0') && version < Gem::Version.new('7.14.0')
+      elsif VERSION_7_TO_7_14.satisfied_by?(version)
         build_flavor = version_info["version"]['build_flavor']
         return false if build_flavor.nil? || build_flavor != 'default' || !valid_tagline?(version_info)
       else

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -285,7 +285,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         return false if build_flavour.nil? || build_flavour != 'default' || !valid_tagline?(version_info)
       else
         # case >= 7.14
-        product_header = response.headers['x-elastic-product']
+        lower_headers = response.headers.transform_keys {|key| key.to_s.downcase }
+        product_header = lower_headers['x-elastic-product']
         return false if product_header.nil? || product_header != 'Elasticsearch'
       end
       return true

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'flores'
   s.add_development_dependency 'cabin', ['~> 0.6']
   s.add_development_dependency 'webrick'
+  s.add_development_dependency 'webmock'
   # Still used in some specs, we should remove this ASAP
   s.add_development_dependency 'elasticsearch'
 end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.1.0'
+  s.version         = '11.2.0'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -192,10 +192,10 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
     context "with multiple URLs in the list" do
       let(:version_ok) do
         MockResponse.new(200, {"tagline" => "You Know, for Search",
-                                       "version" => {
-                                         "number" => '7.13.0',
-                                         "build_flavour" => 'default'}
-                                      })
+                               "version" => {
+                                 "number" => '7.13.0',
+                                 "build_flavor" => 'default'}
+                               })
       end
 
       before :each do
@@ -417,21 +417,21 @@ describe "#elasticsearch?" do
   end
 
   context "when connecting to a cluster with version in [7.0.0..7.14.0)" do
-    it "must be successful is 'build_flavour' is 'default' and tagline is correct" do
+    it "must be successful is 'build_flavor' is 'default' and tagline is correct" do
       allow(adapter).to receive(:perform_request)
                                 .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavour": "default"}, "tagline": "You Know, for Search"}))
+                                .and_return(MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavor": "default"}, "tagline": "You Know, for Search"}))
       expect(subject.elasticsearch?(url)).to be true
     end
 
-    it "should fail if 'build_flavour' is not 'default' and tagline is correct" do
+    it "should fail if 'build_flavor' is not 'default' and tagline is correct" do
       allow(adapter).to receive(:perform_request)
                                 .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavour": "oss"}, "tagline": "You Know, for Search"}))
+                                .and_return(MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavor": "oss"}, "tagline": "You Know, for Search"}))
       expect(subject.elasticsearch?(url)).to be false
     end
 
-    it "should fail if 'build_flavour' is not present and tagline is correct" do
+    it "should fail if 'build_flavor' is not present and tagline is correct" do
       allow(adapter).to receive(:perform_request)
                                 .with(anything, :get, "/", anything, anything)
                                 .and_return(MockResponse.new(200, {"version": {"number": "7.5.0"}, "tagline": "You Know, for Search"}))

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -61,7 +61,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
           expect(adapter).to receive(:perform_request).with(anything, :head, "/", anything, anything) do |url, _, _, _, _|
             expect(url.path).to be_empty
           end
-          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Not a valid Elasticsearch")
+          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Could not connect to a compatible version of Elasticsearch")
         end
       end
 
@@ -72,7 +72,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
           expect(adapter).to receive(:perform_request).with(anything, :head, eq(healthcheck_path), anything, anything) do |url, _, _, _, _|
             expect(url.path).to be_empty
           end
-          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Not a valid Elasticsearch")
+          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Could not connect to a compatible version of Elasticsearch")
         end
       end
     end

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -355,6 +355,8 @@ describe "#elasticsearch?" do
 
   let(:url) { ::LogStash::Util::SafeURI.new("http://localhost:9200") }
 
+  after(:all) { WebMock.disable! }
+
   context "in case HTTP error code" do
     it "should fail for 401" do
       stub_request(:get, "localhost:9200").to_return(status: 401)

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -61,7 +61,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
           expect(adapter).to receive(:perform_request).with(anything, :head, "/", anything, anything) do |url, _, _, _, _|
             expect(url.path).to be_empty
           end
-          subject.healthcheck!
+          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Not a valid Elasticsearch")
         end
       end
 
@@ -72,7 +72,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
           expect(adapter).to receive(:perform_request).with(anything, :head, eq(healthcheck_path), anything, anything) do |url, _, _, _, _|
             expect(url.path).to be_empty
           end
-          subject.healthcheck!
+          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Not a valid Elasticsearch")
         end
       end
     end
@@ -244,8 +244,14 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
       ::LogStash::Util::SafeURI.new("http://otherhost:9201")
     ] }
 
+    let(:valid_response) { MockResponse.new(200, {"tagline" => "You Know, for Search",
+                                                          "version" => {
+                                                            "number" => '7.13.0',
+                                                            "build_flavor" => 'default'}
+                                                          }) }
+
     before(:each) do
-      allow(subject).to receive(:perform_request_to_url).and_return(nil)
+      allow(subject).to receive(:perform_request_to_url).and_return(valid_response)
       subject.start
     end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -156,7 +156,7 @@ describe LogStash::Outputs::ElasticSearch do
         include_examples("an authenticated config")
       end
 
-      context 'claud_auth also set' do
+      context 'cloud_auth also set' do
         let(:do_register) { false } # this is what we want to test, so we disable the before(:each) call
         let(:options) { { "user" => user, "password" => password, "cloud_auth" => "elastic:my-passwd-00" } }
 


### PR DESCRIPTION
Update client behavior to match functionality of 7.14+

----

## Tasks
- [x] change error message from `LogStash::ConfigurationError: Not a valid Elasticsearch` to `could not connect to a compatible version of Elasticsearch`