### PR TITLE
Data streams require ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 11.3.1
+ - ECS-related fixes [#1046](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1046)
+   - Data Streams requirement on ECS is properly enforced when running on Logstash 8, and warned about when running on Logstash 7.
+   - ECS Compatibility v8 can now be selected
+
 ## 11.3.0
  - Adds ECS templates [#1048](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1048)
    - Adds templates for ECS v1 for Elasticsearch 8.x

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -502,7 +502,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       @default_index = "logstash-%{+yyyy.MM.dd}"
       @default_ilm_rollover_alias = "logstash"
       @default_template_name = 'logstash'
-    when :v1
+    when :v1, :v8
       @default_index = "ecs-logstash-%{+yyyy.MM.dd}"
       @default_ilm_rollover_alias = "ecs-logstash"
       @default_template_name = 'ecs-logstash'

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -94,6 +94,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   require "logstash/outputs/elasticsearch/ilm"
   require "logstash/outputs/elasticsearch/data_stream_support"
   require 'logstash/plugin_mixins/ecs_compatibility_support'
+  require 'logstash/plugin_mixins/deprecation_logger_support'
 
   # Protocol agnostic methods
   include(LogStash::PluginMixins::ElasticSearch::Common)
@@ -103,6 +104,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # ecs_compatibility option, provided by Logstash core or the support adapter.
   include(LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8))
+
+  # deprecation logger adapter for older Logstashes
+  include(LogStash::PluginMixins::DeprecationLoggerSupport)
 
   # Generic/API config options that any document indexer output needs
   include(LogStash::PluginMixins::ElasticSearch::APIConfigs)

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -2,6 +2,15 @@ module LogStash module Outputs class ElasticSearch
   # DS specific behavior/configuration.
   module DataStreamSupport
 
+    # @api private
+    ENABLING_ECS_GUIDANCE = <<~END.tr("\n", " ")
+      Elasticsearch data streams require that events adhere to the Elastic Common Schema.
+      While `ecs_compatibility` can be set for this individual Elasticsearch output plugin, doing so will not fix schema conflicts caused by upstream plugins in your pipeline.
+      To avoid mapping conflicts, you will need to use ECS-compatible field names and datatypes throughout your pipeline.
+      Many plugins support an `ecs_compatibility` mode, and the `pipeline.ecs_compatibility` setting can be used to opt-in for all plugins in a pipeline.
+    END
+    private_constant :ENABLING_ECS_GUIDANCE
+
     def self.included(base)
       # Defines whether data will be indexed into an Elasticsearch data stream,
       # `data_stream_*` settings will only be used if this setting is enabled!
@@ -58,7 +67,7 @@ module LogStash module Outputs class ElasticSearch
         end
         return true
       else
-        use_data_stream = data_stream_default(data_stream_params, invalid_data_stream_params.empty?)
+        use_data_stream = data_stream_default(data_stream_params, invalid_data_stream_params)
         if !use_data_stream && data_stream_params.any?
           # DS (auto) disabled but there's still some data-stream parameters (and no `data_stream => false`)
           @logger.error "Ambiguous configuration; data stream settings are present, but data streams are not enabled", data_stream_params
@@ -123,18 +132,28 @@ module LogStash module Outputs class ElasticSearch
     DATA_STREAMS_ENABLED_BY_DEFAULT_LS_VERSION = '8.0.0'
 
     # when data_stream => is either 'auto' or not set
-    def data_stream_default(data_stream_params, valid_data_stream_config)
+    # @param data_stream_params [#any?]
+    # @param invalid_data_stream_config [#any?#inspect]
+    def data_stream_default(data_stream_params, invalid_data_stream_config)
+      if ecs_compatibility == :disabled
+        @logger.debug("Not eligible for data streams because ecs_compatibility is not enabled. " + ENABLING_ECS_GUIDANCE)
+        return false
+      end
+
       ds_default = ::Gem::Version.create(LOGSTASH_VERSION) >= ::Gem::Version.create(DATA_STREAMS_ENABLED_BY_DEFAULT_LS_VERSION)
 
       if ds_default # LS 8.0
-        return false unless valid_data_stream_config
+        if invalid_data_stream_config.any?
+          @logger.debug("Not eligible for data streams because config contains one or more settings that are not compatible with data streams: #{invalid_data_stream_config.inspect}")
+          return false
+        end
 
         @logger.debug 'Configuration is data stream compliant'
         return true
       end
 
       # LS 7.x
-      if valid_data_stream_config && !data_stream_params.any?
+      if !invalid_data_stream_config.any? && !data_stream_params.any?
         @logger.warn "Configuration is data stream compliant but due backwards compatibility Logstash 7.x will not assume " +
                      "writing to a data-stream, default behavior will change on Logstash 8.0 " +
                      "(set `data_stream => true/false` to disable this warning)"

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -112,6 +112,7 @@ module LogStash module Outputs class ElasticSearch
           true
         when 'data_stream'
           value.to_s == 'true'
+        when 'ecs_compatibility' then true # reqiuired for LS <= 6.x
         else
           name.start_with?('data_stream_') ||
               shared_params.include?(name) ||

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -116,7 +116,7 @@ module LogStash module Outputs class ElasticSearch
           true
         when 'data_stream'
           value.to_s == 'true'
-        when 'ecs_compatibility' then true # reqiuired for LS <= 6.x
+        when 'ecs_compatibility' then true # required for LS <= 6.x
         else
           name.start_with?('data_stream_') ||
               shared_params.include?(name) ||

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -78,11 +78,15 @@ module LogStash module Outputs class ElasticSearch
         return true
       else
         use_data_stream = data_stream_default(data_stream_params, invalid_data_stream_params)
-        if !use_data_stream && data_stream_params.any?
+        if use_data_stream
+          @logger.info("Config is compliant with data streams. `data_stream => auto` resolved to `true`")
+        elsif data_stream_params.any?
           # DS (auto) disabled but there's still some data-stream parameters (and no `data_stream => false`)
           @logger.error "Ambiguous configuration; data stream settings are present, but data streams are not enabled", data_stream_params
           raise LogStash::ConfigurationError, "Ambiguous configuration, please set data_stream => true " +
               "or remove data stream specific settings: #{data_stream_params.keys}"
+        else
+          @logger.info("Config is not compliant with data streams. `data_stream => auto` resolved to `false`")
         end
         use_data_stream
       end

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -110,8 +110,8 @@ module LogStash module Outputs class ElasticSearch
     # @return [Gem::Version] if ES supports DS nil (or raise) otherwise
     def assert_es_version_supports_data_streams
       fail 'no last_es_version' unless last_es_version # assert - should not happen
-      es_version = Gem::Version.create(last_es_version)
-      if es_version < Gem::Version.create(DATA_STREAMS_ORIGIN_ES_VERSION)
+      es_version = ::Gem::Version.create(last_es_version)
+      if es_version < ::Gem::Version.create(DATA_STREAMS_ORIGIN_ES_VERSION)
         @logger.error "Elasticsearch version does not support data streams, Logstash might end up writing to an index", es_version: es_version.version
         # NOTE: when switching to synchronous check from register, this should be a ConfigurationError
         raise LogStash::Error, "A data_stream configuration is only supported since Elasticsearch #{DATA_STREAMS_ORIGIN_ES_VERSION} " +
@@ -124,7 +124,7 @@ module LogStash module Outputs class ElasticSearch
 
     # when data_stream => is either 'auto' or not set
     def data_stream_default(data_stream_params, valid_data_stream_config)
-      ds_default = Gem::Version.create(LOGSTASH_VERSION) >= Gem::Version.create(DATA_STREAMS_ENABLED_BY_DEFAULT_LS_VERSION)
+      ds_default = ::Gem::Version.create(LOGSTASH_VERSION) >= ::Gem::Version.create(DATA_STREAMS_ENABLED_BY_DEFAULT_LS_VERSION)
 
       if ds_default # LS 8.0
         return false unless valid_data_stream_config

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.3.0'
+  s.version         = '11.3.1'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.0'
+  s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
 
   s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'logstash-devutils'

--- a/spec/integration/outputs/data_stream_spec.rb
+++ b/spec/integration/outputs/data_stream_spec.rb
@@ -12,6 +12,13 @@ describe "data streams", :integration => true do
 
   subject { LogStash::Outputs::ElasticSearch.new(options) }
 
+  # All data-streams features require that the plugin be run in a non-disabled ECS compatibility mode.
+  # We run the plugin in ECS by default, and add test scenarios specifically for it being disabled.
+  let(:ecs_compatibility) { :v1 }
+  before(:each) do
+    allow( subject ).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+  end
+
   before :each do
     @es = get_client
     @es.delete_by_query(index: ".ds-#{ds_name}-*", expand_wildcards: :all, body: { query: { match_all: {} } }) rescue nil

--- a/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
+++ b/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
@@ -4,8 +4,16 @@ require "logstash/outputs/elasticsearch/data_stream_support"
 describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
 
   subject { LogStash::Outputs::ElasticSearch.new(options) }
+
   let(:options) { { 'hosts' => [ 'localhost:12345' ] } }
   let(:es_version) { '7.10.1' }
+
+  # All data-streams features require that the plugin be run in a non-disabled ECS compatibility mode.
+  # We run the plugin in ECS by default, and add test scenarios specifically for it being disabled.
+  let(:ecs_compatibility) { :v1 }
+  before(:each) do
+    allow(subject).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+  end
 
   let(:do_register) { false }
   let(:stub_plugin_register!) do
@@ -66,6 +74,25 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
       end
     end
 
+    context 'ecs_compatibility disabled' do
+      let(:ecs_compatibility) { :disabled }
+
+      {
+        '7.x (pre-DS)' => '7.9.0',
+        '7.x (with DS)' => '7.11.0',
+        '8.0' => '8.0.0',
+        '8.x' => '8.1.2',
+      }.each do |ls_version_desc, ls_version|
+        context "on LS #{ls_version_desc}" do
+          around(:each) { |example| change_constant(:LOGSTASH_VERSION, ls_version, &example) }
+          it "does not use data-streams" do
+            expect( subject.logger ).to receive(:debug).with(a_string_including "ecs_compatibility is not enabled")
+            expect( subject.data_stream_config? ).to be false
+          end
+        end
+      end
+    end
+
     context 'non-compatible ES' do
 
       let(:es_version) { '7.8.0' }
@@ -95,6 +122,7 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
     before { allow(subject).to receive(:last_es_version).and_return(es_version) }
 
     it "does not use data-streams on LS 7.x" do
+      expect( subject.logger ).to receive(:warn).with(a_string_including "Logstash 7.x will not assume writing to a data-stream")
       change_constant :LOGSTASH_VERSION, '7.10.0' do
         expect( subject.data_stream_config? ).to be false
       end
@@ -197,7 +225,7 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
       end
     end
 
-    it "does use data-streams on LS 8.0" do
+    it "does use data-streams on LS 8.x" do
       change_constant :LOGSTASH_VERSION, '8.1.0' do
         expect( subject.data_stream_config? ).to be true
       end

--- a/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
+++ b/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
@@ -12,7 +12,7 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
   # We run the plugin in ECS by default, and add test scenarios specifically for it being disabled.
   let(:ecs_compatibility) { :v1 }
   before(:each) do
-    allow(subject).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+    allow_any_instance_of(LogStash::Outputs::ElasticSearch).to receive(:ecs_compatibility).and_return(ecs_compatibility)
   end
 
   let(:do_register) { false }

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -959,7 +959,7 @@ describe LogStash::Outputs::ElasticSearch do
     context 'error raised' do
 
       let(:es_version) { '7.8.0' }
-      let(:options) { super().merge('data_stream' => 'true') }
+      let(:options) { super().merge('data_stream' => 'true', 'ecs_compatibility' => 'v1') }
       let(:latch) { Concurrent::CountDownLatch.new }
 
       before do


### PR DESCRIPTION
When data streams were initially added to this output plugin, we had planned on ECS being on-by-default in Logstash 8, so it made sense to also have data streams be the default target. We had temporarily punted the switch for ECS in Logstash to a later date, which revealed that running very simple configs in the LS8 betas cause runtime mapping errors (typically caused by upstream plugins, also not operating in ECS-mode, introducing ECS-conflicts implicitly). Even though we are back on track for the undrerlying ECS changes to go into Logstash 8, it will be helpful to codify this requirement.

In order to set our users up for success, this plugin should avoid routing to data streams unless it is being run in an ECS compatibility mode (preferably derived from the `pipeline.ecs_compatibility` setting, indicating that the upstream plugins that are the likely _source_ of the conflicts are operating in ECS mode).

To address this, this changeset does two things:
  - `data_stream => auto` resolves to _false_ when the plugin's `ecs_compatibility` is `disabled`.
  - `data_stream => true` now requires the effective `ecs_compatibility` to be non-`disabled` (**breaking? discuss**).


This change also makes necessary fixes to use ECS v8, and to specifying `ecs_compatibility` explicitly on Logstash 6.

TODO:
 - [x] code changes
 - ~[ ] docs changes~
 - [x] version bump
 - [x] changelog