### PR TITLE
Refactor: review manticore error handling/logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.3.2
+ - Refactor: review manticore error handling/logging [#1029](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1029)
+   - Java causes on connection related exceptions will now be extra logged when plugin is logging at debug level
+
 ## 11.3.1
  - ECS-related fixes [#1046](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1046)
    - Data Streams requirement on ECS is properly enforced when running on Logstash 8, and warned about when running on Logstash 7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.3.2
- - Refactor: review manticore error handling/logging [#1029](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1029)
+ - Refactor: review manticore error handling/logging, logging originating cause in case of connection related error when debug level is enabled [#1029](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1029)
    - Java causes on connection related exceptions will now be extra logged when plugin is logging at debug level
 
 ## 11.3.1

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -322,8 +322,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
       adapter_options[:headers] = client_settings[:headers] if client_settings[:headers]
 
-      adapter_class = ::LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter
-      adapter = adapter_class.new(@logger, adapter_options)
+      ::LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(@logger, adapter_options)
     end
 
     def prepare_user_agent

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -126,9 +126,6 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
 
       parsed_path_and_query = java.net.URI.new(path_and_query)
 
-      query = request_uri.query
-      parsed_query = parsed_path_and_query.query
-
       new_query_parts = [request_uri.query, parsed_path_and_query.query].select do |part|
         part && !part.empty? # Skip empty nil and ""
       end

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -72,8 +72,9 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         # We want to block for our usage, this will wait for the response to finish
         resp.call
       rescue ::Manticore::Timeout, ::Manticore::SocketException, ::Manticore::ClientProtocolException,
-             ::Manticore::ResolutionFailure, ::Manticore::SocketTimeout => e
-        @logger.debug("Failed to perform request", message: e.message, exception: e.class)
+             ::Manticore::ResolutionFailure,
+             ::Manticore::UnknownException => e
+        @logger.info("Failed to perform request", message: e.message, exception: e.class, cause: e.respond_to?(:cause) && e.cause)
         raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError.new(e, url)
       end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -7,9 +7,9 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
   class ManticoreAdapter
     attr_reader :manticore, :logger
 
-    def initialize(logger, options={})
+    def initialize(logger, options)
       @logger = logger
-      options = options.clone || {}
+      options = options.dup
       options[:ssl] = options[:ssl] || {}
 
       # We manage our own retries directly, so let's disable them here

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -323,9 +323,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     end
 
     def perform_request_to_url(url, method, path, params={}, body=nil)
-      res = @adapter.perform_request(url, method, path, params, body)
-    rescue *@adapter.host_unreachable_exceptions => e
-      raise HostUnreachableError.new(e, url), "Could not reach host #{e.class}: #{e.message}"
+      @adapter.perform_request(url, method, path, params, body)
     end
 
     def normalize_url(uri)

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -8,12 +8,12 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       attr_reader :url, :response_code, :request_body, :response_body
 
       def initialize(response_code, url, request_body, response_body)
+        super(message)
+
         @response_code = response_code
         @url = url
         @request_body = request_body
         @response_body = response_body
-
-        super(message)
       end
 
       def message
@@ -24,10 +24,10 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       attr_reader :original_error, :url
 
       def initialize(original_error, url)
+        super(message)
+
         @original_error = original_error
         @url = url
-
-        super(message)
       end
 
       def message

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -8,7 +8,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       attr_reader :url, :response_code, :request_body, :response_body
 
       def initialize(response_code, url, request_body, response_body)
-        super(message)
+        super("Got response code '#{response_code}' contacting Elasticsearch at URL '#{url}'")
 
         @response_code = response_code
         @url = url
@@ -16,23 +16,17 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         @response_body = response_body
       end
 
-      def message
-        "Got response code '#{response_code}' contacting Elasticsearch at URL '#{@url}'"
-      end
     end
     class HostUnreachableError < Error;
       attr_reader :original_error, :url
 
       def initialize(original_error, url)
-        super(message)
+        super("Elasticsearch Unreachable: [#{url}][#{original_error.class}] #{original_error.message}")
 
         @original_error = original_error
         @url = url
       end
 
-      def message
-        "Elasticsearch Unreachable: [#{@url}][#{original_error.class}] #{original_error.message}"
-      end
     end
 
     attr_reader :logger, :adapter, :sniffing, :sniffer_delay, :resurrect_delay, :healthcheck_path, :sniffing_path, :bulk_path

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -12,6 +12,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         @url = url
         @request_body = request_body
         @response_body = response_body
+
+        super(message)
       end
 
       def message
@@ -24,6 +26,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       def initialize(original_error, url)
         @original_error = original_error
         @url = url
+
+        super(message)
       end
 
       def message

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.3.1'
+  s.version         = '11.3.2'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/spec/integration/outputs/sniffer_spec.rb
+++ b/spec/integration/outputs/sniffer_spec.rb
@@ -5,7 +5,7 @@ require "socket"
 
 describe "pool sniffer", :integration => true do
   let(:logger) { Cabin::Channel.get }
-  let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger) }
+  let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger, {}) }
   let(:es_host) { get_host_port.split(":").first }
   let(:es_port) { get_host_port.split(":").last }
   let(:es_ip) { IPSocket.getaddress(es_host) }

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -16,7 +16,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
     rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError => e
       expect( e.original_error ).to be_a ::Manticore::ClientStoppedException
     end
