### PR TITLE
Add schema name to default host

### DIFF
--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -65,7 +65,7 @@ module LogStash; module PluginMixins; module ElasticSearch
       @hosts = Array(@hosts)
       if @hosts.empty?
         @logger.info("No 'host' set in elasticsearch output. Defaulting to localhost")
-        @hosts.replace(["localhost"])
+        @hosts.replace(["http://localhost:9200"])
       end
     end
 


### PR DESCRIPTION
Use `http://localhost:9200` instead of `localhost` when no host is set.

```
[2022-07-04T09:55:39,808][INFO ][logstash.outputs.elasticsearch][cdll-pipeline-production] New Elasticsearch output {:class=>"LogStash::Outputs::ElasticSearch", :hosts=>[]}
[2022-07-04T09:55:39,809][INFO ][logstash.outputs.elasticsearch][cdll-pipeline-production] No 'host' set in elasticsearch output. Defaulting to localhost
[2022-07-04T09:55:39,821][INFO ][logstash.outputs.elasticsearch] Using a default mapping template {:es_version=>8, :ecs_compatibility=>:disabled}
[2022-07-04T09:55:40,731][ERROR][logstash.javapipeline    ][my_custom-pipeline] Pipeline error {:pipeline_id=>"my_custom-pipeline", :exception=>#<NoMethodError: undefined method `scheme' for "localhost":String>, :backtrace=>["/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client_builder.rb:110:in `block in setup_ssl'", "org/jruby/RubyArray.java:4553:in `any?'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client_builder.rb:110:in `setup_ssl'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch/http_client_builder.rb:59:in `build'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/plugin_mixins/elasticsearch/common.rb:34:in `build_client'", "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.4.1-java/lib/logstash/outputs/elasticsearch.rb:279:in `register'", "org/logstash/config/ir/compiler/OutputStrategyExt.java:131:in `register'", "org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java:68:in `register'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:233:in `block in register_plugins'", "org/jruby/RubyArray.java:1821:in `each'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:232:in `register_plugins'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:598:in `maybe_setup_out_plugins'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:245:in `start_workers'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:190:in `run'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:142:in `block in start'"], "pipeline.sources"=>["/etc/logstash/conf.d/my-confs/my_logstash_pipeline.conf"], :thread=>"#<Thread:0x2c9bc14c@/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:130 run>"}
[2022-07-04T09:55:40,734][INFO ][logstash.javapipeline    ][my_custom-pipeline] Pipeline terminated {"pipeline.id"=>"my_custom-pipeline"}
[2022-07-04T09:55:40,737][ERROR][logstash.agent           ] Failed to execute action {:id=>:"my_custom-pipeline", :action_type=>LogStash::ConvergeResult::FailedAction, :message=>"Could not execute action: PipelineAction::Create<my_custom-pipeline>, action_result: false", :backtrace=>nil}
```

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
