### PR TITLE
Feat: add support for 'traces' data stream type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.3.3
+ - Feat: add support for 'traces' data stream type [#1057](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1057)
+
 ## 11.3.2
  - Refactor: review manticore error handling/logging, logging originating cause in case of connection related error when debug level is enabled [#1029](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1029)
    - Java causes on connection related exceptions will now be extra logged when plugin is logging at debug level

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -505,7 +505,7 @@ overwritten with a warning.
 * Default value is `logs`.
 
 The data stream type used to construct the data stream at index time.
-Currently, only `logs`, `metrics` and `synthetics` are supported.
+Currently, only `logs`, `metrics`, `synthetics` and `traces` are supported.
 
 [id="plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -18,7 +18,7 @@ module LogStash module Outputs class ElasticSearch
       # Defaults to `false` in Logstash 7.x and `auto` starting in Logstash 8.0.
       base.config :data_stream, :validate => ['true', 'false', 'auto']
 
-      base.config :data_stream_type, :validate => ['logs', 'metrics', 'synthetics'], :default => 'logs'
+      base.config :data_stream_type, :validate => ['logs', 'metrics', 'synthetics', 'traces'], :default => 'logs'
       base.config :data_stream_dataset, :validate => :dataset_identifier, :default => 'generic'
       base.config :data_stream_namespace, :validate => :namespace_identifier, :default => 'default'
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.3.2'
+  s.version         = '11.3.3'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"


### PR DESCRIPTION
Adds support for 'traces' data stream type.

Related issue: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1052