### PR TITLE
Validate the action before sending the bulk request to ES.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.10.0
+ - Feature: reject unsupported events before sending bulk request to Elasticsearch. [#1080](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1080)
+
 ## 11.9.0
  - Feature: force unresolved dynamic index names to be sent into DLQ. This feature could be explicitly disabled using `dlq_on_failed_indexname_interpolation` setting [#1084](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1084)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 11.10.0
- - Feature: reject unsupported events before sending bulk request to Elasticsearch. [#1080](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1080)
+## 11.9.1
+ - Fixes a possible infinite-retry-loop that could occur when this plugin is configured with an `action` whose value contains a [sprintf-style placeholder][] that fails to be resolved for an individual event. Events in this state will be routed to the pipeline's [dead letter queue][DLQ] if it is available, or will be logged-and-dropped so that the remaining events in the batch can be processed [#1080](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1080)
+ 
+[sprintf-style placeholder]: https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#sprintf
+[DLQ]: https://www.elastic.co/guide/en/logstash/current/dead-letter-queues.html
 
 ## 11.9.0
  - Feature: force unresolved dynamic index names to be sent into DLQ. This feature could be explicitly disabled using `dlq_on_failed_indexname_interpolation` setting [#1084](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1084)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/log
 
 ## Developing
 
-### 1. Plugin Developement and Testing
+### 1. Plugin Development and Testing
 
 #### Code
 - To get started, you'll need JRuby with the Bundler gem installed.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -395,7 +395,7 @@ The Elasticsearch action to perform. Valid actions are:
   document if not already present. See the `doc_as_upsert` option. NOTE: This does not work and is not supported
   in Elasticsearch 1.x. Please upgrade to ES 2.x or greater to use this feature with Logstash!
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
-  would use the foo field for the action. If resolved action is not in [`index`, `delete`, `create`, `update`], the event will be ignored and send to DLQ, if enabled.
+  would use the foo field for the action. If resolved action is not in [`index`, `delete`, `create`, `update`], the event will not be sent to {es}, and instead either will be sent to the pipeline's <<dead-letter-queues,dead letter queue (DLQ)>> if it is enabled, or will be logged and dropped.
 
 For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bulk API documentation].
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -395,7 +395,7 @@ The Elasticsearch action to perform. Valid actions are:
   document if not already present. See the `doc_as_upsert` option. NOTE: This does not work and is not supported
   in Elasticsearch 1.x. Please upgrade to ES 2.x or greater to use this feature with Logstash!
 - A sprintf style string to change the action based on the content of the event. The value `%{[foo]}`
-  would use the foo field for the action
+  would use the foo field for the action. If resolved action is not in [`index`, `delete`, `create`, `update`], the event will be ignored and send to DLQ, if enabled.
 
 For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bulk API documentation].
 

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -151,7 +151,7 @@ module LogStash; module Outputs; class ElasticSearch;
                    :payload_size => stream_writer.pos,
                    :content_length => body_stream.size,
                    :batch_offset => (actions.size - batch_actions.size))
-      bulk_responses << bulk_send(body_stream, batch_actions)
+      bulk_responses << bulk_send(body_stream, batch_actions) if body_stream.size > 0
 
       body_stream.close if !http_compression
       join_bulk_responses(bulk_responses)

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -165,7 +165,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def retrying_submit(actions)
-      # filter out unsupported ES actions
+      # reject unsupported ES actions and keep only valid actions to send to ES
       submit_actions = reject_unsupported_actions(actions)
       sleep_interval = @retry_initial_interval
 

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -198,7 +198,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     def filter_unsupported_actions(actions)
       return if actions.nil? || actions.size < 1
       supported_actions, unsupported_actions = actions.partition { |action, _, _| LogStash::Outputs::ElasticSearch::VALID_HTTP_ACTIONS.include?(action) }
-      unless unsupported_actions.nil? && unsupported_actions.size == 0
+      if !unsupported_actions.nil? && unsupported_actions.size > 0
         handle_dlq_or_drop(unsupported_actions)
         @logger.warn("Number of requests filtered out before sending to Elasticsearch because of unsupported action, ", size: actions.size)
       end

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -165,11 +165,11 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def retrying_submit(actions)
-      # Initially we submit the full list of actions
-      # filter out invalid ES unsupported actions
+      # filter out unsupported ES actions
       submit_actions = filter_unsupported_actions(actions)
       sleep_interval = @retry_initial_interval
 
+      # Initially we submit the full list of valid actions
       while submit_actions && submit_actions.size > 0
 
         # We retry with whatever is didn't succeed
@@ -196,7 +196,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     # method filters out unsupported actions by warning, writes event to DQL if enabled
     # @returns valid actions
     def filter_unsupported_actions(actions)
-      return if actions.empty? || actions.size < 1
+      return if actions.nil? || actions.size < 1
       grouped_actions = actions.group_by { |action, arg, source | LogStash::Outputs::ElasticSearch::VALID_HTTP_ACTIONS.include?(action) }
       unless grouped_actions[false].nil?
         @logger.warn("Number of requests filtered out before sending to Elasticsearch because of unsupported action, ", size: grouped_actions[false].size)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.10.0'
+  s.version         = '11.9.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cabin', ['~> 0.6']
   s.add_development_dependency 'webrick'
   s.add_development_dependency 'webmock'
+  s.add_development_dependency 'rspec-collection_matchers'
   # Still used in some specs, we should remove this ASAP
   s.add_development_dependency 'elasticsearch'
 end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.9.0'
+  s.version         = '11.10.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -137,7 +137,7 @@ describe "indexing with sprintf resolution", :integration => true do
     before { subject.instance_variable_set('@dlq_writer', dlq_writer) }
 
     it "should doesn't create an index name with unresolved placeholders" do
-      expect(dlq_writer).to receive(:write).once.with(event, /Could not resolve dynamic index/)
+      expect(dlq_writer).to receive(:write).once.with(event, a_string_including("Badly formatted index, after interpolation still contains placeholder"))
       subject.multi_receive(events)
 
       escaped_index_name = CGI.escape("%{[index_name]}_dynamic")

--- a/spec/integration/outputs/unsupported_actions_spec.rb
+++ b/spec/integration/outputs/unsupported_actions_spec.rb
@@ -59,8 +59,8 @@ describe "Unsupported actions testing...", :integration => true do
         action.eql?("index") || action.eql?("update")
       end
 
-      indexed_events = events.filter { |event| index_or_update.call(event) }
-      rejected_events = events.filter { |event| !index_or_update.call(event) }
+      indexed_events = events.select { |event| index_or_update.call(event) }
+      rejected_events = events.select { |event| !index_or_update.call(event) }
 
       indexed_events.each do |event|
         response = @es.get(:index => INDEX, :type => doc_type, :id => event.get("doc_id"), :refresh => true)

--- a/spec/integration/outputs/unsupported_actions_spec.rb
+++ b/spec/integration/outputs/unsupported_actions_spec.rb
@@ -1,0 +1,60 @@
+require_relative "../../../spec/es_spec_helper"
+
+describe "Unsupported actions testing...", :integration => true do
+  require "logstash/outputs/elasticsearch"
+
+  INDEX = "logstash-unsupported-actions-rejected"
+
+  def get_es_output( options={} )
+    settings = {
+      "manage_template" => true,
+      "index" => INDEX,
+      "template_overwrite" => true,
+      "hosts" => get_host_port(),
+      "action" => "%{action_field}",
+      "id" => "%{doc_id}"
+    }
+    LogStash::Outputs::ElasticSearch.new(settings.merge!(options))
+  end
+
+  before :each do
+    @es = get_client
+    # Delete all templates first.
+    # Clean ES of data before we start.
+    @es.indices.delete_template(:name => "*")
+    # This can fail if there are no indexes, ignore failure.
+    @es.indices.delete(:index => "*") rescue nil
+    # index single doc for update purpose
+    @es.index(
+      :index => INDEX,
+      :type => doc_type,
+      :id => "2",
+      :body => { :message => 'Test', :counter => 1 }
+    )
+    @es.indices.refresh
+  end
+
+  context "multiple actions include unsupported action" do
+    let(:events) {[
+      LogStash::Event.new("action_field" => "index", "id" => 1, "message"=> "hello"),
+      LogStash::Event.new("action_field" => "update", "id" => 2, "message"=> "hi"),
+      LogStash::Event.new("action_field" => "delete", "id" => 3, "message"=> "bye"),
+      LogStash::Event.new("action_field" => "unsupported_action", "id" => 4, "message"=> "world!")
+    ]}
+
+    it "should reject unsupported doc" do
+      subject = get_es_output
+      subject.register
+      subject.multi_receive(events)
+      events.each do | event |
+        action = event.get("action_field")
+        if action.eql?("index") || action.eql?("update")
+          response = @es.get(:index => INDEX, :type => doc_type, :id => event.get("id"), :refresh => true)
+          expect(response['_source']['message']).to eq(event.get("message"))
+        else
+          expect {@es.get(:index => INDEX, :type => doc_type, :id => event.get("id"), :refresh => true)}.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -267,21 +267,6 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
           end
         end
 
-        context "with partial unsupported action" do
-          let(:actions) { [
-            ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> "hello"}],
-            ["unsupported_action", {:_id=>nil, :_index=>"logstash"}, {"message"=> "world!"}],
-          ]}
-          it "executes one bulk_send operation" do
-            allow(subject).to receive(:join_bulk_responses)
-            expect(subject).to receive(:bulk_send).once do |body_stream, batch_actions|
-              action, source = batch_actions.first
-              action_type, input_args, source = actions[0]
-              expect(action["index"]).to match(input_args)
-            end
-            subject.send(:bulk, actions)
-          end
-        end
        end
      end
   end

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -266,6 +266,18 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
             end
           end
         end
