### PR TITLE
ECS templates for elasticsearch 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 11.3.0
+ - Adds ECS templates [#1048](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1048)
+   - Adds templates for ECS v1 for Elasticsearch 8.x
+   - Adds templates for BETA preview of ECS v8 for both Elasticsearch 7.x and 8.x
+
 ## 11.2.3
  - Downgrade ECS templates, pinning to v1.10.0 of upstream; fixes an issue where ECS templates cannot be installed in Elasticsearch 6.x or 7.1-7.2, since the generated templates include fields of `type: flattened` that was introduced in Elasticsearch 7.3
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,10 @@ require "logstash/devutils/rake"
 
 ECS_VERSIONS = {
     v1: 'v1.10.0', # WARNING: v1.11 breaks 6.x (see: https://github.com/elastic/ecs/issues/1649)
+
+    # PRERELEASE: 8.0@{2021-11-02T20:09:42Z}
+    # when pinning to released tag, remove BETA warning.
+    v8: 'b3dace43afb0dce743605cdd4cc067a3a6b8131c',
 }
 
 ECS_LOGSTASH_INDEX_PATTERNS = %w(
@@ -12,6 +16,9 @@ task :'vendor-ecs-schemata' do
   download_ecs_schema(:v1, 6)
   download_ecs_schema(:v1, 7)
   download_ecs_schema(:v1, 8, 7) { |template| transform_for_es8!(template) }
+
+  download_ecs_schema(:v8, 7)
+  download_ecs_schema(:v8, 8, 7) { |template| transform_for_es8!(template) }
 end
 task :vendor => :'vendor-ecs-schemata'
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,27 +11,48 @@ ECS_LOGSTASH_INDEX_PATTERNS = %w(
 task :'vendor-ecs-schemata' do
   download_ecs_schema(:v1, 6)
   download_ecs_schema(:v1, 7)
+  download_ecs_schema(:v1, 8, 7) { |template| transform_for_es8!(template) }
 end
 task :vendor => :'vendor-ecs-schemata'
 
-def download_ecs_schema(ecs_major_version, es_major)
-  $stderr.puts("Vendoring ECS #{ecs_major_version} template for Elasticsearch #{es_major}")
+def download_ecs_schema(ecs_major_version, es_major, generated_for_es_major=es_major)
+  $stderr.puts("Vendoring ECS #{ecs_major_version} template for Elasticsearch #{es_major}"+(es_major==generated_for_es_major ? '': " (transformed from templates pre-generated for ES #{generated_for_es_major})"))
   require 'net/http'
   require 'json'
   Net::HTTP.start('raw.githubusercontent.com', :use_ssl => true) do |http|
     ecs_release_tag = ECS_VERSIONS.fetch(ecs_major_version)
-    response = http.get("/elastic/ecs/#{ecs_release_tag}/generated/elasticsearch/#{es_major}/template.json")
+    response = http.get("/elastic/ecs/#{ecs_release_tag}/generated/elasticsearch/#{generated_for_es_major}/template.json")
     fail "#{response.code} #{response.message}" unless (200...300).cover?(response.code.to_i)
     template_directory = File.expand_path("../lib/logstash/outputs/elasticsearch/templates/ecs-#{ecs_major_version}", __FILE__)
     Dir.mkdir(template_directory) unless File.exists?(template_directory)
     File.open(File.join(template_directory, "/elasticsearch-#{es_major}x.json"), "w") do |handle|
-      handle.write(replace_index_patterns(response.body, ECS_LOGSTASH_INDEX_PATTERNS))
+      template = JSON.load(response.body)
+      replace_index_patterns!(template, ECS_LOGSTASH_INDEX_PATTERNS)
+      yield(template) if block_given?
+      handle.write(JSON.pretty_generate template)
     end
   end
 end
 
-def replace_index_patterns(template_json, replacement_index_patterns)
-  template_obj = JSON.load(template_json)
-  template_obj.update('index_patterns' => replacement_index_patterns)
-  JSON.pretty_generate(template_obj)
+# destructively replaces the index pattern with the provided replacements
+def replace_index_patterns!(template, replacement_index_patterns)
+  template.update('index_patterns' => replacement_index_patterns)
+end
+
+# destructively transforms a legacy template into an ES8-compatible index_template.
+def transform_for_es8!(template)
+  # `settings` and `mappings` are now nested under top-level `template`
+  template["template"] = {
+    "settings" => template.delete("settings"),
+    "mappings" => template.delete("mappings"),
+  }
+
+  # `order` is gone, replaced with `priority`.
+  template.delete('order')
+  template["priority"] = 200 #arbitrary
+
+  # a new free-form `_meta` exists, so let's add a note about where the template came from
+  template["_meta"] = { "description" => "ECS index template for logstash-output-elasticsearch" }
+
+  nil
 end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -102,7 +102,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   include(LogStash::Outputs::ElasticSearch::Ilm)
 
   # ecs_compatibility option, provided by Logstash core or the support adapter.
-  include(LogStash::PluginMixins::ECSCompatibilitySupport)
+  include(LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8))
 
   # Generic/API config options that any document indexer output needs
   include(LogStash::PluginMixins::ElasticSearch::APIConfigs)
@@ -300,6 +300,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     @bulk_request_metrics = metric.namespace(:bulk_requests)
     @document_level_metrics = metric.namespace(:documents)
+
+    if ecs_compatibility == :v8
+      @logger.warn("Elasticsearch Output configured with `ecs_compatibility => v8`, which resolved to an UNRELEASED preview of version 8.0.0 of the Elastic Common Schema. " +
+                   "Once ECS v8 and an updated release of this plugin are publicly available, you will need to update this plugin to resolve this warning.")
+    end
   end
 
   # @override post-register when ES connection established

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.2.3'
+  s.version         = '11.3.0'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -1,8 +1,12 @@
 require_relative "../../../spec/es_spec_helper"
 
 describe "index template expected behavior", :integration => true do
+  let(:ecs_compatibility) { fail('spec group does not define `ecs_compatibility`!') }
+
   subject! do
     require "logstash/outputs/elasticsearch"
+    allow_any_instance_of(LogStash::Outputs::ElasticSearch).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+
     settings = {
       "manage_template" => true,
       "template_overwrite" => true,
@@ -11,86 +15,117 @@ describe "index template expected behavior", :integration => true do
     next LogStash::Outputs::ElasticSearch.new(settings)
   end
 
-  before :each do
-    # Delete all templates first.
+  let(:elasticsearch_client) { get_client }
+
+  before(:each) do
+    # delete indices and templates
     require "elasticsearch"
 
-    # Clean ES of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
-
+    elasticsearch_client.indices.delete_template(:name => '*')
     # This can fail if there are no indexes, ignore failure.
-    @es.indices.delete(:index => "*") rescue nil
+    elasticsearch_client.indices.delete(:index => '*') rescue nil
+  end
 
-    subject.register
+  context 'with ecs_compatibility => disabled' do
+    let(:ecs_compatibility) { :disabled }
+    before :each do
+      @es = elasticsearch_client # cache as ivar for tests...
 
-    subject.multi_receive([
-      LogStash::Event.new("message" => "sample message here"),
-      LogStash::Event.new("somemessage" => { "message" => "sample nested message here" }),
-      LogStash::Event.new("somevalue" => 100),
-      LogStash::Event.new("somevalue" => 10),
-      LogStash::Event.new("somevalue" => 1),
-      LogStash::Event.new("country" => "us"),
-      LogStash::Event.new("country" => "at"),
-      LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0 ] })
-    ])
+      subject.register
 
