### PR TITLE
Improve log messages for data stream support checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 11.12.2
+ - Changed the log messages for data stream checks [#1109](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1109)
+   - Added more details about incompatible data streams supplied configurations
+   - Changed the data stream auto-configuration log levels from `debug` to `info`
+
 ## 11.12.1
  - Log bulk request response body on error, not just when debug logging is enabled [#1096](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1096)
 

--- a/lib/logstash/outputs/elasticsearch/data_stream_support.rb
+++ b/lib/logstash/outputs/elasticsearch/data_stream_support.rb
@@ -28,7 +28,6 @@ module LogStash module Outputs class ElasticSearch
       base.extend(Validator)
     end
 
-    # @note assumes to be running AFTER {after_successful_connection} completed, due ES version checks
     def data_stream_config?
       @data_stream_config.nil? ? @data_stream_config = check_data_stream_config! : @data_stream_config
     end
@@ -50,46 +49,57 @@ module LogStash module Outputs class ElasticSearch
     # @param params the user configuration for the ES output
     # @note LS initialized configuration (with filled defaults) won't detect as data-stream
     # compatible, only explicit (`original_params`) config should be tested.
-    # @return [TrueClass|FalseClass] whether given configuration is data-stream compatible
+    # @return [Boolean] whether given configuration is data-stream compatible
     def check_data_stream_config!(params = original_params)
-      data_stream_params = params.select { |name, _| name.start_with?('data_stream_') } # exclude data_stream =>
-      invalid_data_stream_params = invalid_data_stream_params(params)
-
       case data_stream_explicit_value
       when false
-        if data_stream_params.any?
-          @logger.error "Ambiguous configuration; data stream settings must not be present when data streams is disabled (caused by: `data_stream => false`)", data_stream_params
-          raise LogStash::ConfigurationError, "Ambiguous configuration, please remove data stream specific settings: #{data_stream_params.keys}"
-        end
+        check_disabled_data_stream_config!(params)
         return false
       when true
-        if invalid_data_stream_params.any?
-          @logger.error "Invalid data stream configuration, following parameters are not supported:", invalid_data_stream_params
-          raise LogStash::ConfigurationError, "Invalid data stream configuration: #{invalid_data_stream_params.keys}"
-        end
-        if ecs_compatibility == :disabled
-          if ::Gem::Version.create(LOGSTASH_VERSION) < ::Gem::Version.create(DATA_STREAMS_REQUIRES_ECS_LS_VERSION)
-            @deprecation_logger.deprecated "In a future release of Logstash, the Elasticsearch output plugin's `data_stream => true` will require the plugin to be run in ECS compatibility mode. " + ENABLING_ECS_GUIDANCE
-          else
-            @logger.error "Invalid data stream configuration; `ecs_compatibility` must not be `disabled`. " + ENABLING_ECS_GUIDANCE
-            raise LogStash::ConfigurationError, "Invalid data stream configuration: `ecs_compatibility => disabled`"
-          end
-        end
+        check_enabled_data_stream_config!(params)
         return true
-      else
-        use_data_stream = data_stream_default(data_stream_params, invalid_data_stream_params)
-        if use_data_stream
-          @logger.info("Config is compliant with data streams. `data_stream => auto` resolved to `true`")
-        elsif data_stream_params.any?
-          # DS (auto) disabled but there's still some data-stream parameters (and no `data_stream => false`)
-          @logger.error "Ambiguous configuration; data stream settings are present, but data streams are not enabled", data_stream_params
-          raise LogStash::ConfigurationError, "Ambiguous configuration, please set data_stream => true " +
-              "or remove data stream specific settings: #{data_stream_params.keys}"
-        else
-          @logger.info("Config is not compliant with data streams. `data_stream => auto` resolved to `false`")
-        end
-        use_data_stream
+      else # data_stream => auto or not set
+        use_data_stream = data_stream_default(params)
+
+        check_disabled_data_stream_config!(params) unless use_data_stream
+
+        @logger.info("Data streams auto configuration (`data_stream => auto` or unset) resolved to `#{use_data_stream}`")
+        return use_data_stream
       end
+    end
+
+    def check_enabled_data_stream_config!(params)
+      invalid_data_stream_params = invalid_data_stream_params(params)
+
+      if invalid_data_stream_params.any?
+        @logger.error "Invalid data stream configuration, the following parameters are not supported:", invalid_data_stream_params
+        raise LogStash::ConfigurationError, "Invalid data stream configuration: #{invalid_data_stream_params.keys}"
+      end
+
+      if ecs_compatibility == :disabled
+        if ::Gem::Version.create(LOGSTASH_VERSION) < ::Gem::Version.create(DATA_STREAMS_REQUIRES_ECS_LS_VERSION)
+          @deprecation_logger.deprecated "In a future release of Logstash, the Elasticsearch output plugin's `data_stream => true` will require the plugin to be run in ECS compatibility mode. " + ENABLING_ECS_GUIDANCE
+        else
+          @logger.error "Invalid data stream configuration; `ecs_compatibility` must not be `disabled`. " + ENABLING_ECS_GUIDANCE
+          raise LogStash::ConfigurationError, "Invalid data stream configuration: `ecs_compatibility => disabled`"
+        end
+      end
+    end
+
+    def check_disabled_data_stream_config!(params)
+      data_stream_params = data_stream_params(params)
+
+      if data_stream_params.any?
+        @logger.error "Ambiguous configuration; data stream settings must not be present when data streams are disabled (caused by `data_stream => false`, `data_stream => auto` or unset resolved to false). " \
+                      "You can either manually set `data_stream => true` or remove the following specific data stream settings: ", data_stream_params
+
+        raise LogStash::ConfigurationError,
+              "Ambiguous configuration; data stream settings must not be present when data streams are disabled: #{data_stream_params.keys}"
+      end
+    end
+
+    def data_stream_params(params)
+      params.select { |name, _| name.start_with?('data_stream_') }
     end
 
     def data_stream_explicit_value
@@ -131,6 +141,7 @@ module LogStash module Outputs class ElasticSearch
 
     DATA_STREAMS_ORIGIN_ES_VERSION = '7.9.0'
 
+    # @note assumes to be running AFTER {after_successful_connection} completed, due ES version checks
     # @return [Gem::Version] if ES supports DS nil (or raise) otherwise
     def assert_es_version_supports_data_streams
       fail 'no last_es_version' unless last_es_version # assert - should not happen
@@ -147,28 +158,26 @@ module LogStash module Outputs class ElasticSearch
     DATA_STREAMS_ENABLED_BY_DEFAULT_LS_VERSION = '8.0.0'
 
     # when data_stream => is either 'auto' or not set
-    # @param data_stream_params [#any?]
-    # @param invalid_data_stream_config [#any?#inspect]
-    def data_stream_default(data_stream_params, invalid_data_stream_config)
+    def data_stream_default(params)
       if ecs_compatibility == :disabled
-        @logger.debug("Not eligible for data streams because ecs_compatibility is not enabled. " + ENABLING_ECS_GUIDANCE)
+        @logger.info("Not eligible for data streams because ecs_compatibility is not enabled. " + ENABLING_ECS_GUIDANCE)
         return false
       end
 
-      ds_default = ::Gem::Version.create(LOGSTASH_VERSION) >= ::Gem::Version.create(DATA_STREAMS_ENABLED_BY_DEFAULT_LS_VERSION)
+      invalid_data_stream_params = invalid_data_stream_params(params)
 
+      ds_default = ::Gem::Version.create(LOGSTASH_VERSION) >= ::Gem::Version.create(DATA_STREAMS_ENABLED_BY_DEFAULT_LS_VERSION)
       if ds_default # LS 8.0
-        if invalid_data_stream_config.any?
-          @logger.debug("Not eligible for data streams because config contains one or more settings that are not compatible with data streams: #{invalid_data_stream_config.inspect}")
+        if invalid_data_stream_params.any?
+          @logger.info("Not eligible for data streams because config contains one or more settings that are not compatible with data streams: #{invalid_data_stream_params.inspect}")
           return false
         end
 
-        @logger.debug 'Configuration is data stream compliant'
         return true
       end
 
       # LS 7.x
-      if !invalid_data_stream_config.any? && !data_stream_params.any?
+      if !invalid_data_stream_params.any? && !data_stream_params(params).any?
         @logger.warn "Configuration is data stream compliant but due backwards compatibility Logstash 7.x will not assume " +
                      "writing to a data-stream, default behavior will change on Logstash 8.0 " +
                      "(set `data_stream => true/false` to disable this warning)"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.12.1'
+  s.version         = '11.12.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
+++ b/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
@@ -84,7 +84,8 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
         context "on LS #{ls_version_desc}" do
           around(:each) { |example| change_constant(:LOGSTASH_VERSION, ls_version, &example) }
           it "does not use data-streams" do
-            expect( subject.logger ).to receive(:debug).with(a_string_including "ecs_compatibility is not enabled")
+            expect( subject.logger ).to receive(:info).with(a_string_including "ecs_compatibility is not enabled")
+            expect( subject.logger ).to receive(:info).with(a_string_including "Data streams auto configuration (`data_stream => auto` or unset) resolved to `false`")
             expect( subject.data_stream_config? ).to be false
           end
         end
@@ -161,7 +162,7 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
 
     it "does not default to data-streams" do
       expect( subject.logger ).to receive(:error) do |msg|
-        expect(msg).to include "Ambiguous configuration; data stream settings are present, but data streams are not enabled"
+        expect(msg).to include "Ambiguous configuration; data stream settings must not be present when data streams are disabled"
       end
       change_constant :LOGSTASH_VERSION, '7.10.2' do
         expect { subject.data_stream_config? }.to raise_error(LogStash::ConfigurationError, /Ambiguous configuration/i)
@@ -173,8 +174,8 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
       let(:options) { super().merge('data_stream' => 'false') }
 
       it "raises a configuration error (due ds specific settings)" do
-        expect( subject.logger ).to receive(:error).with(/Ambiguous configuration; data stream settings must not be present when data streams is disabled/,
-                                                         {"data_stream_auto_routing"=>"false", "data_stream_dataset"=>"test"})
+        expect( subject.logger ).to receive(:error).with(/Ambiguous configuration; data stream settings must not be present when data streams are disabled/,
+                                                          {"data_stream_auto_routing"=>"false", "data_stream_dataset"=>"test"})
         change_constant :LOGSTASH_VERSION, '7.10.2' do
           expect { subject.data_stream_config? }.to raise_error(LogStash::ConfigurationError, /Ambiguous configuration/i)
         end


### PR DESCRIPTION
What this PR does?
- Refactored the [check_data_stream_config!](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1109/files#diff-56fc556089a712f2ab141b29aa8363f8aaf2f3ee65360c538cc42245a0647ca9R53) method to reduce the cyclomatic complexity. 
- Changed the [data_stream_default](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1109/files#diff-56fc556089a712f2ab141b29aa8363f8aaf2f3ee65360c538cc42245a0647ca9R161) log levels from `debug` to `info`. Those messages are helpful to users understanding the data stream auto-configuration mechanism/default and troubleshooting possibly incompatible settings.
- Logs were being printed twice due to a race condition on the `data_stream_config?` method, caused by the [register](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1109/files#diff-940291b716938425b715566d94fceb6a35ac05e51f901276637846a9abc77737) function.



Closes #1070 