### PR TITLE
[DOC] Add index template restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.9.3
+  - [DOC] Add index template restriction
+
 ## 11.9.2
   - Fix broken link to Logstash Reference [#1085](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1085)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.9.3
-  - [DOC] Add index template restriction
+  - [DOC] Add index template restriction [#1089](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1089)
 
 ## 11.9.2
   - Fix broken link to Logstash Reference [#1085](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1085)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -255,6 +255,14 @@ overwritten as the settings `index.lifecycle.name` and
 NOTE: If the index property is supplied in the output definition, it will be overwritten by the rollover alias.
 
 
+[id="plugins-{type}s-{plugin}-index-template"]
+==== Index Template
+
+The {ref}/index-templates.html[composable index templates] introduced in Elasticsearch 7.8.
+Logstash uses {ref}/indices-put-template.html[_index_template] to create index template for {es} 8.x and
+uses {ref}/indices-templates-v1.html[_template] to create legacy template for {es} 7.x.
+Make sure the format of template is compatible to corresponding {es} version.
+
 ==== Batch Sizes
 
 This plugin attempts to send batches of events to the {ref}/docs-bulk.html[{es}

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.9.2'
+  s.version         = '11.9.3'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Relates: #1088

The composable [index templates](https://www.elastic.co/guide/en/elasticsearch/reference/8.4/index-templates.html) are introduced in Elasticsearch 7.8. The plan was to deprecate the [legacy template API](https://www.elastic.co/guide/en/elasticsearch/reference/8.4/indices-templates-v1.html) in Elasticsearch 8.0, but as of now, the [deprecation](https://github.com/elastic/elasticsearch/issues/53101) defers to 9.0.

This document explains the expectation of the plugin that the template used for ES 8.x is different to ES 7.x
