### PR TITLE
Support legacy template api in elasticsearch 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 11.9.4
+## 11.10.0
  - Add legacy template API support for Elasticsearch 8 [#1092](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1092)
 
 ## 11.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.9.4
+ - Add legacy template API support for elasticsearch 8.x
+
 ## 11.9.3
  - DOC: clarify that `http_compression` option only affects _requests_; compressed _responses_ have always been read independent of this setting [#1030 ](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1030)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.9.4
- - Add legacy template API support for elasticsearch 8.x
+ - Add legacy template API support for Elasticsearch 8 [#1092](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1092)
 
 ## 11.9.3
  - DOC: clarify that `http_compression` option only affects _requests_; compressed _responses_ have always been read independent of this setting [#1030 ](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1030)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -362,6 +362,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-template_legacy>> |<<string,string>>, one of `["true", "false", "auto"]`|No
 | <<plugins-{type}s-{plugin}-template_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template_overwrite>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
@@ -1081,6 +1082,22 @@ the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.
 
 You can set the path to your own template here, if you so desire.
 If not set, the included template will be used.
+
+[id="plugins-{type}s-{plugin}-template_legacy"]
+===== `template_legacy`
+
+  * Value can be any of: `true`, `false`, `auto`
+  * Default value is `auto`
+
+The default setting of `auto` will use
+{ref}/index-templates.html[index template API] to create index template, if the
+Elasticsearch cluster is running Elasticsearch version `8.0.0` or higher,
+and use {ref}/indices-templates-v1.html[legacy template API] otherwise.
+
+Setting this flag to `true` will use legacy template API to create index template.
+Setting this flag to `false` will use index template API to create index template.
+
+NOTE: The format of template needs to match with the corresponding Elasticsearch version.
 
 [id="plugins-{type}s-{plugin}-template_name"]
 ===== `template_name`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -362,7 +362,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-template_legacy>> |<<string,string>>, one of `["true", "false", "auto"]`|No
+| <<plugins-{type}s-{plugin}-template_api>> |<<string,string>>, one of `["true", "false", "auto"]`|No
 | <<plugins-{type}s-{plugin}-template_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template_overwrite>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
@@ -1083,10 +1083,10 @@ the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.
 You can set the path to your own template here, if you so desire.
 If not set, the included template will be used.
 
-[id="plugins-{type}s-{plugin}-template_legacy"]
-===== `template_legacy`
+[id="plugins-{type}s-{plugin}-template_api"]
+===== `template_api`
 
-  * Value can be any of: `true`, `false`, `auto`
+  * Value can be any of: `auto`, `legacy`, `composable`
   * Default value is `auto`
 
 The default setting of `auto` will use
@@ -1094,8 +1094,8 @@ The default setting of `auto` will use
 Elasticsearch cluster is running Elasticsearch version `8.0.0` or higher,
 and use {ref}/indices-templates-v1.html[legacy template API] otherwise.
 
-Setting this flag to `true` will use legacy template API to create index template.
-Setting this flag to `false` will use index template API to create index template.
+Setting this flag to `legacy` will use legacy template API to create index template.
+Setting this flag to `composable` will use index template API to create index template.
 
 NOTE: The format of template needs to match with the corresponding Elasticsearch version.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -362,7 +362,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-template_api>> |<<string,string>>, one of `["true", "false", "auto"]`|No
+| <<plugins-{type}s-{plugin}-template_api>> |<<string,string>>, one of `["auto", "legacy", "composable"]`|No
 | <<plugins-{type}s-{plugin}-template_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template_overwrite>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1097,7 +1097,7 @@ and use {ref}/indices-templates-v1.html[legacy template API] otherwise.
 Setting this flag to `legacy` will use legacy template API to create index template.
 Setting this flag to `composable` will use index template API to create index template.
 
-NOTE: The format of template needs to match with the corresponding Elasticsearch version.
+NOTE: The format of template provided to <<plugins-{type}s-{plugin}-template>> needs to match the template API being used.
 
 [id="plugins-{type}s-{plugin}-template_name"]
 ===== `template_name`

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -340,6 +340,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       @logger.warn("Elasticsearch Output configured with `ecs_compatibility => v8`, which resolved to an UNRELEASED preview of version 8.0.0 of the Elastic Common Schema. " +
                    "Once ECS v8 and an updated release of this plugin are publicly available, you will need to update this plugin to resolve this warning.")
     end
+
+    if @client.maximum_seen_major_version < 8 && @template_api == 'auto'
+      @logger.warn("Elasticsearch Output configured with `template_api => auto` uses legacy template API to manage index template for Elasticsearch 7 or below. " +
+                     "Legacy template API will be removed in Elasticsearch 9. It is recommended to set `template_api => legacy` before any upgrade " +
+                     "and please consider to migrate to composable index templates.")
+    end
   end
 
   # @override post-register when ES connection established

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -185,6 +185,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # the "logstash" template (i.e. removing all customized settings)
   config :template_overwrite, :validate => :boolean, :default => false
 
+  # Flag for enabling legacy template api for Elasticsearch 8
+  # Default auto will use index template api for Elasticsearch 8 and use legacy api for 7
+  # Set to true to use legacy template api
+  config :template_legacy, :validate => [true, false, 'true', 'false', 'auto'], :default => 'auto'
+
   # The version to use for indexing. Use sprintf syntax like `%{my_version}` to use a field value here.
   # See https://www.elastic.co/blog/elasticsearch-versioning-support.
   config :version, :validate => :string

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -187,8 +187,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
   # Flag for enabling legacy template api for Elasticsearch 8
   # Default auto will use index template api for Elasticsearch 8 and use legacy api for 7
-  # Set to true to use legacy template api
-  config :template_legacy, :validate => [true, false, 'true', 'false', 'auto'], :default => 'auto'
+  # Set to legacy to use legacy template api
+  config :template_api, :validate => ['auto', 'legacy', 'composable'], :default => 'auto'
 
   # The version to use for indexing. Use sprintf syntax like `%{my_version}` to use a field value here.
   # See https://www.elastic.co/blog/elasticsearch-versioning-support.

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -340,12 +340,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       @logger.warn("Elasticsearch Output configured with `ecs_compatibility => v8`, which resolved to an UNRELEASED preview of version 8.0.0 of the Elastic Common Schema. " +
                    "Once ECS v8 and an updated release of this plugin are publicly available, you will need to update this plugin to resolve this warning.")
     end
-
-    if @client.maximum_seen_major_version < 8 && @template_api == 'auto'
-      @logger.warn("Elasticsearch Output configured with `template_api => auto` uses legacy template API to manage index template for Elasticsearch 7 or below. " +
-                     "Legacy template API will be removed in Elasticsearch 9. It is recommended to set `template_api => legacy` before any upgrade " +
-                     "and please consider to migrate to composable index templates.")
-    end
   end
 
   # @override post-register when ES connection established

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -77,12 +77,12 @@ module LogStash; module Outputs; class ElasticSearch;
       }
     end
 
-    def template_install(name, template, force=false)
-      if template_exists?(name) && !force
+    def template_install(template_endpoint, name, template, force=false)
+      if template_exists?(template_endpoint, name) && !force
         @logger.debug("Found existing Elasticsearch template, skipping template management", name: name)
         return
       end
-      template_put(name, template)
+      template_put(template_endpoint, name, template)
     end
 
     def last_es_version
@@ -402,18 +402,14 @@ module LogStash; module Outputs; class ElasticSearch;
       response.code >= 200 && response.code <= 299
     end
 
-    def template_exists?(name)
+    def template_exists?(template_endpoint, name)
       exists?("/#{template_endpoint}/#{name}")
     end
 
-    def template_put(name, template)
+    def template_put(template_endpoint, name, template)
       path = "#{template_endpoint}/#{name}"
       logger.info("Installing Elasticsearch template", name: name)
       @pool.put(path, nil, LogStash::Json.dump(template))
-    end
-
-    def template_endpoint
-      maximum_seen_major_version < 8 ? '_template' : '_index_template'
     end
 
     # ILM methods

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -68,9 +68,9 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.template_endpoint(plugin)
-      if plugin.template_legacy == 'auto'
+      if plugin.template_api == 'auto'
         plugin.maximum_seen_major_version < 8 ? LEGACY_TEMPLATE_ENDPOINT : INDEX_TEMPLATE_ENDPOINT
-      elsif plugin.template_legacy.to_s == 'true'
+      elsif plugin.template_api.to_s == 'legacy'
         LEGACY_TEMPLATE_ENDPOINT
       else
         INDEX_TEMPLATE_ENDPOINT

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -8,9 +8,11 @@ module LogStash; module Outputs; class ElasticSearch
       return unless plugin.manage_template
 
       if plugin.maximum_seen_major_version < 8 && plugin.template_api == 'auto'
-        plugin.logger.warn("Elasticsearch Output configured with `template_api => auto` uses legacy template API to manage index template for Elasticsearch 7 or below. " +
-                             "Legacy template API will be removed in Elasticsearch 9. It is recommended to set `template_api => legacy` before any upgrade " +
-                             "and please consider to migrate to composable index templates.")
+        plugin.logger.warn("`template_api => auto` resolved to `legacy` since we are connected to " + "Elasticsearch #{plugin.maximum_seen_major_version}, " +
+                           "but will resolve to `composable` the first time it connects to Elasticsearch 8+. " +
+                           "We recommend either setting `template_api => legacy` to continue providing legacy-style templates, " +
+                           "or migrating your template to the composable style and setting `template_api => composable`. " +
+                           "The legacy template API is slated for removal in Elasticsearch 9.")
       end
 
       if plugin.template

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -6,6 +6,13 @@ module LogStash; module Outputs; class ElasticSearch
     # To be mixed into the elasticsearch plugin base
     def self.install_template(plugin)
       return unless plugin.manage_template
+
+      if plugin.maximum_seen_major_version < 8 && plugin.template_api == 'auto'
+        plugin.logger.warn("Elasticsearch Output configured with `template_api => auto` uses legacy template API to manage index template for Elasticsearch 7 or below. " +
+                             "Legacy template API will be removed in Elasticsearch 9. It is recommended to set `template_api => legacy` before any upgrade " +
+                             "and please consider to migrate to composable index templates.")
+      end
+
       if plugin.template
         plugin.logger.info("Using mapping template from", :path => plugin.template)
         template = read_template_file(plugin.template)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.9.4'
+  s.version         = '11.10.0'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.9.3'
+  s.version         = '11.9.4'
 
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -140,27 +140,6 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     end
   end
 
-  describe "index template" do
-    subject { described_class.new(base_options) }
-    let(:template_name) { "logstash" }
-    let(:template) { {} }
-    let(:get_response) {
-      double("response", :body => {})
-    }
-
-    it "should call composable index template in version 8+" do
-      expect(subject).to receive(:maximum_seen_major_version).and_return(8)
-      expect(subject.pool).to receive(:put).with("_index_template/#{template_name}", nil, anything).and_return(get_response)
-      subject.template_put(template_name, template)
-    end
-
-    it "should call index template in version < 8" do
-      expect(subject).to receive(:maximum_seen_major_version).and_return(7)
-      expect(subject.pool).to receive(:put).with("_template/#{template_name}", nil, anything).and_return(get_response)
-      subject.template_put(template_name, template)
-    end
-  end
-
   describe "join_bulk_responses" do
     subject { described_class.new(base_options) }
 

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -98,5 +98,18 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
         end
       end
     end
+
+    describe "template_legacy => 'false'" do
+      let(:plugin_settings) { {"manage_template" => true, "template_legacy" => 'false'} }
+      let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }
+
+      describe "in version 8+" do
+        it "should use legacy template API" do
+          expect(plugin).to receive(:maximum_seen_major_version).never
+          endpoint = described_class.template_endpoint(plugin)
+          expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager:: INDEX_TEMPLATE_ENDPOINT)
+        end
+      end
+    end
   end
 end

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -65,8 +65,8 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
   end
 
   describe "template endpoint" do
-    describe "template_legacy => 'auto'" do
-      let(:plugin_settings) { {"manage_template" => true, "template_legacy" => 'auto'} }
+    describe "template_api => 'auto'" do
+      let(:plugin_settings) { {"manage_template" => true, "template_api" => 'auto'} }
       let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }
 
       describe "in version 8+" do
