### PR TITLE
Fix termination deadlock when the output is retrying whole failed bulk requests

### DIFF
--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -155,7 +155,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def shutting_down?
-      @stopping.true? || (!execution_context.pipeline.nil? && execution_context.pipeline.shutdown_requested? && !execution_context.pipeline.worker_threads_draining?)
+      @stopping.true? || (!execution_context.nil? && !execution_context.pipeline.nil? && execution_context.pipeline.shutdown_requested? && !execution_context.pipeline.worker_threads_draining?)
     end
 
     # launch a thread that waits for an initial successful connection to the ES cluster to call the given block

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -155,7 +155,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def shutting_down?
-      @stopping.true? || (execution_context.pipeline.shutdown_requested? && !execution_context.pipeline.worker_threads_draining?)
+      @stopping.true? || (!execution_context.pipeline.nil? && execution_context.pipeline.shutdown_requested? && !execution_context.pipeline.worker_threads_draining?)
     end
 
     # launch a thread that waits for an initial successful connection to the ES cluster to call the given block


### PR DESCRIPTION
Closes: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1116
Detailed explanation of the problem: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1116#issuecomment-1424343607

Break the termination deadlock when whole bulk requests are failing in a retry loop during pipeline terminations

