### PR TITLE
Deprecates option  in favor of `silence_errors_in_log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
- - Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `log_silenced_errors` [#1068](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1068)
+ - Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `silence_errors_in_log` [#1068](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1068)
 
 ## 11.6.0
  - Added support for `ca_trusted_fingerprint` when run on Logstash 8.3+ [#1074](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1074)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 11.6.1
  - Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `silence_errors_in_log` [#1068](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1068)
 
 ## 11.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
- - Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `log_silenced_errors` [#n](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/n)
+ - Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `log_silenced_errors` [#1068](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1068)
 
 ## 11.6.0
  - Added support for `ca_trusted_fingerprint` when run on Logstash 8.3+ [#1074](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1074)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 11.6.1
+## 11.7.0
  - Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `silence_errors_in_log` [#1068](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1068)
 
 ## 11.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+ - Feature: deprecates the `failure_type_logging_whitelist` configuration option, renaming it `log_silenced_errors` [#n](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/n)
+
 ## 11.6.0
  - Added support for `ca_trusted_fingerprint` when run on Logstash 8.3+ [#1074](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1074)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -332,6 +332,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-log_silenced_errors>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-manage_template>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-parameters>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-parent>> |<<string,string>>|No
@@ -584,9 +585,7 @@ of this setting affects the _default_ values of:
   * Value type is <<array,array>>
   * Default value is `[]`
 
-Set the Elasticsearch errors in the whitelist that you don't want to log.
-A useful example is when you want to skip all 409 errors
-which are `document_already_exists_exception`.
+NOTE: Deprecated, refer to <<plugins-{type}s-{plugin}-log_silenced_errors>>.
 
 [id="plugins-{type}s-{plugin}-custom_headers"]
 ===== `custom_headers`
@@ -761,6 +760,25 @@ It can be either .jks or .p12
   * There is no default value for this setting.
 
 Set the keystore password
+
+[id="plugins-{type}s-{plugin}-log_silenced_errors"]
+===== `log_silenced_errors`
+
+* Value type is <<array,array>>
+* Default value is `[]`
+
+Defines the list of Elasticsearch errors that you don't want to log.
+A useful example is when you want to skip all 409 errors
+which are `document_already_exists_exception`.
+
+[source,ruby]
+    output {
+      elasticsearch {
+        log_silenced_errors => ["document_already_exists_exception"]
+      }
+    }
+
+NOTE: Deprecates <<plugins-{type}s-{plugin}-failure_type_logging_whitelist>>.
 
 [id="plugins-{type}s-{plugin}-manage_template"]
 ===== `manage_template`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -332,7 +332,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
-| <<plugins-{type}s-{plugin}-log_silenced_errors>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-silence_errors_in_log>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-manage_template>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-parameters>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-parent>> |<<string,string>>|No
@@ -585,7 +585,7 @@ of this setting affects the _default_ values of:
   * Value type is <<array,array>>
   * Default value is `[]`
 
-NOTE: Deprecated, refer to <<plugins-{type}s-{plugin}-log_silenced_errors>>.
+NOTE: Deprecated, refer to <<plugins-{type}s-{plugin}-silence_errors_in_log>>.
 
 [id="plugins-{type}s-{plugin}-custom_headers"]
 ===== `custom_headers`
@@ -761,8 +761,8 @@ It can be either .jks or .p12
 
 Set the keystore password
 
-[id="plugins-{type}s-{plugin}-log_silenced_errors"]
-===== `log_silenced_errors`
+[id="plugins-{type}s-{plugin}-silence_errors_in_log"]
+===== `silence_errors_in_log`
 
 * Value type is <<array,array>>
 * Default value is `[]`
@@ -774,7 +774,7 @@ which are `document_already_exists_exception`.
 [source,ruby]
     output {
       elasticsearch {
-        log_silenced_errors => ["document_already_exists_exception"]
+        silence_errors_in_log => ["document_already_exists_exception"]
       }
     }
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -761,25 +761,6 @@ It can be either .jks or .p12
 
 Set the keystore password
 
-[id="plugins-{type}s-{plugin}-silence_errors_in_log"]
-===== `silence_errors_in_log`
-
-* Value type is <<array,array>>
-* Default value is `[]`
-
-Defines the list of Elasticsearch errors that you don't want to log.
-A useful example is when you want to skip all 409 errors
-which are `document_already_exists_exception`.
-
-[source,ruby]
-    output {
-      elasticsearch {
-        silence_errors_in_log => ["document_already_exists_exception"]
-      }
-    }
-
-NOTE: Deprecates <<plugins-{type}s-{plugin}-failure_type_logging_whitelist>>.
-
 [id="plugins-{type}s-{plugin}-manage_template"]
 ===== `manage_template`
 
@@ -979,6 +960,25 @@ Set variable name passed to script (scripted update)
   * Default value is `false`
 
 if enabled, script is in charge of creating non-existent document (scripted update)
+
+[id="plugins-{type}s-{plugin}-silence_errors_in_log"]
+===== `silence_errors_in_log`
+
+* Value type is <<array,array>>
+* Default value is `[]`
+
+Defines the list of Elasticsearch errors that you don't want to log.
+A useful example is when you want to skip all 409 errors
+which are `document_already_exists_exception`.
+
+[source,ruby]
+    output {
+      elasticsearch {
+        silence_errors_in_log => ["document_already_exists_exception"]
+      }
+    }
+
+NOTE: Deprecates <<plugins-{type}s-{plugin}-failure_type_logging_whitelist>>.
 
 [id="plugins-{type}s-{plugin}-sniffing"]
 ===== `sniffing`

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -266,6 +266,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   end
 
   def register
+    if !failure_type_logging_whitelist.empty?
+      @deprecation_logger.deprecated "'failure_type_logging_whitelist' is deprecated and in a future version of " +
+        "Elasticsearch output plugin will be removed, please use 'log_silenced_errors' instead."
+      log_silenced_errors = log_silenced_errors | failure_type_logging_whitelist
+    end
+
     @after_successful_connection_done = Concurrent::AtomicBoolean.new(false)
     @stopping = Concurrent::AtomicBoolean.new(false)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -269,7 +269,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     if !failure_type_logging_whitelist.empty?
       @deprecation_logger.deprecated "'failure_type_logging_whitelist' is deprecated and in a future version of " +
         "Elasticsearch output plugin will be removed, please use 'log_silenced_errors' instead."
-      log_silenced_errors = log_silenced_errors | failure_type_logging_whitelist
+      @log_silenced_errors = log_silenced_errors | failure_type_logging_whitelist
     end
 
     @after_successful_connection_done = Concurrent::AtomicBoolean.new(false)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -267,8 +267,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   def register
     if !failure_type_logging_whitelist.empty?
-      @deprecation_logger.deprecated "'failure_type_logging_whitelist' is deprecated and in a future version of " +
-        "Elasticsearch output plugin will be removed, please use 'silence_errors_in_log' instead."
+      log_message = "'failure_type_logging_whitelist' is deprecated and in a future version of Elasticsearch " +
+        "output plugin will be removed, please use 'silence_errors_in_log' instead."
+      @deprecation_logger.deprecated log_message
+      @logger.warn log_message
       @silence_errors_in_log = silence_errors_in_log | failure_type_logging_whitelist
     end
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -268,8 +268,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   def register
     if !failure_type_logging_whitelist.empty?
       @deprecation_logger.deprecated "'failure_type_logging_whitelist' is deprecated and in a future version of " +
-        "Elasticsearch output plugin will be removed, please use 'log_silenced_errors' instead."
-      @log_silenced_errors = log_silenced_errors | failure_type_logging_whitelist
+        "Elasticsearch output plugin will be removed, please use 'silence_errors_in_log' instead."
+      @silence_errors_in_log = silence_errors_in_log | failure_type_logging_whitelist
     end
 
     @after_successful_connection_done = Concurrent::AtomicBoolean.new(false)

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -99,14 +99,14 @@ module LogStash; module PluginMixins; module ElasticSearch
         # a timeout occurs, the request will be retried.
         :timeout => { :validate => :number, :default => 60 },
 
-        # Deprecated, refer to `log_silenced_errors`.
+        # Deprecated, refer to `silence_errors_in_log`.
         :failure_type_logging_whitelist => { :validate => :array, :default => [] },
 
         # Defines the list of Elasticsearch errors that you don't want to log.
         # A useful example is when you want to skip all 409 errors
         # which are `document_already_exists_exception`.
         # Deprecates `failure_type_logging_whitelist`.
-        :log_silenced_errors => { :validate => :array, :default => [] },
+        :silence_errors_in_log => { :validate => :array, :default => [] },
 
         # While the output tries to reuse connections efficiently we have a maximum.
         # This sets the maximum number of open connections the output will create.

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -99,10 +99,14 @@ module LogStash; module PluginMixins; module ElasticSearch
         # a timeout occurs, the request will be retried.
         :timeout => { :validate => :number, :default => 60 },
 
-        # Set the Elasticsearch errors in the whitelist that you don't want to log.
+        # Deprecated, refer to `log_silenced_errors`.
+        :failure_type_logging_whitelist => { :validate => :array, :default => [] },
+
+        # Defines the list of Elasticsearch errors that you don't want to log.
         # A useful example is when you want to skip all 409 errors
         # which are `document_already_exists_exception`.
-        :failure_type_logging_whitelist => { :validate => :array, :default => [] },
+        # Deprecates `failure_type_logging_whitelist`.
+        :log_silenced_errors => { :validate => :array, :default => [] },
 
         # While the output tries to reuse connections efficiently we have a maximum.
         # This sets the maximum number of open connections the output will create.

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -284,7 +284,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def log_failure_type?(failure)
-      !log_silenced_errors.include?(failure["type"])
+      !silence_errors_in_log.include?(failure["type"])
     end
 
     # Rescue retryable errors during bulk submission

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -284,7 +284,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def log_failure_type?(failure)
-      !failure_type_logging_whitelist.include?(failure["type"])
+      !log_silenced_errors.include?(failure["type"])
     end
 
     # Rescue retryable errors during bulk submission

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.6.1'
+  s.version         = '11.7.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.6.0'
+  s.version         = '11.6.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -45,8 +45,8 @@ describe "whitelisting error types in expected behavior" do
     end
   end
 
-  describe "when failure logging is disabled for docuemnt exists error" do
-    let(:settings) { super().merge("failure_type_logging_whitelist" => ["document_already_exists_exception"]) }
+  describe "when failure logging is disabled for document exists error" do
+    let(:settings) { super().merge("log_silenced_errors" => ["document_already_exists_exception"]) }
 
     it "should log a failure on the action" do
       expect(subject.logger).not_to have_received(:warn).with("Failed action", anything)

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -46,7 +46,7 @@ describe "whitelisting error types in expected behavior" do
   end
 
   describe "when failure logging is disabled for document exists error" do
-    let(:settings) { super().merge("log_silenced_errors" => ["document_already_exists_exception"]) }
+    let(:settings) { super().merge("silence_errors_in_log" => ["document_already_exists_exception"]) }
 
     it "should log a failure on the action" do
       expect(subject.logger).not_to have_received(:warn).with("Failed action", anything)


### PR DESCRIPTION
## Release notes
Deprecates `failure_type_logging_whitelist` setting renaming it `silence_errors_in_log`


## What does this PR do?

Introduce a new setting named `silence_errors_in_log` with exact same behavior of `failure_type_logging_whitelist`. It print a deprecation log message if `failure_type_logging_whitelist` is used.

## Why is it important/What is the impact to the user?

Rename a setting that's generally confusing the user to a more meaningful name.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Run against a real ES instance

## How to test this PR locally

- launch an ES instance, for example `docker-compose -f es_and_kb.yml up` 
[es_and_kb.txt](https://github.com/logstash-plugins/logstash-output-elasticsearch/files/8081186/es_and_kb.txt)
- from http://localhost:5601 Kibana UI (credential: elastic, changeme) create and index and put into read only:
```
PUT /test_index
PUT test_index/_settings 
{ 
  "index.blocks.read_only" : true 
}
```
- configure a pipeline to write into:
```
input {
	generator {
		message => '{"name": "John", "surname": "Doe"}'
		count => 1
		codec => json
	}
}

output {
	elasticsearch {
               # failure_type_logging_whitelist => ["cluster_block_exception"]
	       # silence_errors_in_log => ["cluster_block_exception"]
		index => "test_index"
		hosts => "http://localhost:9200"
		user => "elastic"
		password => "changeme"
		dlq_custom_codes => [403]
	}
}	
```

- [ ] enable the `failure_type_logging_whitelist` and check that a deprecation log is present in `logs/logstash-deprecation.log`. After the deprecation log the work as expected and doesn't log the content of the `403` responses from Elasticsearch
- [ ] comment `failure_type_logging_whitelist` and decomment the `silence_errors_in_log` and verify the feature work as expected (no log of error responses)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates https://github.com/elastic/logstash/issues/10493

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