-    @es.indices.refresh
+      subject.multi_receive([
+        LogStash::Event.new("message" => "sample message here"),
+        LogStash::Event.new("somemessage" => { "message" => "sample nested message here" }),
+        LogStash::Event.new("somevalue" => 100),
+        LogStash::Event.new("somevalue" => 10),
+        LogStash::Event.new("somevalue" => 1),
+        LogStash::Event.new("country" => "us"),
+        LogStash::Event.new("country" => "at"),
+        LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0 ] })
+      ])
 
-    # Wait or fail until everything's indexed.
-    Stud::try(20.times) do
-      r = @es.search(index: 'logstash-*')
-      expect(r).to have_hits(8)
+      @es.indices.refresh
+
+      # Wait or fail until everything's indexed.
+      Stud::try(20.times) do
+        r = @es.search(index: 'logstash-*')
+        expect(r).to have_hits(8)
+      end
+    end
+
+    it "permits phrase searching on string fields" do
+      results = @es.search(:q => "message:\"sample message\"")
+      expect(results).to have_hits(1)
+      expect(results["hits"]["hits"][0]["_source"]["message"]).to eq("sample message here")
+    end
+
+    it "numbers dynamically map to a numeric type and permit range queries" do
+      results = @es.search(:q => "somevalue:[5 TO 105]")
+      expect(results).to have_hits(2)
+
+      values = results["hits"]["hits"].collect { |r| r["_source"]["somevalue"] }
+      expect(values).to include(10)
+      expect(values).to include(100)
+      expect(values).to_not include(1)
+    end
+
+    it "does not create .keyword field for top-level message field" do
+      results = @es.search(:q => "message.keyword:\"sample message here\"")
+      expect(results).to have_hits(0)
+    end
+
+    it "creates .keyword field for nested message fields" do
+      results = @es.search(:q => "somemessage.message.keyword:\"sample nested message here\"")
+      expect(results).to have_hits(1)
+    end
+
+    it "creates .keyword field from any string field which is not_analyzed" do
+      results = @es.search(:q => "country.keyword:\"us\"")
+      expect(results).to have_hits(1)
+      expect(results["hits"]["hits"][0]["_source"]["country"]).to eq("us")
+
+      # partial or terms should not work.
+      results = @es.search(:q => "country.keyword:\"u\"")
+      expect(results).to have_hits(0)
+    end
+
+    it "make [geoip][location] a geo_point" do
+      expect(field_properties_from_template("logstash", "geoip")["location"]["type"]).to eq("geo_point")
+    end
+
+    it "aggregate .keyword results correctly " do
+      results = @es.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
+      terms = results["buckets"].collect { |b| b["key"] }
+
+      expect(terms).to include("us")
+
+      # 'at' is a stopword, make sure stopwords are not ignored.
+      expect(terms).to include("at")
     end
   end
 