+
+        context "with partial unsupported action" do
+          let(:actions) { [
+            ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> "hello"}],
+            ["unsupported_action", {:_id=>nil, :_index=>"logstash"}, {"message"=> "world!"}],
+          ]}
+          it "executes one bulk_send operation" do
+            allow(subject).to receive(:join_bulk_responses)
+            expect(subject).to receive(:bulk_send).once
+            s = subject.send(:bulk, actions)
+          end
+        end
        end
      end
   end

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -274,8 +274,12 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
           ]}
           it "executes one bulk_send operation" do
             allow(subject).to receive(:join_bulk_responses)
-            expect(subject).to receive(:bulk_send).once
-            s = subject.send(:bulk, actions)
+            expect(subject).to receive(:bulk_send).once do |body_stream, batch_actions|
+              action, source = batch_actions.first
+              action_type, input_args, source = actions[0]
+              expect(action["index"]).to match(input_args)
+            end
+            subject.send(:bulk, actions)
           end
         end
        end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -347,7 +347,7 @@ describe LogStash::Outputs::ElasticSearch do
                               }
                     },
                     # NOTE: this is an artificial success (usually everything fails with a 500) but even if some doc where
-                    # to succeed due the unexpected reponse items we can not clearly identify which actions to retry ...
+                    # to succeed due the unexpected response items we can not clearly identify which actions to retry ...
                     {"index"=>{"_index"=>"bar2", "_type"=>"_doc", "_id"=>nil, "status"=>201}},
                     {"index"=>{"_index"=>"bar2", "_type"=>"_doc", "_id"=>nil, "status"=>500,
                                "error"=>{"type" => "illegal_state_exception",
@@ -379,6 +379,88 @@ describe LogStash::Outputs::ElasticSearch do
                                                        hash_including(:message => 'Sent 2 documents but Elasticsearch returned 3 responses (likely a bug with _bulk endpoint)'))
 
         subject.multi_receive(events)
+      end
+    end
+
+    context "unsupported actions" do
+      # to capture the logs to meet our expectations
+      before { subject.instance_variable_set '@dlq_writer', nil }
+      let(:logger_stub) { double("logger").as_null_object }
+      let(:options) { super().merge("index" => "%{index}", "action" => "%{action_field}") }
+
+      context "with multiple valid actions with one trailing invalid action" do
+        let(:events) {[
+          LogStash::Event.new("action_field" => "index", "id" => 1, "message"=> "hello"),
+          LogStash::Event.new("action_field" => "index", "id" => 2, "message"=> "hi"),
+          LogStash::Event.new("action_field" => "index", "id" => 3, "message"=> "bye"),
+          LogStash::Event.new("action_field" => "unsupported_action", "id" => 4, "message"=> "world!")
+        ]}
+        it "rejects unsupported actions" do
+          event_action_tuples = elasticsearch_output_instance.map_events(events)
+          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
+          expect(valid_actions.size).to be == 3
+          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported")
+        end
+      end
+
+      context "with one leading invalid action followed by multiple valid actions" do
+        let(:events) {[
+          LogStash::Event.new("action_field" => "unsupported_action", "id" => 1, "message"=> "world!"),
+          LogStash::Event.new("action_field" => "index", "id" => 2, "message"=> "hello"),
+          LogStash::Event.new("action_field" => "index", "id" => 3, "message"=> "hi"),
+          LogStash::Event.new("action_field" => "index", "id" => 4, "message"=> "bye")
+        ]}
+        it "rejects unsupported actions" do
+          event_action_tuples = elasticsearch_output_instance.map_events(events)
+          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
+          expect(valid_actions.size).to be == 3
+          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+        end
+      end
+
+      context "with batch of multiple invalid actions and no valid actions" do
+        let(:events) {[
+          LogStash::Event.new("action_field" => "unsupported_action1", "id" => 1, "message"=> "world!"),
+          LogStash::Event.new("action_field" => "unsupported_action2", "id" => 2, "message"=> "hello"),
+          LogStash::Event.new("action_field" => "unsupported_action3", "id" => 3, "message"=> "hi"),
+          LogStash::Event.new("action_field" => "unsupported_action4", "id" => 4, "message"=> "bye")
+        ]}
+        it "rejects unsupported actions" do
+          event_action_tuples = elasticsearch_output_instance.map_events(events)
+          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
+          expect(valid_actions.size).to be == 0
+          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+        end
+      end
+
+      context "with batch of intermixed valid and invalid actions" do
+        let(:events) {[
+          LogStash::Event.new("action_field" => "index", "id" => 1, "message"=> "world!"),
+          LogStash::Event.new("action_field" => "unsupported_action2", "id" => 2, "message"=> "hello"),
+          LogStash::Event.new("action_field" => "unsupported_action3", "id" => 3, "message"=> "hi"),
+          LogStash::Event.new("action_field" => "index", "id" => 4, "message"=> "bye")
+        ]}
+        it "rejects unsupported actions" do
+          event_action_tuples = elasticsearch_output_instance.map_events(events)
+          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
+          expect(valid_actions.size).to be == 2
+          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+        end
+      end
+
+      context "with batch of exactly one action that is invalid" do
+        let(:events) {[
+          LogStash::Event.new("action_field" => "index", "id" => 1, "message"=> "world!"),
+          LogStash::Event.new("action_field" => "index", "id" => 2, "message"=> "hello"),
+          LogStash::Event.new("action_field" => "unsupported_action3", "id" => 3, "message"=> "hi"),
+          LogStash::Event.new("action_field" => "index", "id" => 4, "message"=> "bye")
+        ]}
+        it "rejects unsupported action" do
+          event_action_tuples = elasticsearch_output_instance.map_events(events)
+          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
+          expect(valid_actions.size).to be == 3
+          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+        end
       end
     end
   end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -393,10 +393,9 @@ describe LogStash::Outputs::ElasticSearch do
           LogStash::Event.new("action_field" => "unsupported_action", "id" => 4, "message"=> "world!")
         ]}
         it "rejects unsupported actions" do
