### PR TITLE
Route badly interpolated dynamic index to DLQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.9.0
+ - Feature: force unresolved dynamic index names to be sent into DLQ. This feature could be explicitly disabled using `dlq_on_failed_indexname_interpolation` setting [#1084](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1084)
+
 ## 11.8.0
  - Feature: Adds a new `dlq_custom_codes` option to customize DLQ codes [#1067](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1067)
  

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -320,6 +320,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-data_stream_sync_fields>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-data_stream_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-dlq_custom_codes>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-dlq_on_failed_indexname_interpolation>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-doc_as_upsert>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-document_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-document_type>> |<<string,string>>|No
@@ -532,6 +533,14 @@ List single-action error codes from Elasticsearch's Bulk API that are considered
 This list is an addition to the ordinary error codes considered for this feature, 400 and 404.
 It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
 The option accepts a list of natural numbers corresponding to HTTP errors codes.
+
+[id="plugins-{type}s-{plugin}-dlq_on_failed_indexname_interpolation"]
+===== `dlq_on_failed_indexname_interpolation`
+
+* Value type is <<boolean,boolean>>
+* Default value is `true`.
+
+If enabled, failed index name interpolation events go into dead letter queue.
 
 [id="plugins-{type}s-{plugin}-doc_as_upsert"]
 ===== `doc_as_upsert`

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -479,7 +479,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     raise IndexInterpolationError, sprintf_index if sprintf_index.match(/%{.*?}/)
     params = {
         :_id => @document_id ? event.sprintf(@document_id) : nil,
-         :_index => sprintf_index,
+        :_index => sprintf_index,
         routing_field_name => @routing ? event.sprintf(@routing) : nil
     }
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -374,9 +374,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   private
   def send_failed_resolutions_to_dlq(failed_action_tuples)
     failed_action_tuples.each do |action|
-      status = nil
-      response = {}
-      handle_dlq_status("Could not resolve dynamic index", action, status, response)
+#       status = nil
+#       response = {}
+#       handle_dlq_status("Could not resolve dynamic index", action, status, response)
+      handle_dlq_status(action, "warn", "Could not resolve dynamic index")
     end
   end
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -374,9 +374,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   private
   def send_failed_resolutions_to_dlq(failed_action_tuples)
     failed_action_tuples.each do |action|
-#       status = nil
-#       response = {}
-#       handle_dlq_status("Could not resolve dynamic index", action, status, response)
       handle_dlq_status(action, "warn", "Could not resolve dynamic index")
     end
   end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.8.0'
+  s.version         = '11.9.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -162,34 +162,6 @@ describe "indexing" do
   let(:es_admin) { 'admin' } # default user added in ES -> 8.x requires auth credentials for /_refresh etc
   let(:es_admin_pass) { 'elastic' }
 
-#   def curl_and_get_json_response(url, method: :get); require 'open3'
-#     cmd = "curl -s -v --show-error #{curl_opts} -X #{method.to_s.upcase} -k #{url}"
-#     begin
-#       out, err, status = Open3.capture3(cmd)
-#     rescue Errno::ENOENT
-#       fail "curl not available, make sure curl binary is installed and available on $PATH"
-#     end
-#
-#     if status.success?
-#       http_status = err.match(/< HTTP\/1.1 (\d+)/)[1] || '0' # < HTTP/1.1 200 OK\r\n
-#
-#       if http_status.strip[0].to_i > 2
-#         error = (LogStash::Json.load(out)['error']) rescue nil
-#         if error
-#           fail "#{cmd.inspect} received an error: #{http_status}\n\n#{error.inspect}"
-#         else
-#           warn out
-#           fail "#{cmd.inspect} unexpected response: #{http_status}\n\n#{err}"
-#         end
-#       end
-#
-#       LogStash::Json.load(out)
-#     else
-#       warn out
-#       fail "#{cmd.inspect} process failed: #{status}\n\n#{err}"
-#     end
-#   end
-
   let(:initial_events) { [] }
 
   let(:do_register) { true }

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -133,8 +133,11 @@ describe "indexing with sprintf resolution", :integration => true do
 
   context "when dynamic field doesn't resolve the index_name" do
     let(:event) { LogStash::Event.new("message" => message, "type" => type) }
+    let(:dlq_writer) { double('DLQ writer') }
+    before { subject.instance_variable_set('@dlq_writer', dlq_writer) }
 
     it "should doesn't create an index name with unresolved placeholders" do
+      expect(dlq_writer).to receive(:write).once.with(event, /Could not resolve dynamic index/)
       subject.multi_receive(events)
 
       escaped_index_name = CGI.escape("%{[index_name]}_dynamic")

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -1,5 +1,6 @@
 require_relative "../../../spec/es_spec_helper"
 require "logstash/outputs/elasticsearch"
+require 'cgi'
 
 describe "TARGET_BULK_BYTES", :integration => true do
   let(:target_bulk_bytes) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES }
@@ -45,6 +46,126 @@ describe "TARGET_BULK_BYTES", :integration => true do
   end
 end
 
+def curl_and_get_json_response(url, method: :get); require 'open3'
+  cmd = "curl -s -v --show-error #{curl_opts} -X #{method.to_s.upcase} -k #{url}"
+  begin
+    out, err, status = Open3.capture3(cmd)
+  rescue Errno::ENOENT
+    fail "curl not available, make sure curl binary is installed and available on $PATH"
+  end
+
+  puts "DNADBG>>> out: #{out}"
+  puts "DNADBG>>> err: #{err}"
+  puts "DNADBG>>> status: #{status}"
+
+  if status.success?
+    http_status = err.match(/< HTTP\/1.1 (\d+)/)[1] || '0' # < HTTP/1.1 200 OK\r\n
+
+    if http_status.strip[0].to_i > 2
+      error = (LogStash::Json.load(out)['error']) rescue nil
+      if error
+        fail "#{cmd.inspect} received an error: #{http_status}\n\n#{error.inspect}"
+      else
+        warn out
+        fail "#{cmd.inspect} unexpected response: #{http_status}\n\n#{err}"
+      end
+    end
+
+    LogStash::Json.load(out)
+  else
+    warn out
+    fail "#{cmd.inspect} process failed: #{status}\n\n#{err}"
+  end
+end
+
+# DBG
+# def curl_and_get_response(url, method: :get); require 'open3'
+#   cmd = "curl -s -v --show-error #{curl_opts} -X #{method.to_s.upcase} -k #{url}"
+#   begin
+#     out, err, status = Open3.capture3(cmd)
+#   rescue Errno::ENOENT
+#     fail "curl not available, make sure curl binary is installed and available on $PATH"
+#   end
+#   puts "DNADBG>>> out: #{out}"
+#   puts "DNADBG>>> err: #{err}"
+#   puts "DNADBG>>> status: #{status}"
+# end
+# DBG
+
+describe "indexing andsel", :integration => true do
+  let(:message) { "Hello from #{__FILE__}" }
+  let(:event) { LogStash::Event.new("message" => message, "type" => type) }
+  let (:index) { "%{[index_name]}_dynamic" }
+  let(:type) { ESHelper.es_version_satisfies?("< 7") ? "doc" : "_doc" }
+  let(:event_count) { 1 }
+  let(:user) { "simpleuser" }
+  let(:password) { "abc123" }
+  let(:config) do
+    {
+      "hosts" => [ get_host_port ],
+      "user" => user,
+      "password" => password,
+      "index" => index
+    }
+  end
+  let(:events) { event_count.times.map { event }.to_a }
+  subject { LogStash::Outputs::ElasticSearch.new(config) }
+
+  let(:es_url) { "http://#{get_host_port}" }
+  let(:index_url) { "#{es_url}/#{index}" }
+
+  let(:curl_opts) { nil }
+
+  let(:es_admin) { 'admin' } # default user added in ES -> 8.x requires auth credentials for /_refresh etc
+  let(:es_admin_pass) { 'elastic' }
+
+  let(:initial_events) { [] }
+
+  let(:do_register) { true }
+
+  before do
+    subject.register if do_register
+    subject.multi_receive(initial_events) if initial_events
+  end
+
+  after do
+    subject.do_close
+  end
+
+  context "with sprintf" do
+    let(:event) { LogStash::Event.new("message" => message, "type" => type, "index_name" => "test") }
+
+    it "should index successfully when field is resolved" do
+      expected_index_name = "test_dynamic"
+      subject.multi_receive(events)
+
+#        curl_and_get_response "#{es_url}/_cat/indices"
+
+#       curl_and_get_json_response "#{es_url}/_refresh", method: :post
+
+      result = curl_and_get_json_response "#{es_url}/#{expected_index_name}"
+
+      expect(result[expected_index_name]).not_to be(nil)
+    end
+
+    context "when dynamic field doesn't resolve the index_name" do
+      let(:event) { LogStash::Event.new("message" => message, "type" => type) }
+
+      it "should index successfully" do
+#         expected_index_name = "test_dynamic"
+        subject.multi_receive(events)
+#         result = curl_and_get_json_response "#{es_url}/#{expected_index_name}"
+#
+#         expect(result[expected_index_name]).to be(nil)
+
+        escaped_index_name = CGI.escape("%{[index_name]}_dynamic")
+        result = curl_and_get_json_response "#{es_url}/#{escaped_index_name}"
+        expect(result["%{[index_name]}_dynamic"]).to be(nil)
+      end
+    end
+  end
+end
+
 describe "indexing" do
   let(:message) { "Hello from #{__FILE__}" }
   let(:event) { LogStash::Event.new("message" => message, "type" => type) }
@@ -63,33 +184,33 @@ describe "indexing" do
   let(:es_admin) { 'admin' } # default user added in ES -> 8.x requires auth credentials for /_refresh etc
   let(:es_admin_pass) { 'elastic' }
 
-  def curl_and_get_json_response(url, method: :get); require 'open3'
-    cmd = "curl -s -v --show-error #{curl_opts} -X #{method.to_s.upcase} -k #{url}"
-    begin
-      out, err, status = Open3.capture3(cmd)
-    rescue Errno::ENOENT
-      fail "curl not available, make sure curl binary is installed and available on $PATH"
-    end
-
-    if status.success?
-      http_status = err.match(/< HTTP\/1.1 (\d+)/)[1] || '0' # < HTTP/1.1 200 OK\r\n
-
-      if http_status.strip[0].to_i > 2
-        error = (LogStash::Json.load(out)['error']) rescue nil
-        if error
-          fail "#{cmd.inspect} received an error: #{http_status}\n\n#{error.inspect}"
-        else
-          warn out
-          fail "#{cmd.inspect} unexpected response: #{http_status}\n\n#{err}"
-        end
-      end
-
-      LogStash::Json.load(out)
-    else
-      warn out
-      fail "#{cmd.inspect} process failed: #{status}\n\n#{err}"
-    end
-  end
+#   def curl_and_get_json_response(url, method: :get); require 'open3'
+#     cmd = "curl -s -v --show-error #{curl_opts} -X #{method.to_s.upcase} -k #{url}"
+#     begin
+#       out, err, status = Open3.capture3(cmd)
+#     rescue Errno::ENOENT
+#       fail "curl not available, make sure curl binary is installed and available on $PATH"
+#     end
+#
+#     if status.success?
+#       http_status = err.match(/< HTTP\/1.1 (\d+)/)[1] || '0' # < HTTP/1.1 200 OK\r\n
+#
+#       if http_status.strip[0].to_i > 2
+#         error = (LogStash::Json.load(out)['error']) rescue nil
+#         if error
+#           fail "#{cmd.inspect} received an error: #{http_status}\n\n#{error.inspect}"
+#         else
+#           warn out
+#           fail "#{cmd.inspect} unexpected response: #{http_status}\n\n#{err}"
+#         end
+#       end
+#
+#       LogStash::Json.load(out)
+#     else
+#       warn out
+#       fail "#{cmd.inspect} process failed: #{status}\n\n#{err}"
+#     end
+#   end
 
   let(:initial_events) { [] }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Modified the resolution of dynamic index name so that in case of interpolation errors the event is sent to the DLQ. This feature could be explicitly disabled configuring properly the `dlq_on_failed_indexname_interpolation`.


## What does this PR do?
Update the the pre-indexing steps, so to that in case of an `IndexInterpolationError` is raised during the index name resolution, the event is sent to DLQ. It leverarges the refactored `#handle_dlq_status` from PR #1080 to reuse the enqueuing logic.

## Why is it important/What is the impact to the user?
Let the user to handle specifically the events which once indexed would create an ugly formatted name like  `%{[not_existing_field]}_index`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run with 
```
.ci/docker-setup.sh && INTEGRATION=true .ci/docker-run.sh
```
- [x] adds feature flag to disable this behavior. Track telemetry data to know how many uses this explicit disabling.

## How to test this PR locally
- enable the DLQ,  set `dead_letter_queue.enable: true` in `config/logstash.yml`.
- launch an Elasticsearch instance
- execute a pipeline which wouldn't  resolve the index name like:
```
input {
	generator {
		message => '{"name": "John", "surname": "Doe"}'
		count => 1
		codec => json
	}
}

output {
	elasticsearch {
		index => "%{[not_existing_field]}"
		hosts => "http://localhost:9200"
		user => "elastic"
		password => "changeme"
	}
}
```
- then drain the DQL with another pipeline and verify it contains the previous failed event:
```
input {
  dead_letter_queue {
  	path => "/path_to/data/dead_letter_queue/"
  }
}

output {
  stdout {
    codec => rubydebug
  }

```
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes #718
- Copies a refactoring done in #1080

## Use cases
As a user I don't want that unresolved index names generates unexpected indexes and I would to reprocess such failed events with another DLQ pipeline.


