### PR TITLE
Fix referencing Gem classes from global lexical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.2.1
+ - Fix referencing Gem classes from global lexical scope [#1044](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1044)
+
 ## 11.2.0
  - Added preflight checks on Elasticsearch [#1026](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1026)
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -37,8 +37,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     ROOT_URI_PATH = '/'.freeze
     LICENSE_PATH = '/_license'.freeze
 
-    VERSION_6_TO_7 = Gem::Requirement.new([">= 6.0.0", "< 7.0.0"])
-    VERSION_7_TO_7_14 = Gem::Requirement.new([">= 7.0.0", "< 7.14.0"])
+    VERSION_6_TO_7 = ::Gem::Requirement.new([">= 6.0.0", "< 7.0.0"])
+    VERSION_7_TO_7_14 = ::Gem::Requirement.new([">= 7.0.0", "< 7.14.0"])
 
     DEFAULT_OPTIONS = {
       :healthcheck_path => ROOT_URI_PATH,
@@ -275,8 +275,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       version_info = LogStash::Json.load(response.body)
       return false if version_info['version'].nil?
 
-      version = Gem::Version.new(version_info["version"]['number'])
-      return false if version < Gem::Version.new('6.0.0')
+      version = ::Gem::Version.new(version_info["version"]['number'])
+      return false if version < ::Gem::Version.new('6.0.0')
 
       if VERSION_6_TO_7.satisfied_by?(version)
         return valid_tagline?(version_info)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.2.0'
+  s.version         = '11.2.1'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"


### PR DESCRIPTION
Some Gem classes was referenced from open Logstash lexical scope while it should refer from the global.