-          event_action_tuples = subject.map_events(events)
-          valid_actions = subject.reject_unsupported_actions(event_action_tuples)
-          expect(valid_actions.size).to be == 3
-          valid_actions.each do |action, _|
+          event_result = subject.send(:safe_interpolation_map_events, events)
+          expect(event_result.successful_events.size).to be == 3
+          event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
         end
@@ -410,10 +409,9 @@ describe LogStash::Outputs::ElasticSearch do
           LogStash::Event.new("action_field" => "index", "id" => 4, "message"=> "bye")
         ]}
         it "rejects unsupported actions" do
-          event_action_tuples = elasticsearch_output_instance.map_events(events)
-          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
-          expect(valid_actions.size).to be == 3
-          valid_actions.each do |action, _|
+          event_result = subject.send(:safe_interpolation_map_events, events)
+          expect(event_result.successful_events.size).to be == 3
+          event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
         end
@@ -427,10 +425,9 @@ describe LogStash::Outputs::ElasticSearch do
           LogStash::Event.new("action_field" => "unsupported_action4", "id" => 4, "message"=> "bye")
         ]}
         it "rejects unsupported actions" do
-          event_action_tuples = elasticsearch_output_instance.map_events(events)
-          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
-          expect(valid_actions.size).to be == 0
-          valid_actions.each do |action, _|
+          event_result = subject.send(:safe_interpolation_map_events, events)
+          expect(event_result.successful_events.size).to be == 0
+          event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
         end
