### PR TITLE
Update the interface for adapting elasticsearch 8.0 templates

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -409,7 +409,7 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def template_endpoint
-      maximum_seen_major_version < 8 ? '_template' : '_index_template'
+      maximum_seen_major_version < 8 ? '_index_template' : '_template'
     end
 
     # ILM methods


### PR DESCRIPTION
The "_index_template" interface is deprecated after elasticsearch 8.0,at least in "8.3.2" version is no longer available

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

**Error message:**
[2022-07-12T11:27:24,029][INFO ][logstash.outputs.elasticsearch][elastiflow] Installing Elasticsearch template {:name=>"elastiflow-4.0.1"}
 111 [2022-07-12T11:27:24,107][ERROR][logstash.outputs.elasticsearch][elastiflow] Failed to install template {:message=>"Got response code '400' contacting Elasticsearch at URL 'http://127.0.0.1:     9200/_index_template/elastiflow-4.0.1'", :exception=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError, :backtrace=>["/home/master/xxx/env/logstash/vendor/bundle/jrub     y/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb:84:in `perform_request'", "/home/master/xxx/env/logstash/vendor/bu     ndle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:324:in `perform_request_to_url'", "/home/master/xxx/env/logstash/vendo     r/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:311:in `block in perform_request'", "/home/master/xxx/env/logstash     /vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:398:in `with_connection'", "/home/master/xxx/env/logstash/ve     ndor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:310:in `perform_request'", "/home/master/xxx/env/logstash/vendo     r/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client/pool.rb:318:in `block in Pool'", "/home/master/xxx/env/logstash/vendor/bun     dle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client.rb:408:in `template_put'", "/home/master/xxx/env/logstash/vendor/bundle/jruby/2     .5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/http_client.rb:85:in `template_install'", "/home/master/xxx/env/logstash/vendor/bundle/jruby/2.5.0/gem     s/logstash-output-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/template_manager.rb:29:in `install'", "/home/master/xxx/env/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-o     utput-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch/template_manager.rb:17:in `install_template'", "/home/master/xxx/env/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-outp     ut-elasticsearch-11.6.0-java/lib/logstash/outputs/elasticsearch.rb:494:in `install_template'", "/home/master/xxx/env/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11     .6.0-java/lib/logstash/outputs/elasticsearch.rb:318:in `finish_register'", "/home/master/xxx/env/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logsta     sh/outputs/elasticsearch.rb:283:in `block in register'", "/home/master/xxx/env/logstash/vendor/bundle/jruby/2.5.0/gems/logstash-output-elasticsearch-11.6.0-java/lib/logstash/plugin_mixins/e     lasticsearch/common.rb:154:in `block in after_successful_connection'"]}

