### PR TITLE
fix jruby bundler for test

### DIFF
--- a/.ci/logstash-run.sh
+++ b/.ci/logstash-run.sh
@@ -38,5 +38,5 @@ else
   echo "Waiting for elasticsearch to respond..."
   ES_VERSION=$(wait_for_es)
   echo "Elasticsearch $ES_VERSION is Up!"
-  bundle exec jruby -rbundler/setup -S rspec -fd $extra_tag_args --tag update_tests:painless --tag es_version:$ES_VERSION spec/integration
+  bundle exec rspec --format=documentation $extra_tag_args --tag update_tests:painless --tag es_version:$ES_VERSION spec/integration
 fi

--- a/.ci/logstash-run.sh
+++ b/.ci/logstash-run.sh
@@ -26,7 +26,7 @@ wait_for_es() {
 }
 
 if [[ "$INTEGRATION" != "true" ]]; then
-  bundle exec rspec --format=documentation spec/unit -t ~integration -t ~secure_integration
+  bundle exec rspec --format=documentation spec/unit --tag ~integration --tag ~secure_integration
 else
 
   if [[ "$SECURE_INTEGRATION" == "true" ]]; then

--- a/.ci/logstash-run.sh
+++ b/.ci/logstash-run.sh
@@ -26,7 +26,7 @@ wait_for_es() {
 }
 
 if [[ "$INTEGRATION" != "true" ]]; then
-  bundle exec jruby -rbundler/setup -S rspec -fd spec/unit -t ~integration -t ~secure_integration
+  bundle exec rspec --format=documentation spec/unit -t ~integration -t ~secure_integration
 else
 
   if [[ "$SECURE_INTEGRATION" == "true" ]]; then

--- a/.ci/logstash-run.sh
+++ b/.ci/logstash-run.sh
@@ -26,7 +26,7 @@ wait_for_es() {
 }
 
 if [[ "$INTEGRATION" != "true" ]]; then
-  jruby -rbundler/setup -S rspec -fd spec/unit -t ~integration -t ~secure_integration
+  bundle exec jruby -rbundler/setup -S rspec -fd spec/unit -t ~integration -t ~secure_integration
 else
 
   if [[ "$SECURE_INTEGRATION" == "true" ]]; then
@@ -38,5 +38,5 @@ else
   echo "Waiting for elasticsearch to respond..."
   ES_VERSION=$(wait_for_es)
   echo "Elasticsearch $ES_VERSION is Up!"
-  jruby -rbundler/setup -S rspec -fd $extra_tag_args --tag update_tests:painless --tag es_version:$ES_VERSION spec/integration
+  bundle exec jruby -rbundler/setup -S rspec -fd $extra_tag_args --tag update_tests:painless --tag es_version:$ES_VERSION spec/integration
 fi


### PR DESCRIPTION
Fix: https://github.com/elastic/logstash/issues/14800

Use the bundler in `/vendor/bundle/jruby/2.6.0/bin/bundle` instead of `/vendor/jruby/bin/bundle` to run test, as Logstash doesn't package the latter in artifacts in https://github.com/elastic/logstash/pull/14667

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