@@ -444,9 +441,8 @@ describe LogStash::Outputs::ElasticSearch do
           LogStash::Event.new("action_field" => "index", "id" => 4, "message"=> "bye")
         ]}
         it "rejects unsupported actions" do
-          event_action_tuples = elasticsearch_output_instance.map_events(events)
-          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
-          expect(valid_actions.size).to be == 2
+          event_result = subject.send(:safe_interpolation_map_events, events)
+          expect(event_result.successful_events.size).to be == 2
           # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
         end
       end
@@ -459,9 +455,8 @@ describe LogStash::Outputs::ElasticSearch do
           LogStash::Event.new("action_field" => "index", "id" => 4, "message"=> "bye")
         ]}
         it "rejects unsupported action" do
-          event_action_tuples = elasticsearch_output_instance.map_events(events)
-          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
-          expect(valid_actions.size).to be == 3
+          event_result = subject.send(:safe_interpolation_map_events, events)
+          expect(event_result.successful_events.size).to be == 3
           # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
         end
       end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -3,8 +3,8 @@ require "base64"
 require "flores/random"
 require 'concurrent/atomic/count_down_latch'
 require "logstash/outputs/elasticsearch"
-
 require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
+require 'rspec/collection_matchers'
 
 describe LogStash::Outputs::ElasticSearch do
   subject(:elasticsearch_output_instance) { described_class.new(options) }