-  end\
+  end
   
   describe "auth" do
     let(:user) { "myuser" }

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -12,10 +12,6 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
     subject.close
     expect { subject.perform_request(::LogStash::Util::SafeURI.new("http://localhost:9200"), :get, '/') }.to raise_error(::Manticore::ClientStoppedException)
   end
-
-  it "should implement host unreachable exceptions" do
-    expect(subject.host_unreachable_exceptions).to be_a(Array)
-  end
   
   describe "auth" do
     let(:user) { "myuser" }

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -10,8 +10,13 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
 
   it "should raise an exception if requests are issued after close" do
     subject.close
-    expect { subject.perform_request(::LogStash::Util::SafeURI.new("http://localhost:9200"), :get, '/') }.to raise_error(::Manticore::ClientStoppedException)
-  end
+    begin
+      subject.perform_request(::LogStash::Util::SafeURI.new("http://localhost:9200"), :get, '/')
+      fail 'expected to raise a HostUnreachableError'
+    rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError => e
+      expect( e.original_error ).to be_a ::Manticore::ClientStoppedException
+    end
+  end\
   
   describe "auth" do
     let(:user) { "myuser" }

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -4,7 +4,7 @@ require 'cabin'
 
 describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   let(:logger) { Cabin::Channel.get }
