### PR TITLE
Adds new counter to track events that are routed to DLQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 11.10.0
+ - Feature: expose `dlq_routed` document metric to track the documents routed into DLQ [#1090](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1090)
+
 ## 11.9.3
  - DOC: clarify that `http_compression` option only affects _requests_; compressed _responses_ have always been read independent of this setting [#1030 ](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1030)
 
 ## 11.9.2
-  - Fix broken link to Logstash Reference [#1085](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1085)
+ - Fix broken link to Logstash Reference [#1085](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1085)
 
 ## 11.9.1
  - Fixes a possible infinite-retry-loop that could occur when this plugin is configured with an `action` whose value contains a [sprintf-style placeholder][] that fails to be resolved for an individual event. Events in this state will be routed to the pipeline's [dead letter queue][DLQ] if it is available, or will be logged-and-dropped so that the remaining events in the batch can be processed [#1080](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1080)

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -273,7 +273,7 @@ module LogStash; module PluginMixins; module ElasticSearch
           next
         elsif @dlq_codes.include?(status)
           handle_dlq_response("Could not index event to Elasticsearch.", action, status, response)
-          @document_level_metrics.increment(:non_retryable_failures)
+          @document_level_metrics.increment(:dlq_routed)
           next
         else
           # only log what the user whitelisted

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.9.3'
-
+  s.version         = '11.10.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/metrics_spec.rb
+++ b/spec/integration/outputs/metrics_spec.rb
@@ -58,7 +58,7 @@ describe "metrics", :integration => true do
     end
 
     it "increases number of successful and non retryable documents" do
-      expect(document_level_metrics).to receive(:increment).with(:non_retryable_failures).once
+      expect(document_level_metrics).to receive(:increment).with(:dlq_routed).once
       expect(document_level_metrics).to receive(:increment).with(:successes).once
       subject.multi_receive(bulk)
     end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Introduces a new document metric name `dlq_routed` to count the events that are routed to DLQ.

## What does this PR do?

Introduces a new document metric name `:dlq_routed` to be incremented every time an event is routed into DLQ.

## Why is it important/What is the impact to the user?

Permit to understand how many events are directed into the DLQ.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run locally

## How to test this PR locally
- enable DLQ in `config/logstash.yml` 
```yaml
dead_letter_queue.enable: true
```
- start an Elasticsearch with an index that result in DLQ routing. For example closed index:
```
PUT test_index/
POST test_index/_close
```
- create a config pipeline that sends event to the Elasticsearch
```
input {
  generator {
    message => '{"name": "Andrea"}'    
    codec => json
  }
}

filter {
  sleep {
    every => 125 
    time => 2
  }
}

output {
  elasticsearch {
    index => "test_index"
    hosts => "http://localhost:9200"
    # dlq_custom_codes => [403]
    user => "elastic"
    password => "changeme"
  }
}
```
- verify the new metric exist with `cURL`:
```bash
curl "localhost:9600/_node/stats/pipelines/main" | jq .pipelines.main.plugins.outputs
```
should have a fragment containing the new `dlq_routed` metric e.g. 
```json
[
  {
    "id": "4b2889390d10d292d378404a93659b893da067cfc9011c1833688e5ebbc963ef",
    "events": {
      "in": 32625,
      "duration_in_millis": 6433,
      "out": 32625
    },
    "bulk_requests": {
      "with_errors": 261,
      "responses": {
        "200": 261
      }
    },
    "documents": {
      "dlq_routed": 32625
    },
    "name": "elasticsearch"
  }
]

```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #778 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