-  it "permits phrase searching on string fields" do
-    results = @es.search(:q => "message:\"sample message\"")
-    expect(results).to have_hits(1)
-    expect(results["hits"]["hits"][0]["_source"]["message"]).to eq("sample message here")
-  end
+  context 'with ECS enabled' do
+    let(:ecs_compatibility) { :v1 }
 
-  it "numbers dynamically map to a numeric type and permit range queries" do
-    results = @es.search(:q => "somevalue:[5 TO 105]")
-    expect(results).to have_hits(2)
+    before(:each) do
+      subject.register # should load template?
+      subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
+    end
 
-    values = results["hits"]["hits"].collect { |r| r["_source"]["somevalue"] }
-    expect(values).to include(10)
-    expect(values).to include(100)
-    expect(values).to_not include(1)
-  end
+    let(:elasticsearch_cluster_major_version) do
+      elasticsearch_client.info&.dig("version", "number" )&.split('.')&.map(&:to_i)&.first
+    end
 
-  it "does not create .keyword field for top-level message field" do
-    results = @es.search(:q => "message.keyword:\"sample message here\"")
-    expect(results).to have_hits(0)
-  end
-
-  it "creates .keyword field for nested message fields" do
-    results = @es.search(:q => "somemessage.message.keyword:\"sample nested message here\"")
-    expect(results).to have_hits(1)
-  end
-
-  it "creates .keyword field from any string field which is not_analyzed" do
-    results = @es.search(:q => "country.keyword:\"us\"")
-    expect(results).to have_hits(1)
-    expect(results["hits"]["hits"][0]["_source"]["country"]).to eq("us")
-
-    # partial or terms should not work.
-    results = @es.search(:q => "country.keyword:\"u\"")
-    expect(results).to have_hits(0)
-  end
-
-  it "make [geoip][location] a geo_point" do
-    expect(field_properties_from_template("logstash", "geoip")["location"]["type"]).to eq("geo_point")
-  end
-
-  it "aggregate .keyword results correctly " do
-    results = @es.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
-    terms = results["buckets"].collect { |b| b["key"] }
-
-    expect(terms).to include("us")
-
-    # 'at' is a stopword, make sure stopwords are not ignored.
-    expect(terms).to include("at")
+    it 'loads the templates' do
+      aggregate_failures do
+        if elasticsearch_cluster_major_version >= 8
+          # In ES 8+ we use the _index_template API
+          expect(elasticsearch_client.indices.exists_index_template(name: 'ecs-logstash')).to be_truthy
+        else
+          # Otherwise, we used the legacy _template API
+          expect(elasticsearch_client.indices.exists_template(name: 'ecs-logstash')).to be_truthy
+        end
+      end
+    end
   end
 end

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -27,6 +27,12 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
     end
   end
 
+  context 'when ECS v8 is requested' do
+    it 'resolves' do
+      expect(described_class.default_template_path(7, :v8)).to end_with("/templates/ecs-v8/elasticsearch-7x.json")
+    end
+  end
+
   describe "index template with ilm settings" do
     let(:plugin_settings) { {"manage_template" => true, "template_overwrite" => true} }
     let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }


### PR DESCRIPTION

 - transforms ECS-generated template for ES7 into ES8-compatible index_template
 - adds _PREVIEW_ of 8.0 templates for Elasticsearch 7 & 8.