@@ -394,10 +394,11 @@ describe LogStash::Outputs::ElasticSearch do
         ]}
         it "rejects unsupported actions" do
           event_result = subject.send(:safe_interpolation_map_events, events)
-          expect(event_result.successful_events.size).to be == 3
+          expect(event_result.successful_events).to have_exactly(3).items
           event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
+          expect(event_result.event_mapping_errors).to have_exactly(1).items
           event_result.event_mapping_errors.each do |event_mapping_error|
             expect(event_mapping_error.message).to eql("Elasticsearch doesn't support [unsupported_action] action")
           end
@@ -413,10 +414,11 @@ describe LogStash::Outputs::ElasticSearch do
         ]}
         it "rejects unsupported actions" do
           event_result = subject.send(:safe_interpolation_map_events, events)
-          expect(event_result.successful_events.size).to be == 3
+          expect(event_result.successful_events).to have_exactly(3).items
           event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
+          expect(event_result.event_mapping_errors).to have_exactly(1).items
           event_result.event_mapping_errors.each do |event_mapping_error|
             expect(event_mapping_error.message).to eql("Elasticsearch doesn't support [unsupported_action] action")
           end
@@ -432,10 +434,11 @@ describe LogStash::Outputs::ElasticSearch do
         ]}
         it "rejects unsupported actions" do
           event_result = subject.send(:safe_interpolation_map_events, events)
