### PR TITLE
dlq-logging: reintroduce structured payload where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.15.2
+ - Restores DLQ logging behavior from 11.8.x to include the action-tuple as structured [#1105](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1105)
+
 ## 11.15.1
  - Move async finish_register to bottom of register to avoid race condition [#1125](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1125)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -405,7 +405,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     event_mapping_errors.each do |event_mapping_error|
       detailed_message = "#{event_mapping_error.message}; event: `#{event_mapping_error.event.to_hash_with_metadata}`"
-      handle_dlq_status(event_mapping_error.event, :warn, detailed_message)
+      @dlq_writer ? @dlq_writer.write(event_mapping_error.event, detailed_message) : @logger.warn(detailed_message)
     end
     @document_level_metrics.increment(:non_retryable_failures, event_mapping_errors.size)
   end
@@ -422,7 +422,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
         successful_events << @event_mapper.call(event)
       rescue EventMappingError => ie
         event_mapping_errors << FailedEventMapping.new(event, ie.message)
-       end
+      end
     end
     MapEventsResult.new(successful_events, event_mapping_errors)
   end

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -23,7 +23,9 @@ describe "index template expected behavior", :integration => true do
 
     elasticsearch_client.indices.delete_template(:name => '*')
     # This can fail if there are no indexes, ignore failure.
-    elasticsearch_client.indices.delete(:index => '*') rescue nil
+    elasticsearch_client.indices.delete(:index => '*') rescue puts("DELETE INDICES ERROR: #{$!}")
+    # Since we are pinned to ES client 7.x, we need to delete data streams the hard way...
+    elasticsearch_client.perform_request("DELETE", "/_data_stream/*") rescue puts("DELETE DATA STREAMS ERROR: #{$!}")
   end
 
   context 'with ecs_compatibility => disabled' do


### PR DESCRIPTION
Alternative to #1104.

I authored this before getting derailed by a more urgent task, and just saw that @andsel had replicated my work in my off-hours. 

In this variant, because the `Elasticsearch#handle_event_mapping_errors` _already_ was making decisions based on the value of `@dlq_writer`, I didn't see the need to constrain the already-leaked DLQ abstraction to `Elasticsearch::Common#handle_dlq_status` and felt that working with `@dlq_writer` directly was more readable and easier to make sense of.

----

Fixes: #1103