-  let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger) }
+  let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger, {}) }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }
   let(:options) { {:resurrect_delay => 2, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
   let(:es_node_versions) { [ "0.0.0" ] }


### PR DESCRIPTION
This PR moves adapter specific error mapping to the adapter itself.

Second, since Manticore now (>= 0.7.1) retains the [native Java cause](https://github.com/cheald/manticore/pull/96) with the `Manticore::ManticoreException` hierarchy, we also log the Java cause using the Log4J2 logger API (so that we're aware of the exception type, stack trace and any Java causes).

Example:
```
[2021-12-01T13:34:36,057][DEBUG][org.apache.http.conn.ssl.SSLConnectionSocketFactory][main] Starting handshake
[2021-12-01T13:34:36,125][DEBUG][org.apache.http.impl.conn.DefaultManagedHttpClientConnection][main] http-outgoing-0: Shutdown connection
[2021-12-01T13:34:36,126][DEBUG][org.apache.http.impl.execchain.MainClientExec][main] Connection discarded
[2021-12-01T13:34:36,126][DEBUG][org.apache.http.impl.conn.PoolingHttpClientConnectionManager][main] Connection released: [id: 0][route: {s}->https://127.0.0.1:9200][total kept alive: 0; route allocated: 0 of 100; total allocated: 0 of 1000]
[2021-12-01T13:34:36,156][INFO ][logstash.outputs.elasticsearch][main] Failed to perform request {:message=>"Received fatal alert: protocol_version", :exception=>Manticore::ClientProtocolException, :cause=>javax.net.ssl.SSLHandshakeException: Received fatal alert: protocol_version, :backtrace=>["/home/kares/workspace/work/elastic/logstash-7.15.2/vendor/bundle/jruby/2.5.0/gems/manticore-0.7.1-java/lib/manticore/response.rb:36:in `block in initialize'", "/home/kares/workspace/work/elastic/logstash-7.15.2/vendor/bundle/jruby/2.5.0/gems/manticore-0.7.1-java/lib/manticore/response.rb:79:in `call'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb:73:in `perform_request'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/pool.rb:330:in `perform_request_to_url'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/pool.rb:239:in `health_check_request'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/pool.rb:246:in `block in healthcheck!'", "org/jruby/RubyHash.java:1415:in `each'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/pool.rb:244:in `healthcheck!'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/pool.rb:376:in `update_urls'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/pool.rb:93:in `update_initial_urls'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client/pool.rb:87:in `start'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client.rb:358:in `build_pool'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client.rb:63:in `initialize'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client_builder.rb:106:in `create_http_client'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch/http_client_builder.rb:102:in `build'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/plugin_mixins/elasticsearch/common.rb:34:in `build_client'", "/home/kares/workspace/work/elastic/plugins/logstash-output-elasticsearch/lib/logstash/outputs/elasticsearch.rb:279:in `register'", "org/logstash/config/ir/compiler/OutputStrategyExt.java:131:in `register'", "org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java:68:in `register'", "/home/kares/workspace/work/elastic/logstash-7.15.2/logstash-core/lib/logstash/java_pipeline.rb:228:in `block in register_plugins'", "org/jruby/RubyArray.java:1820:in `each'", "/home/kares/workspace/work/elastic/logstash-7.15.2/logstash-core/lib/logstash/java_pipeline.rb:227:in `register_plugins'", "/home/kares/workspace/work/elastic/logstash-7.15.2/logstash-core/lib/logstash/java_pipeline.rb:585:in `maybe_setup_out_plugins'", "/home/kares/workspace/work/elastic/logstash-7.15.2/logstash-core/lib/logstash/java_pipeline.rb:240:in `start_workers'", "/home/kares/workspace/work/elastic/logstash-7.15.2/logstash-core/lib/logstash/java_pipeline.rb:185:in `run'", "/home/kares/workspace/work/elastic/logstash-7.15.2/logstash-core/lib/logstash/java_pipeline.rb:137:in `block in start'"]}
[2021-12-01T13:34:36,225][DEBUG][logstash.outputs.elasticsearch.httpclient.manticoreadapter][main] 
javax.net.ssl.SSLHandshakeException: Received fatal alert: protocol_version
	at sun.security.ssl.Alert.createSSLException(sun/security/ssl/Alert.java:131) ~[?:?]
	at sun.security.ssl.Alert.createSSLException(sun/security/ssl/Alert.java:117) ~[?:?]
	at sun.security.ssl.TransportContext.fatal(sun/security/ssl/TransportContext.java:336) ~[?:?]
	at sun.security.ssl.Alert$AlertConsumer.consume(sun/security/ssl/Alert.java:293) ~[?:?]
	at sun.security.ssl.TransportContext.dispatch(sun/security/ssl/TransportContext.java:185) ~[?:?]
	at sun.security.ssl.SSLTransport.decode(sun/security/ssl/SSLTransport.java:172) ~[?:?]
	at sun.security.ssl.SSLSocketImpl.decode(sun/security/ssl/SSLSocketImpl.java:1426) ~[?:?]
	at sun.security.ssl.SSLSocketImpl.readHandshakeRecord(sun/security/ssl/SSLSocketImpl.java:1336) ~[?:?]
	at sun.security.ssl.SSLSocketImpl.startHandshake(sun/security/ssl/SSLSocketImpl.java:450) ~[?:?]
	at sun.security.ssl.SSLSocketImpl.startHandshake(sun/security/ssl/SSLSocketImpl.java:421) ~[?:?]
	at org.apache.http.conn.ssl.SSLConnectionSocketFactory.createLayeredSocket(org/apache/http/conn/ssl/SSLConnectionSocketFactory.java:394) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.conn.ssl.SSLConnectionSocketFactory.connectSocket(org/apache/http/conn/ssl/SSLConnectionSocketFactory.java:353) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(org/apache/http/impl/conn/DefaultHttpClientConnectionOperator.java:141) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(org/apache/http/impl/conn/PoolingHttpClientConnectionManager.java:353) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.execchain.MainClientExec.establishRoute(org/apache/http/impl/execchain/MainClientExec.java:380) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.execchain.MainClientExec.execute(org/apache/http/impl/execchain/MainClientExec.java:236) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.execchain.ProtocolExec.execute(org/apache/http/impl/execchain/ProtocolExec.java:184) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.execchain.RetryExec.execute(org/apache/http/impl/execchain/RetryExec.java:88) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.execchain.RedirectExec.execute(org/apache/http/impl/execchain/RedirectExec.java:110) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.client.InternalHttpClient.doExecute(org/apache/http/impl/client/InternalHttpClient.java:184) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.client.CloseableHttpClient.execute(org/apache/http/impl/client/CloseableHttpClient.java:71) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.client.CloseableHttpClient.execute(org/apache/http/impl/client/CloseableHttpClient.java:220) ~[httpclient-4.5.2.jar:4.5.2]
	at org.apache.http.impl.client.CloseableHttpClient.execute(org/apache/http/impl/client/CloseableHttpClient.java:164) ~[httpclient-4.5.2.jar:4.5.2]
        ...
```
(the last logging line with the stack-trace is new - hasn't been logged before, stack-traces only show up with `debug` level)