-          expect(event_result.successful_events.size).to be == 0
+          expect(event_result.successful_events).to have(:no).items
           event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
+          expect(event_result.event_mapping_errors).to have_exactly(4).items
           event_result.event_mapping_errors.each do |event_mapping_error|
             expect(event_mapping_error.message).to include "Elasticsearch doesn't support"
           end
@@ -451,8 +454,8 @@ describe LogStash::Outputs::ElasticSearch do
         ]}
         it "rejects unsupported actions" do
           event_result = subject.send(:safe_interpolation_map_events, events)
-          expect(event_result.successful_events.size).to be == 2
-          expect(event_result.event_mapping_errors.size).to be == 2
+          expect(event_result.successful_events).to have_exactly(2).items
+          expect(event_result.event_mapping_errors).to have_exactly(2).items
           event_result.event_mapping_errors.each do |event_mapping_error|
             expect(event_mapping_error.message).to include "Elasticsearch doesn't support"
           end
@@ -468,7 +471,8 @@ describe LogStash::Outputs::ElasticSearch do
         ]}
         it "rejects unsupported action" do
           event_result = subject.send(:safe_interpolation_map_events, events)
-          expect(event_result.successful_events.size).to be == 3
+          expect(event_result.successful_events).to have_exactly(3).items
+          expect(event_result.event_mapping_errors).to have_exactly(1).items
           event_result.event_mapping_errors.each do |event_mapping_error|
             expect(event_mapping_error.message).to eql("Elasticsearch doesn't support [unsupported_action3] action")
           end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -383,10 +383,7 @@ describe LogStash::Outputs::ElasticSearch do
     end
 
     context "unsupported actions" do
-      # to capture the logs to meet our expectations
-      before { subject.instance_variable_set '@dlq_writer', nil }
-      let(:logger_stub) { double("logger").as_null_object }
-      let(:options) { super().merge("index" => "%{index}", "action" => "%{action_field}") }
+      let(:options) { super().merge("index" => "logstash", "action" => "%{action_field}") }
 
       context "with multiple valid actions with one trailing invalid action" do
         let(:events) {[
@@ -396,10 +393,12 @@ describe LogStash::Outputs::ElasticSearch do
           LogStash::Event.new("action_field" => "unsupported_action", "id" => 4, "message"=> "world!")
         ]}
         it "rejects unsupported actions" do
-          event_action_tuples = elasticsearch_output_instance.map_events(events)
-          valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
+          event_action_tuples = subject.map_events(events)
+          valid_actions = subject.reject_unsupported_actions(event_action_tuples)
           expect(valid_actions.size).to be == 3
-          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported")
+          valid_actions.each do |action, _|
+            expect(action).to_not eql("unsupported_action")
+          end
         end
       end
 
@@ -414,7 +413,9 @@ describe LogStash::Outputs::ElasticSearch do
           event_action_tuples = elasticsearch_output_instance.map_events(events)
           valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
           expect(valid_actions.size).to be == 3
-          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+          valid_actions.each do |action, _|
+            expect(action).to_not eql("unsupported_action")
+          end
         end
       end
 
@@ -429,7 +430,9 @@ describe LogStash::Outputs::ElasticSearch do
           event_action_tuples = elasticsearch_output_instance.map_events(events)
           valid_actions = elasticsearch_output_instance.reject_unsupported_actions(event_action_tuples)
           expect(valid_actions.size).to be == 0
