### PR TITLE
Adds a new `dlq_custom_codes` option to customize DLQ codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.7.0
+ - Feat: Adds a new `dlq_custom_codes` option to customize DLQ codes [#1067](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1067)
+ 
 ## 11.6.0
  - Added support for `ca_trusted_fingerprint` when run on Logstash 8.3+ [#1074](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1074)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -197,7 +197,7 @@ re-indexed to Elasticsearch. If the DLQ is not enabled, and a mapping error
 happens, the problem is logged as a warning, and the event is dropped. See
 <<dead-letter-queues>> for more information about processing events in the DLQ.
 The list of error codes accepted for DLQ could be customized with <<plugins-{type}s-{plugin}-dlq_custom_codes>>
-but should be done only in motivated cases.
+but should be used only in motivated cases.
 
 [id="plugins-{type}s-{plugin}-ilm"]
 ==== Index Lifecycle Management
@@ -527,7 +527,8 @@ Currently, only `logs`, `metrics`, `synthetics` and `traces` are supported.
 * Value type is <<number,number>>
 * Default value is `[]`.
 
-List extra HTTP's error codes that are considered valid to move the events into the dead letter queue.
+List HTTP's error codes that are considered valid to move the events into the dead letter queue.
+This list is an addition to the ordinary error codes considered for this feature, 400 and 404.
 It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
 The option accepts a list of natural numbers corresponding to HTTP errors codes.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -527,7 +527,7 @@ Currently, only `logs`, `metrics`, `synthetics` and `traces` are supported.
 * Value type is <<number,number>>
 * Default value is `[]`.
 
-List HTTP's error codes that are considered valid to move the events into the dead letter queue.
+List single-action error codes from Elasticsearch's Bulk API that are considered valid to move the events into the dead letter queue.
 This list is an addition to the ordinary error codes considered for this feature, 400 and 404.
 It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
 The option accepts a list of natural numbers corresponding to HTTP errors codes.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -196,6 +196,8 @@ processed at a later time. Often times, the offending field can be removed and
 re-indexed to Elasticsearch. If the DLQ is not enabled, and a mapping error
 happens, the problem is logged as a warning, and the event is dropped. See
 <<dead-letter-queues>> for more information about processing events in the DLQ.
+The list of error codes accepted for DLQ could be customized with <<plugins-{type}s-{plugin}-dlq_custom_codes>>
+but should be done only in motivated cases.
 
 [id="plugins-{type}s-{plugin}-ilm"]
 ==== Index Lifecycle Management
@@ -317,6 +319,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-data_stream_namespace>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-data_stream_sync_fields>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-data_stream_type>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-dlq_custom_codes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-doc_as_upsert>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-document_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-document_type>> |<<string,string>>|No
@@ -517,6 +520,16 @@ overwritten with a warning.
 
 The data stream type used to construct the data stream at index time.
 Currently, only `logs`, `metrics`, `synthetics` and `traces` are supported.
+
+[id="plugins-{type}s-{plugin}-dlq_custom_codes"]
+===== `dlq_custom_codes`
+
+* Value type is <<number,number>>
+* Default value is `[]`.
+
+List extra HTTP's error codes that are considered valid to move the events into the dead letter queue.
+It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
+The option accepts a list of natural numbers corresponding to HTTP errors codes.
 
 [id="plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -299,10 +299,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     # To support BWC, we check if DLQ exists in core (< 5.4). If it doesn't, we use nil to resort to previous behavior.
     @dlq_writer = dlq_enabled? ? execution_context.dlq_writer : nil
 
+    @dlq_codes = DOC_DLQ_CODES.to_set
+
     if dlq_enabled?
       check_dlq_custom_codes
-      @dlq_codes = dlq_custom_codes.to_set
-      @dlq_codes.merge(DOC_DLQ_CODES)
+      @dlq_codes.merge(dlq_custom_codes)
     else
       raise LogStash::ConfigurationError, "DLQ feature (dlq_custom_codes) is configured while DLQ is not enabled" unless dlq_custom_codes.empty?
     end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -255,6 +255,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # ILM policy to use, if undefined the default policy will be used.
   config :ilm_policy, :validate => :string, :default => DEFAULT_POLICY
 
+  # List extra HTTP's error codes that are considered valid to move the events into the dead letter queue.
+  # It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
+  # The option accepts a list of natural numbers corresponding to HTTP errors codes.
   config :dlq_custom_codes, :validate => :number, :list => true, :default => []
 
   attr_reader :client

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -300,6 +300,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     if dlq_enabled?
       check_dlq_custom_codes
+    else
+      raise LogStash::ConfigurationError, "DLQ feature (dlq_custom_codes) is configured while DLQ is not enabled" unless dlq_custom_codes.empty?
     end
 
     if data_stream_config?

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -9,6 +9,7 @@ require "socket" # for Socket.gethostname
 require "thread" # for safe queueing
 require "uri" # for escaping user input
 require "forwardable"
+require "set"
 
 # .Compatibility Note
 # [NOTE]
@@ -300,6 +301,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     if dlq_enabled?
       check_dlq_custom_codes
+      @dlq_codes = dlq_custom_codes.to_set
+      @dlq_codes.merge(DOC_DLQ_CODES)
     else
       raise LogStash::ConfigurationError, "DLQ feature (dlq_custom_codes) is configured while DLQ is not enabled" unless dlq_custom_codes.empty?
     end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -543,12 +543,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   def check_dlq_custom_codes
     intersection = dlq_custom_codes & DOC_DLQ_CODES
-    raise LogStash::ConfigurationError, "dlq_custom_codes contains error codes already used: #{intersection}" unless intersection.empty?
+    raise LogStash::ConfigurationError, "#{intersection} are already defined as standard DLQ error codes" unless intersection.empty?
 
     intersection = dlq_custom_codes & DOC_SUCCESS_CODES
-    raise LogStash::ConfigurationError, "dlq_custom_codes contains error codes already defined as success: #{intersection}" unless intersection.empty?
+    raise LogStash::ConfigurationError, "#{intersection} are success codes which cannot be redefined in dlq_custom_codes" unless intersection.empty?
 
     intersection = dlq_custom_codes & [DOC_CONFLICT_CODE]
-    raise LogStash::ConfigurationError, "dlq_custom_codes contains error codes already defined as conflict: #{intersection}" unless intersection.empty?
+    raise LogStash::ConfigurationError, "#{intersection} are error codes already defined as conflict which cannot be redefined in dlq_custom_codes" unless intersection.empty?
   end
 end

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -268,7 +268,7 @@ module LogStash; module PluginMixins; module ElasticSearch
           @document_level_metrics.increment(:non_retryable_failures)
           @logger.warn "Failed action", status: status, action: action, response: response if log_failure_type?(error)
           next
-        elsif DOC_DLQ_CODES.include?(status) || dlq_custom_codes.include?(status)
+        elsif @dlq_codes.include?(status)
           handle_dlq_status("Could not index event to Elasticsearch.", action, status, response)
           @document_level_metrics.increment(:non_retryable_failures)
           next

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -268,7 +268,7 @@ module LogStash; module PluginMixins; module ElasticSearch
           @document_level_metrics.increment(:non_retryable_failures)
           @logger.warn "Failed action", status: status, action: action, response: response if log_failure_type?(error)
           next
-        elsif DOC_DLQ_CODES.include?(status)
+        elsif DOC_DLQ_CODES.include?(status) || dlq_custom_codes.include?(status)
           handle_dlq_status("Could not index event to Elasticsearch.", action, status, response)
           @document_level_metrics.increment(:non_retryable_failures)
           next

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.6.0'
+  s.version         = '11.7.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -269,6 +269,13 @@ describe LogStash::Outputs::ElasticSearch do
           expect{ subject.register }.to raise_error(LogStash::ConfigurationError, /are already defined as standard DLQ error codes/)
         end
       end
+
+      context "is configured but DLQ is not enabled" do
+        it "raise a configuration error" do
+          allow(subject).to receive(:dlq_enabled?).and_return(false)
+          expect{ subject.register }.to raise_error(LogStash::ConfigurationError, /configured while DLQ is not enabled/)
+        end
+      end
     end if LOGSTASH_VERSION > '7.0'
 
     describe "#multi_receive" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -260,13 +260,13 @@ describe LogStash::Outputs::ElasticSearch do
       end
     end
 
-    describe "when 'dlq_custom_codes' contains" do
+    describe "when 'dlq_custom_codes'" do
       let(:options) { super().merge('dlq_custom_codes' => [404]) }
       let(:do_register) { false }
 
-      context "already defined codes" do
+      context "contains already defined codes" do
         it "should raise a configuration error" do
-          expect{ subject.register }.to raise_error(LogStash::ConfigurationError, /dlq_custom_codes contains error codes already/)
+          expect{ subject.register }.to raise_error(LogStash::ConfigurationError, /are already defined as standard DLQ error codes/)
         end
       end
     end if LOGSTASH_VERSION > '7.0'

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -269,7 +269,7 @@ describe LogStash::Outputs::ElasticSearch do
           expect{ subject.register }.to raise_error(LogStash::ConfigurationError, /dlq_custom_codes contains error codes already/)
         end
       end
-    end
+    end if LOGSTASH_VERSION > '7.0'
 
     describe "#multi_receive" do
       let(:events) { [double("one"), double("two"), double("three")] }


### PR DESCRIPTION
## Release notes
Adds `dlq_custom_codes` option to customize the list of HTTP codes that are considered eligible for DLQ.

## What does this PR do?
Introduced a new configuration option, named `dlq_custom_codes` which accepts a list of HTTP error codes.
The list is to be considered as an addition to the already existing codes that the plugin uses (DLQ_CODES, DOC_SUCCESS_CODES, DOC_CONFLICT_CODE defined in module `Common`). If the list has an intersection with those error codes then it's reported as a configuration error.

## Why is it important/What is the impact to the user?
This is a feature requested in #697, in some cases some error codes returned by Elasticsearch should be handled as DLQ messaged and not retried for ever. For example writing to a read only index report a 403, the index status would never change automatically so it's best to move these events to DLQ for a later reprocessing.
Under normal conditions the user shouldn't customize this list, but it's an helper in some circumstances.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test a version of the plugin with a real ES

## How to test this PR locally
- launch an ES instance, for example `docker-compose -f es_and_kb.yml up` 
[es_and_kb.txt](https://github.com/logstash-plugins/logstash-output-elasticsearch/files/8081186/es_and_kb.txt)
- from http://localhost:5601 Kibana UI (credential: elastic, changeme) create and index and put into read only:
```
PUT /test_index
PUT test_index/_settings 
{ 
  "index.blocks.read_only" : true 
}
```
- configure a pipeline to write into:
```
input {
	stdin {}
}

output {
	elasticsearch {
		index => "test_index"
		hosts => "http://localhost:9200"
		user => "elastic"
		password => "changeme"
		dlq_custom_codes => [403]
	}
}	
```
- enable DLQ in `config/logstash.yml` : 
```
dead_letter_queue.enable: true
```
- start the pipeline and generate an input and stop
- check that the string you typed is present in DLQ 
```
strings data/dead_letter_queue/main/1.log
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #697
- Related https://github.com/elastic/logstash/issues/10493

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
HTTP error codes used to decide if an event index reply has to be moved into the DLQ are 400 and 404. These codes are hard coded, this PR aims the user to customize this list extending other than 400 and 404.