### PR TITLE
ecs: update v1 to ECS v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.2.2
+ - Update ECS templates from upstream; `ecs_compatiblity => v1` now resolves to templates for ECS v1.12.1 [#1027](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1027)
+
 ## 11.2.1
  - Fix referencing Gem classes from global lexical scope [#1044](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1044)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require "logstash/devutils/rake"
 
 ECS_VERSIONS = {
-    v1: 'v1.5.0'
+    v1: 'v1.12.1'
 }
 
 ECS_LOGSTASH_INDEX_PATTERNS = %w(

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.2.1'
+  s.version         = '11.2.2'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"


### PR DESCRIPTION
Updates our vendoring definition so that when `ecs_compatibility => v1` is specified the ECS v1.12.1 templates are loaded.