-          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+          valid_actions.each do |action, _|
+            expect(action).to_not eql("unsupported_action")
+          end
         end
       end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -857,6 +857,7 @@ describe LogStash::Outputs::ElasticSearch do
 
     context 'when @dlq_writer is nil' do
       before { subject.instance_variable_set '@dlq_writer', nil }
+      let(:action) { LogStash::Outputs::ElasticSearch::EventActionTuple.new(:action, :params, LogStash::Event.new("foo" => "bar")) }
 
       context 'resorting to previous behaviour of logging the error' do
         context 'getting an invalid_index_name_exception' do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -398,6 +398,9 @@ describe LogStash::Outputs::ElasticSearch do
           event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
+          event_result.event_mapping_errors.each do |event_mapping_error|
+            expect(event_mapping_error.message).to eql("Elasticsearch doesn't support [unsupported_action] action")
+          end
         end
       end
 
@@ -413,6 +416,9 @@ describe LogStash::Outputs::ElasticSearch do
           expect(event_result.successful_events.size).to be == 3
           event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
+          end
+          event_result.event_mapping_errors.each do |event_mapping_error|
+            expect(event_mapping_error.message).to eql("Elasticsearch doesn't support [unsupported_action] action")
           end
         end
       end
@@ -430,6 +436,9 @@ describe LogStash::Outputs::ElasticSearch do
           event_result.successful_events.each do |action, _|
             expect(action).to_not eql("unsupported_action")
           end
+          event_result.event_mapping_errors.each do |event_mapping_error|
+            expect(event_mapping_error.message).to include "Elasticsearch doesn't support"
+          end
         end
       end
 
@@ -443,7 +452,10 @@ describe LogStash::Outputs::ElasticSearch do
         it "rejects unsupported actions" do
           event_result = subject.send(:safe_interpolation_map_events, events)
           expect(event_result.successful_events.size).to be == 2
-          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+          expect(event_result.event_mapping_errors.size).to be == 2
+          event_result.event_mapping_errors.each do |event_mapping_error|
+            expect(event_mapping_error.message).to include "Elasticsearch doesn't support"
+          end
         end
       end
 
@@ -457,7 +469,9 @@ describe LogStash::Outputs::ElasticSearch do
         it "rejects unsupported action" do
           event_result = subject.send(:safe_interpolation_map_events, events)
           expect(event_result.successful_events.size).to be == 3
-          # expect(logger_stub).to have_received(:warn).with(a_string_including "Could not index event to Elasticsearch because its action is not supported.")
+          event_result.event_mapping_errors.each do |event_mapping_error|
+            expect(event_mapping_error.message).to eql("Elasticsearch doesn't support [unsupported_action3] action")
+          end
         end
       end
     end


### PR DESCRIPTION
# This PR is under process
We have common logics with #1084, rebasing and leveraging the changes. 

## What this PR does?
Plugin receives `400 Validation Failed: 1: no requests added` exception when requesting unsupported bulk action.
This PR introduces a validation check on action before sending bulk request to ES.

Closes #1079 

## Test
### Manual testing
  - Used configuration to read from JSON file and send to ES. File contains an action field which is not in [`index`, `create`, `update`, `delete`]
```
   input {
      file {
          path => "/path/to/files/*.json"
          start_position => "beginning"
          codec => "json"
      }
   }
   output {
     elasticsearch {
       ....
       action => "%{[@metadata][action]}"
     }
   }
```
 - Result
```
[2022-09-09T11:59:44,810][WARN ][logstash.outputs.elasticsearch][main][ca10f590b6ab3366bc38f754293adbd2499c9d97aedd7933d11542cd26cd056d] Could not index event to Elasticsearch because its action is not supported. Action: ["partialupdate", {:_id=>"5412e1fe-7822-4440-86b6-5b508ab99229", :_index=>"logstash-test-output", :routing=>nil}, {"eventData"=>....}]
```