@@ -86,8 +86,8 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
       end
     end
 
-    describe "template_legacy => 'true'" do
-      let(:plugin_settings) { {"manage_template" => true, "template_legacy" => 'true'} }
+    describe "template_api => 'legacy'" do
+      let(:plugin_settings) { {"manage_template" => true, "template_api" => 'legacy'} }
       let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }
 
       describe "in version 8+" do
@@ -99,8 +99,8 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
       end
     end
 
-    describe "template_legacy => 'false'" do
-      let(:plugin_settings) { {"manage_template" => true, "template_legacy" => 'false'} }
+    describe "template_api => 'composable'" do
+      let(:plugin_settings) { {"manage_template" => true, "template_api" => 'composable'} }
       let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }
 
       describe "in version 8+" do

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -63,4 +63,40 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
       end
     end
   end
+
+  describe "template endpoint" do
+    describe "template_legacy => 'auto'" do
+      let(:plugin_settings) { {"manage_template" => true, "template_legacy" => 'auto'} }
+      let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }
+
+      describe "in version 8+" do
+        it "should use index template API" do
+          expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(8)
+          endpoint = described_class.template_endpoint(plugin)
+          expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::INDEX_TEMPLATE_ENDPOINT)
+        end
+      end
+
+      describe "in version < 8" do
+        it "should use legacy template API" do
+          expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(7)
+          endpoint = described_class.template_endpoint(plugin)
+          expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::LEGACY_TEMPLATE_ENDPOINT)
+        end
+      end
+    end
+
+    describe "template_legacy => 'true'" do
+      let(:plugin_settings) { {"manage_template" => true, "template_legacy" => 'true'} }
+      let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }
+
+      describe "in version 8+" do
+        it "should use legacy template API" do
+          expect(plugin).to receive(:maximum_seen_major_version).never
+          endpoint = described_class.template_endpoint(plugin)
+          expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::LEGACY_TEMPLATE_ENDPOINT)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixed: #1088

Prior to the change, the plugin uses legacy API for ES 7.x and forces to use index template API for ES 8.x. However, legacy template API is still available in ES 8 and user should be allowed to use it.

This commit adds a new flag `template_api` to control which API to use. The available value is `auto`, `legacy` and `composable`. The default value is `auto`.
- `auto` Logstash detect the version of Elasticsearch. It uses index template API for 8 and legacy API for 7. 
- `legacy` use legacy API
- `composable` use index template API
