### PR TITLE
Doc: Fix note format

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -117,8 +117,8 @@ output {
 
 ==== Writing to different indices: best practices
 
-NOTE: You cannot use dynamic variable substitution when `ilm_enabled` is `true` and
-when using `ilm_rollover_alias`.
+NOTE: You cannot use dynamic variable substitution when `ilm_enabled` is `true` 
+and when using `ilm_rollover_alias`.
 
 If you're sending events to the same Elasticsearch cluster, but you're targeting different indices you can:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -117,12 +117,8 @@ output {
 
 ==== Writing to different indices: best practices
 
-[NOTE]
-================================================================================
-You cannot use dynamic variable substitution when `ilm_enabled` is `true` and
+NOTE: You cannot use dynamic variable substitution when `ilm_enabled` is `true` and
 when using `ilm_rollover_alias`.
-
-================================================================================
 
 If you're sending events to the same Elasticsearch cluster, but you're targeting different indices you can:
 


### PR DESCRIPTION
Current note formatting works, but isn't the best approach for simple notes. Fixing because formatting gets perpetuated in other places in docs. 