### Unit testing
  - Run the unit test
  `rspec spec/unit/outputs/elasticsearch_spec.rb`


### Logs
```
[2022-09-21T09:55:33,170][WARN ][logstash.outputs.elasticsearch][main][02e543d9daaf1e2af9190a6aef2cb91aa012fabaf7756093f487d85b2b9224de] Badly formatted index, after interpolation still contains placeholder: [%{[index_name]}], {"action"=>"index", "host"=>{"name"=>"dhcp-128-189-70-158"}, "name"=>"TEST", "source"=>"template", "@timestamp"=>2022-09-21T16:55:33.045630Z, "type"=>"TEST", "version"=>1, "@version"=>"1", "log"=>{"file"=>{"path"=>"/Users/mashhur/Dev/elastic/SDH/test2.json"}}, "event"=>{"original"=>"{\"name\":\"TEST\",\"type\":\"TEST\",\"action\":\"index\",\"source\":\"template\",\"version\":1}"}}

[2022-09-21T09:55:33,171][WARN ][logstash.outputs.elasticsearch][main][02e543d9daaf1e2af9190a6aef2cb91aa012fabaf7756093f487d85b2b9224de] Elasticsearch doesn't support [partialupdate] action, {"action"=>"partialupdate", "host"=>{"name"=>"dhcp-128-189-70-158"}, "source"=>"template", "type"=>"TEST", "index_name"=>"logstash-output", "@version"=>"1", "log"=>{"file"=>{"path"=>"/Users/mashhur/Dev/elastic/SDH/test2.json"}}, "event"=>{"original"=>"{\"name\":\"TEST\",\"type\":\"TEST\",\"action\":\"partialupdate\",\"source\":\"template\",\"version\":1,\"index_name\":\"logstash-output\"}"}, "name"=>"TEST", "@timestamp"=>2022-09-21T16:55:33.052311Z, "version"=>1}


[2022-09-21T09:55:33,171][WARN ][logstash.outputs.elasticsearch][main][02e543d9daaf1e2af9190a6aef2cb91aa012fabaf7756093f487d85b2b9224de] Can't map the event, needs to configure the pipeline settings according to the input. The event sent to DLQ: Badly formatted index, after interpolation still contains placeholder: [%{[index_name]}], {"action"=>"index", "host"=>{"name"=>"dhcp-128-189-70-158."}, "name"=>"TEST", "source"=>"template", "@timestamp"=>2022-09-21T16:55:33.045630Z, "type"=>"TEST", "version"=>1, "@version"=>"1", "log"=>{"file"=>{"path"=>"/Users/mashhur/Dev/elastic/SDH/test2.json"}}, "event"=>{"original"=>"{\"name\":\"TEST\",\"type\":\"TEST\",\"action\":\"index\",\"source\":\"template\",\"version\":1}"}}


[2022-09-21T09:55:33,171][WARN ][logstash.outputs.elasticsearch][main][02e543d9daaf1e2af9190a6aef2cb91aa012fabaf7756093f487d85b2b9224de] Can't map the event, needs to configure the pipeline settings according to the input. The event sent to DLQ: Elasticsearch doesn't support [partialupdate] action, {"action"=>"partialupdate", "host"=>{"name"=>"dhcp-128-189-70-158"}, "source"=>"template", "type"=>"TEST", "index_name"=>"logstash-output", "@version"=>"1", "log"=>{"file"=>{"path"=>"/Users/mashhur/Dev/elastic/SDH/test2.json"}}, "event"=>{"original"=>"{\"name\":\"TEST\",\"type\":\"TEST\",\"action\":\"partialupdate\",\"source\":\"template\",\"version\":1,\"index_name\":\"logstash-output\"}"}, "name"=>"TEST", "@timestamp"=>2022-09-21T16:55:33.052311Z, "version"=>1}
```