### PR TITLE
Standardize and add SSL settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 11.14.0
+ - Reviewed and deprecated SSL settings to comply with Logstash's naming convention [#1115](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1115)
+   - Deprecated `ssl` in favor of `ssl_enabled`
+   - Deprecated `cacert` in favor of `ssl_certificate_authorities`
+   - Deprecated `keystore` in favor of `ssl_keystore_path`
+   - Deprecated `keystore_password` in favor of `ssl_keystore_password`
+   - Deprecated `truststore` in favor of `ssl_truststore_path`
+   - Deprecated `truststore_password` in favor of `ssl_truststore_password`
+   - Deprecated `ssl_certificate_verification` in favor of `ssl_verification_mode`
+
 ## 11.13.1
  - Avoid crash by ensuring ILM settings are injected in the correct location depending on the default (or custom) template format, template_api setting and ES version [#1102](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1102)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 11.14.0
- - Reviewed and deprecated SSL settings to comply with Logstash's naming convention [#1115](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1115)
+ - Added SSL settings for: [#1115](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1115)
+   - `ssl_truststore_type`: The format of the truststore file
+   - `ssl_keystore_type`: The format of the keystore file
+   - `ssl_certificate`: OpenSSL-style X.509 certificate file to authenticate the client
+   - `ssl_key`: OpenSSL-style RSA private key that corresponds to the `ssl_certificate`
+   - `ssl_cipher_suites`: The list of cipher suites
+ - Reviewed and deprecated SSL settings to comply with Logstash's naming convention
    - Deprecated `ssl` in favor of `ssl_enabled`
    - Deprecated `cacert` in favor of `ssl_certificate_authorities`
    - Deprecated `keystore` in favor of `ssl_keystore_path`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -299,7 +299,7 @@ checks.
 ==== Elasticsearch Output Configuration Options
 
 This plugin supports the following configuration options plus the
-<<plugins-{type}s-{plugin}-common-options>> described later.
+<<plugins-{type}s-{plugin}-common-options>> and the <<plugins-{type}s-{plugin}-deprecated-options>> described later.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -307,7 +307,6 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-action>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-bulk_path>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|__Deprecated__
 | <<plugins-{type}s-{plugin}-ca_trusted_fingerprint>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cloud_auth>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-cloud_id>> |<<string,string>>|No
@@ -333,8 +332,6 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-ilm_policy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ilm_rollover_alias>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-silence_errors_in_log>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-manage_template>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-parameters>> |<<hash,hash>>|No
@@ -358,10 +355,8 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-sniffing>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-sniffing_delay>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sniffing_path>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
-| <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |list of <<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> |<<path,path>>|No
@@ -378,8 +373,6 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-template_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template_overwrite>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-upsert>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-validate_after_inactivity>> |<<number,number>>|No
@@ -433,15 +426,6 @@ Elasticsearch {ref}/security-api-create-api-key.html[Create API key API].
 
 HTTP Path to perform the _bulk requests to
 this defaults to a concatenation of the path parameter and "_bulk"
-
-[id="plugins-{type}s-{plugin}-cacert"]
-===== `cacert`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
-
-  * Value type is a list of <<path,path>>
-  * There is no default value for this setting.
-
-The .cer or .pem file to validate the server's certificate.
 
 [id="plugins-{type}s-{plugin}-ca_trusted_fingerprint"]
 ===== `ca_trusted_fingerprint`
@@ -782,27 +766,6 @@ Logstash uses
 http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[Joda
 formats] and the `@timestamp` field of each event is being used as source for the date.
 
-[id="plugins-{type}s-{plugin}-keystore"]
-===== `keystore`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-The keystore used to present a certificate to the server.
-It can be either .jks or .p12
-
-NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_certificate>> at the same time.
-
-[id="plugins-{type}s-{plugin}-keystore_password"]
-===== `keystore_password`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
-
-  * Value type is <<password,password>>
-  * There is no default value for this setting.
-
-Set the keystore password
-
 [id="plugins-{type}s-{plugin}-manage_template"]
 ===== `manage_template`
 
@@ -1051,17 +1014,6 @@ the default value is computed by concatenating the path value and "_nodes/http"
 if sniffing_path is set it will be used as an absolute path
 do not use full URL here, only paths, e.g. "/sniff/_nodes/http"
 
-[id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
-
-  * Value type is <<boolean,boolean>>
-  * There is no default value for this setting.
-
-Enable SSL/TLS secured communication to Elasticsearch cluster.
-Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<plugins-{type}s-{plugin}-hosts>> or extracted from the <<plugins-{type}s-{plugin}-cloud_id>>.
-If no explicit protocol is specified plain HTTP will be used.
-
 [id="plugins-{type}s-{plugin}-ssl_certificate"]
 ===== `ssl_certificate`
   * Value type is <<path,path>>
@@ -1080,17 +1032,6 @@ NOTE: This setting can be used only if <<plugins-{type}s-{plugin}-ssl_key>> is s
 The .cer or .pem files to validate the server's certificate.
 
 NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_truststore_path>> at the same time.
-
-[id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
-===== `ssl_certificate_verification`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_verification_mode>>]
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `true`
-
-Option to validate the server's certificate. Disabling this severely compromises security.
-For more information on disabling certificate verification please read
-https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
 
 [id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
 ===== `ssl_cipher_suites`
@@ -1274,26 +1215,6 @@ the "logstash" template (i.e. removing all customized settings)
 Set the timeout, in seconds, for network operations and requests sent Elasticsearch. If
 a timeout occurs, the request will be retried.
 
-[id="plugins-{type}s-{plugin}-truststore"]
-===== `truststore`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-The truststore to validate the server's certificate.
-It can be either .jks or .p12.
-Use either `:truststore` or `:cacert`.
-
-[id="plugins-{type}s-{plugin}-truststore_password"]
-===== `truststore_password`
-deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
-
-  * Value type is <<password,password>>
-  * There is no default value for this setting.
-
-Set the truststore password
-
 [id="plugins-{type}s-{plugin}-upsert"]
 ===== `upsert`
 
@@ -1350,6 +1271,97 @@ https://www.elastic.co/blog/elasticsearch-versioning-support[versioning support
 blog] and {ref}/docs-index_.html#_version_types[Version types] in the
 Elasticsearch documentation.
 
+[id="plugins-{type}s-{plugin}-deprecated-options"]
+==== Elasticsearch Output Deprecated Configuration Options
+
+This plugin supports the following deprecated configurations.
+
+WARNING: Deprecated options are subject to removal in future releases.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting|Input type|Replaced by
+| <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_keystore_path>>
+| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|<<plugins-{type}s-{plugin}-ssl_keystore_password>>
+| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|<<plugins-{type}s-{plugin}-ssl_enabled>>
+| <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|<<plugins-{type}s-{plugin}-ssl_verification_mode>>
+| <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_truststore_path>>
+| <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|<<plugins-{type}s-{plugin}-ssl_truststore_password>>
+|=======================================================================
+
+
+[id="plugins-{type}s-{plugin}-cacert"]
+===== `cacert`
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
+
+* Value type is a list of <<path,path>>
+* There is no default value for this setting.
+
+The .cer or .pem file to validate the server's certificate.
+
+[id="plugins-{type}s-{plugin}-keystore"]
+===== `keystore`
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+The keystore used to present a certificate to the server.
+It can be either .jks or .p12
+
+NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_certificate>> at the same time.
+
+[id="plugins-{type}s-{plugin}-keystore_password"]
+===== `keystore_password`
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+
+Set the keystore password
+
+[id="plugins-{type}s-{plugin}-ssl"]
+===== `ssl`
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
+
+* Value type is <<boolean,boolean>>
+* There is no default value for this setting.
+
+Enable SSL/TLS secured communication to Elasticsearch cluster.
+Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<plugins-{type}s-{plugin}-hosts>> or extracted from the <<plugins-{type}s-{plugin}-cloud_id>>.
+If no explicit protocol is specified plain HTTP will be used.
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
+===== `ssl_certificate_verification`
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_verification_mode>>]
+
+* Value type is <<boolean,boolean>>
+* Default value is `true`
+
+Option to validate the server's certificate. Disabling this severely compromises security.
+For more information on disabling certificate verification please read
+https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+
+[id="plugins-{type}s-{plugin}-truststore"]
+===== `truststore`
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+The truststore to validate the server's certificate.
+It can be either `.jks` or `.p12`.
+Use either `:truststore` or `:cacert`.
+
+[id="plugins-{type}s-{plugin}-truststore_password"]
+===== `truststore_password`
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+
+Set the truststore password
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -359,14 +359,19 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-sniffing_delay>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sniffing_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|__Deprecated__
+| <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|__Deprecated__
+| <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |list of <<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_key>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_path>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_keystore_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_truststore_path>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_truststore_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>, one of `["full", "none"]`|No
 | <<plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-template_api>> |<<string,string>>, one of `["auto", "legacy", "composable"]`|No
@@ -787,6 +792,8 @@ deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
 The keystore used to present a certificate to the server.
 It can be either .jks or .p12
 
+NOTE: You cannot use this setting and `ssl_certificate` at the same time.
+
 [id="plugins-{type}s-{plugin}-keystore_password"]
 ===== `keystore_password`
 deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
@@ -1055,6 +1062,15 @@ Enable SSL/TLS secured communication to Elasticsearch cluster.
 Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<plugins-{type}s-{plugin}-hosts>> or extracted from the <<plugins-{type}s-{plugin}-cloud_id>>.
 If no explicit protocol is specified plain HTTP will be used.
 
+[id="plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate`
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+SSL certificate to use to authenticate the client. This certificate should be an OpenSSL-style X.509 certificate file.
+
+NOTE: This setting can be used only if `ssl_key` is set.
+
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
 ===== `ssl_certificate_authorities`
 
@@ -1062,6 +1078,8 @@ If no explicit protocol is specified plain HTTP will be used.
   * There is no default value for this setting
 
 The .cer or .pem files to validate the server's certificate.
+
+NOTE: You cannot use this setting and `ssl_truststore_path` at the same time.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
 ===== `ssl_certificate_verification`
@@ -1074,6 +1092,14 @@ Option to validate the server's certificate. Disabling this severely compromises
 For more information on disabling certificate verification please read
 https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
 
+[id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
+===== `ssl_cipher_suites`
+  * Value type is a list of <<string,string>>
+  * There is no default value for this setting
+
+The list of cipher suites to use, listed by priorities.
+Supported cipher suites vary depending on which version of Java is used.
+
 [id="plugins-{type}s-{plugin}-ssl_enabled"]
 ===== `ssl_enabled`
 
@@ -1083,6 +1109,15 @@ https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
 Enable SSL/TLS secured communication to Elasticsearch cluster.
 Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<plugins-{type}s-{plugin}-hosts>> or extracted from the <<plugins-{type}s-{plugin}-cloud_id>>.
 If no explicit protocol is specified plain HTTP will be used.
+
+[id="plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key`
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+OpenSSL-style RSA private key that corresponds to the `ssl_certificate`.
+
+NOTE: This setting can be used only if `ssl_certificate` is set.
 
 [id="plugins-{type}s-{plugin}-ssl_keystore_password"]
 ===== `ssl_keystore_password`
@@ -1100,6 +1135,16 @@ Set the keystore password
 
 The keystore used to present a certificate to the server.
 It can be either .jks or .p12
+
+NOTE: You cannot use this setting and `ssl_certificate` at the same time.
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_type"]
+===== `ssl_keystore_type`
+
+  * Value can be any of: `jks`, `pkcs12`
+  * If not provided, the value will be inferred from the keystore filename.
+
+The format of the keystore file. It must be either `jks` or `pkcs12`.
 
 [id="plugins-{type}s-{plugin}-ssl_supported_protocols"]
 ===== `ssl_supported_protocols`
@@ -1134,7 +1179,16 @@ Set the truststore password
 
 The truststore to validate the server's certificate.
 It can be either .jks or .p12.
-Use either `:truststore` or `:cacert`.
+
+NOTE: You cannot use this setting and `ssl_certificate_authorities` at the same time.
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_type"]
+===== `ssl_truststore_type`
+
+* Value can be any of: `jks`, `pkcs12`
+* If not provided, the value will be inferred from the truststore filename.
+
+The format of the truststore file. It must be either `jks` or `pkcs12`.
 
 [id="plugins-{type}s-{plugin}-ssl_verification_mode"]
 ===== `ssl_verification_mode`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -307,7 +307,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-action>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-bulk_path>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|__Deprecated__
 | <<plugins-{type}s-{plugin}-ca_trusted_fingerprint>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cloud_auth>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-cloud_id>> |<<string,string>>|No
@@ -333,8 +333,8 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-ilm_policy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ilm_rollover_alias>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-index>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|__Deprecated__
+| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-silence_errors_in_log>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-manage_template>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-parameters>> |<<hash,hash>>|No
@@ -358,16 +358,23 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-sniffing>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-sniffing_delay>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-sniffing_path>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|__Deprecated__
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_verification>> |<<boolean,boolean>>|__Deprecated__
+| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_keystore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-ssl_keystore_path>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_truststore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-ssl_truststore_path>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>, one of `["full", "none"]`|No
 | <<plugins-{type}s-{plugin}-template>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-template_api>> |<<string,string>>, one of `["auto", "legacy", "composable"]`|No
 | <<plugins-{type}s-{plugin}-template_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-template_overwrite>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|__Deprecated__
+| <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-upsert>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-validate_after_inactivity>> |<<number,number>>|No
@@ -424,8 +431,9 @@ this defaults to a concatenation of the path parameter and "_bulk"
 
 [id="plugins-{type}s-{plugin}-cacert"]
 ===== `cacert`
+deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
 
-  * Value type is <<path,path>>
+  * Value type is a list of <<path,path>>
   * There is no default value for this setting.
 
 The .cer or .pem file to validate the server's certificate.
@@ -771,6 +779,7 @@ formats] and the `@timestamp` field of each event is being used as source for th
 
 [id="plugins-{type}s-{plugin}-keystore"]
 ===== `keystore`
+deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -780,6 +789,7 @@ It can be either .jks or .p12
 
 [id="plugins-{type}s-{plugin}-keystore_password"]
 ===== `keystore_password`
+deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -1036,6 +1046,7 @@ do not use full URL here, only paths, e.g. "/sniff/_nodes/http"
 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl`
+deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
 
   * Value type is <<boolean,boolean>>
   * There is no default value for this setting.
@@ -1044,8 +1055,17 @@ Enable SSL/TLS secured communication to Elasticsearch cluster.
 Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<plugins-{type}s-{plugin}-hosts>> or extracted from the <<plugins-{type}s-{plugin}-cloud_id>>.
 If no explicit protocol is specified plain HTTP will be used.
 
+[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities`
+
+  * Value type is a list of <<path,path>>
+  * There is no default value for this setting
+
+The .cer or .pem files to validate the server's certificate.
+
 [id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
 ===== `ssl_certificate_verification`
+deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_verification_mode>>]
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -1053,6 +1073,33 @@ If no explicit protocol is specified plain HTTP will be used.
 Option to validate the server's certificate. Disabling this severely compromises security.
 For more information on disabling certificate verification please read
 https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+  * Value type is <<boolean,boolean>>
+  * There is no default value for this setting.
+
+Enable SSL/TLS secured communication to Elasticsearch cluster.
+Leaving this unspecified will use whatever scheme is specified in the URLs listed in <<plugins-{type}s-{plugin}-hosts>> or extracted from the <<plugins-{type}s-{plugin}-cloud_id>>.
+If no explicit protocol is specified plain HTTP will be used.
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_password"]
+===== `ssl_keystore_password`
+
+  * Value type is <<password,password>>
+  * There is no default value for this setting.
+
+Set the keystore password
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_path"]
+===== `ssl_keystore_path`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+The keystore used to present a certificate to the server.
+It can be either .jks or .p12
 
 [id="plugins-{type}s-{plugin}-ssl_supported_protocols"]
 ===== `ssl_supported_protocols`
@@ -1070,6 +1117,40 @@ For Java 8 `'TLSv1.3'` is supported  only since **8u262** (AdoptOpenJDK), but re
 NOTE: If you configure the plugin to use `'TLSv1.1'` on any recent JVM, such as the one packaged with Logstash,
 the protocol is disabled by default and needs to be enabled manually by changing `jdk.tls.disabledAlgorithms` in
 the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.1` needs to be removed from the list.
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_password"]
+===== `ssl_truststore_password`
+
+  * Value type is <<password,password>>
+  * There is no default value for this setting.
+
+Set the truststore password
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_path"]
+===== `ssl_truststore_path`
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+The truststore to validate the server's certificate.
+It can be either .jks or .p12.
+Use either `:truststore` or `:cacert`.
+
+[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
+===== `ssl_verification_mode`
+
+  * Value can be any of: `full`, `none`
+  * Default value is `["full"]`
+
+Defines how to verify the certificates presented by another party in the TLS connection:
+
+`full` validates that the server certificate has an issue date that’s within
+the not_before and not_after dates; chains to a trusted Certificate Authority (CA), and
+has a hostname or IP address that matches the names within the certificate.
+
+`none` performs no certificate validation.
+
+WARNING: Setting certificate verification to `none` disables many security benefits of SSL/TLS, which is very dangerous. For more information on disabling certificate verification please read https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
 
 [id="plugins-{type}s-{plugin}-template"]
 ===== `template`
@@ -1141,6 +1222,7 @@ a timeout occurs, the request will be retried.
 
 [id="plugins-{type}s-{plugin}-truststore"]
 ===== `truststore`
+deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -1151,6 +1233,7 @@ Use either `:truststore` or `:cacert`.
 
 [id="plugins-{type}s-{plugin}-truststore_password"]
 ===== `truststore_password`
+deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
 
   * Value type is <<password,password>>
   * There is no default value for this setting.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -420,7 +420,7 @@ For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bu
   * There is no default value for this setting.
 
 Authenticate using Elasticsearch API key.
-Note that this option also requires SSL/TLS, which can be enabled by supplying a <<plugins-{type}s-{plugin}-cloud_id>>, a list of HTTPS <<plugins-{type}s-{plugin}-hosts>>, or by setting <<plugins-{type}s-{plugin}-ssl,`ssl => true`>>.
+Note that this option also requires SSL/TLS, which can be enabled by supplying a <<plugins-{type}s-{plugin}-cloud_id>>, a list of HTTPS <<plugins-{type}s-{plugin}-hosts>>, or by setting <<plugins-{type}s-{plugin}-ssl,`ssl_enabled => true`>>.
 
 Format is `id:api_key` where `id` and `api_key` are as returned by the
 Elasticsearch {ref}/security-api-create-api-key.html[Create API key API].
@@ -436,7 +436,7 @@ this defaults to a concatenation of the path parameter and "_bulk"
 
 [id="plugins-{type}s-{plugin}-cacert"]
 ===== `cacert`
-deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
 
   * Value type is a list of <<path,path>>
   * There is no default value for this setting.
@@ -784,7 +784,7 @@ formats] and the `@timestamp` field of each event is being used as source for th
 
 [id="plugins-{type}s-{plugin}-keystore"]
 ===== `keystore`
-deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -792,11 +792,11 @@ deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
 The keystore used to present a certificate to the server.
 It can be either .jks or .p12
 
-NOTE: You cannot use this setting and `ssl_certificate` at the same time.
+NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_certificate>> at the same time.
 
 [id="plugins-{type}s-{plugin}-keystore_password"]
 ===== `keystore_password`
-deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -1053,7 +1053,7 @@ do not use full URL here, only paths, e.g. "/sniff/_nodes/http"
 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl`
-deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
 
   * Value type is <<boolean,boolean>>
   * There is no default value for this setting.
@@ -1069,7 +1069,7 @@ If no explicit protocol is specified plain HTTP will be used.
 
 SSL certificate to use to authenticate the client. This certificate should be an OpenSSL-style X.509 certificate file.
 
-NOTE: This setting can be used only if `ssl_key` is set.
+NOTE: This setting can be used only if <<plugins-{type}s-{plugin}-ssl_key>> is set.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
 ===== `ssl_certificate_authorities`
@@ -1079,11 +1079,11 @@ NOTE: This setting can be used only if `ssl_key` is set.
 
 The .cer or .pem files to validate the server's certificate.
 
-NOTE: You cannot use this setting and `ssl_truststore_path` at the same time.
+NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_truststore_path>> at the same time.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_verification"]
 ===== `ssl_certificate_verification`
-deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_verification_mode>>]
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_verification_mode>>]
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -1115,9 +1115,9 @@ If no explicit protocol is specified plain HTTP will be used.
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-OpenSSL-style RSA private key that corresponds to the `ssl_certificate`.
+OpenSSL-style RSA private key that corresponds to the <<plugins-{type}s-{plugin}-ssl_certificate>>.
 
-NOTE: This setting can be used only if `ssl_certificate` is set.
+NOTE: This setting can be used only if <<plugins-{type}s-{plugin}-ssl_certificate>> is set.
 
 [id="plugins-{type}s-{plugin}-ssl_keystore_password"]
 ===== `ssl_keystore_password`
@@ -1134,9 +1134,9 @@ Set the keystore password
   * There is no default value for this setting.
 
 The keystore used to present a certificate to the server.
-It can be either .jks or .p12
+It can be either `.jks` or `.p12`
 
-NOTE: You cannot use this setting and `ssl_certificate` at the same time.
+NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_certificate>> at the same time.
 
 [id="plugins-{type}s-{plugin}-ssl_keystore_type"]
 ===== `ssl_keystore_type`
@@ -1156,7 +1156,7 @@ The format of the keystore file. It must be either `jks` or `pkcs12`.
 
 List of allowed SSL/TLS versions to use when establishing a connection to the Elasticsearch cluster.
 
-For Java 8 `'TLSv1.3'` is supported  only since **8u262** (AdoptOpenJDK), but requires that you set the
+For Java 8 `'TLSv1.3'` is supported only since **8u262** (AdoptOpenJDK), but requires that you set the
 `LS_JAVA_OPTS="-Djdk.tls.client.protocols=TLSv1.3"` system property in Logstash.
 
 NOTE: If you configure the plugin to use `'TLSv1.1'` on any recent JVM, such as the one packaged with Logstash,
@@ -1178,9 +1178,9 @@ Set the truststore password
   * There is no default value for this setting.
 
 The truststore to validate the server's certificate.
-It can be either .jks or .p12.
+It can be either `.jks` or `.p12`.
 
-NOTE: You cannot use this setting and `ssl_certificate_authorities` at the same time.
+NOTE: You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> at the same time.
 
 [id="plugins-{type}s-{plugin}-ssl_truststore_type"]
 ===== `ssl_truststore_type`
@@ -1276,7 +1276,7 @@ a timeout occurs, the request will be retried.
 
 [id="plugins-{type}s-{plugin}-truststore"]
 ===== `truststore`
-deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -1287,7 +1287,7 @@ Use either `:truststore` or `:cacert`.
 
 [id="plugins-{type}s-{plugin}-truststore_password"]
 ===== `truststore_password`
-deprecated[8.8.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
+deprecated[11.14.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
 
   * Value type is <<password,password>>
   * There is no default value for this setting.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1098,7 +1098,7 @@ https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
   * There is no default value for this setting
 
 The list of cipher suites to use, listed by priorities.
-Supported cipher suites vary depending on which version of Java is used.
+Supported cipher suites vary depending on the Java and protocol versions.
 
 [id="plugins-{type}s-{plugin}-ssl_enabled"]
 ===== `ssl_enabled`
@@ -1194,7 +1194,7 @@ The format of the truststore file. It must be either `jks` or `pkcs12`.
 ===== `ssl_verification_mode`
 
   * Value can be any of: `full`, `none`
-  * Default value is `["full"]`
+  * Default value is `full`
 
 Defines how to verify the certificates presented by another party in the TLS connection:
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -283,10 +283,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   def initialize(*params)
     super
     setup_ecs_compatibility_related_defaults
-    setup_ssl_params
   end
 
   def register
+    setup_ssl_params!
+
     if !failure_type_logging_whitelist.empty?
       log_message = "'failure_type_logging_whitelist' is deprecated and in a future version of Elasticsearch " +
         "output plugin will be removed, please use 'silence_errors_in_log' instead."
@@ -627,7 +628,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     end
   end
 
-  def setup_ssl_params
+  def setup_ssl_params!
     @ssl_enabled = normalize_config(:ssl_enabled) do |normalize|
       normalize.with_deprecated_alias(:ssl)
     end

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -115,17 +115,17 @@ module LogStash; module Outputs; class ElasticSearch;
       ssl_certificate_authorities, ssl_truststore_path, ssl_certificate, ssl_keystore_path = params.values_at('ssl_certificate_authorities', 'ssl_truststore_path', 'ssl_certificate', 'ssl_keystore_path')
 
       if ssl_certificate_authorities && ssl_truststore_path
-        raise(LogStash::ConfigurationError, 'Use either "ssl_certificate_authorities/cacert" or "ssl_truststore_path/truststore" when configuring the CA certificate')
+        raise LogStash::ConfigurationError, 'Use either "ssl_certificate_authorities/cacert" or "ssl_truststore_path/truststore" when configuring the CA certificate'
       end
 
       if ssl_certificate && ssl_keystore_path
-        raise(LogStash::ConfigurationError, 'Use either "ssl_certificate" or "ssl_keystore_path/keystore" when configuring client certificates')
+        raise LogStash::ConfigurationError, 'Use either "ssl_certificate" or "ssl_keystore_path/keystore" when configuring client certificates'
       end
 
       ssl_options = {:enabled => true}
 
       if ssl_certificate_authorities&.any?
-        raise(LogStash::ConfigurationError, 'Multiple values on "ssl_certificate_authorities" are not supported by this plugin') if ssl_certificate_authorities.size > 1
+        raise LogStash::ConfigurationError, 'Multiple values on "ssl_certificate_authorities" are not supported by this plugin' if ssl_certificate_authorities.size > 1
         ssl_options[:ca_file] = ssl_certificate_authorities.first
       end
 
@@ -137,7 +137,7 @@ module LogStash; module Outputs; class ElasticSearch;
         ssl_options[:client_cert] = ssl_certificate
         ssl_options[:client_key] = ssl_key
       elsif !!ssl_certificate || !!ssl_key
-        raise(LogStash::ConfigurationError, 'You must set both "ssl_certificate" and "ssl_key" for client authentication')
+        raise LogStash::ConfigurationError, 'You must set both "ssl_certificate" and "ssl_key" for client authentication'
       end
 
       ssl_verification_mode = params["ssl_verification_mode"]

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -133,11 +133,12 @@ module LogStash; module Outputs; class ElasticSearch;
       setup_ssl_store(ssl_options, 'keystore', params)
 
       ssl_key = params["ssl_key"]
-      if ssl_certificate && ssl_key
+      if ssl_certificate
+        raise LogStash::ConfigurationError, 'Using an "ssl_certificate" requires an "ssl_key"' unless ssl_key
         ssl_options[:client_cert] = ssl_certificate
         ssl_options[:client_key] = ssl_key
-      elsif !!ssl_certificate || !!ssl_key
-        raise LogStash::ConfigurationError, 'You must set both "ssl_certificate" and "ssl_key" for client authentication'
+      elsif !ssl_key.nil?
+        raise LogStash::ConfigurationError, 'An "ssl_certificate" is required when using an "ssl_key"'
       end
 
       ssl_verification_mode = params["ssl_verification_mode"]

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -80,6 +80,9 @@ module LogStash; module PluginMixins; module ElasticSearch
         # Use either `:ssl_truststore_path` or `:ssl_certificate_authorities`
         :ssl_truststore_path => { :validate => :path },
 
+        # The format of the truststore file. It must be either jks or pkcs12
+        :ssl_truststore_type => { :validate => %w[pkcs12 jks] },
+
         # Set the truststore password
         :truststore_password => { :validate => :password, :deprecated => "Use 'ssl_truststore_password' instead." },
 
@@ -94,6 +97,9 @@ module LogStash; module PluginMixins; module ElasticSearch
         # It can be either .jks or .p12
         :ssl_keystore_path => { :validate => :path },
 
+        # The format of the keystore file. It must be either jks or pkcs12
+        :ssl_keystore_type => { :validate => %w[pkcs12 jks] },
+
         # Set the keystore password
         :keystore_password => { :validate => :password, :deprecated => "Set 'ssl_keystore_password' instead." },
 
@@ -101,6 +107,16 @@ module LogStash; module PluginMixins; module ElasticSearch
         :ssl_keystore_password => { :validate => :password },
 
         :ssl_supported_protocols => { :validate => ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'], :default => [], :list => true },
+
+        # OpenSSL-style X.509 certificate certificate to authenticate the client
+        :ssl_certificate => { :validate => :path },
+
+        # OpenSSL-style RSA private key to authenticate the client
+        :ssl_key => { :validate => :path },
+
+        # The list of cipher suites to use, listed by priorities.
+        # Supported cipher suites vary depending on which version of Java is used.
+        :ssl_cipher_suites => { :validate => :string, :list => true },
 
         # This setting asks Elasticsearch for the list of all cluster nodes and adds them to the hosts list.
         # Note: This will return ALL nodes with HTTP enabled (including master nodes!). If you use

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -45,32 +45,60 @@ module LogStash; module PluginMixins; module ElasticSearch
         # Enable SSL/TLS secured communication to Elasticsearch cluster. Leaving this unspecified will use whatever scheme
         # is specified in the URLs listed in 'hosts'. If no explicit protocol is specified plain HTTP will be used.
         # If SSL is explicitly disabled here the plugin will refuse to start if an HTTPS URL is given in 'hosts'
-        :ssl => { :validate => :boolean },
+        :ssl => { :validate => :boolean, :deprecated => "Set 'ssl_enabled' instead." },
+
+        # Enable SSL/TLS secured communication to Elasticsearch cluster. Leaving this unspecified will use whatever scheme
+        # is specified in the URLs listed in 'hosts'. If no explicit protocol is specified plain HTTP will be used.
+        # If SSL is explicitly disabled here the plugin will refuse to start if an HTTPS URL is given in 'hosts'
+        :ssl_enabled => { :validate => :boolean },
 
         # Option to validate the server's certificate. Disabling this severely compromises security.
         # For more information on disabling certificate verification please read
         # https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf
-        :ssl_certificate_verification => { :validate => :boolean, :default => true },
+        :ssl_certificate_verification => { :validate => :boolean, :default => true, :deprecated => "Set 'ssl_verification_mode' instead." },
+
+        # Options to verify the server's certificate.
+        # "full": validates that the provided certificate has an issue date that’s within the not_before and not_after dates;
+        # chains to a trusted Certificate Authority (CA); has a hostname or IP address that matches the names within the certificate.
+        # "none": performs no certificate validation. Disabling this severely compromises security (https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf)
+        :ssl_verification_mode => { :validate => %w[full none], :default => 'full' },
 
         # The .cer or .pem file to validate the server's certificate
-        :cacert => { :validate => :path },
+        :cacert => { :validate => :path, :deprecated => "Set 'ssl_certificate_authorities' instead." },
+
+        # The .cer or .pem files to validate the server's certificate
+        :ssl_certificate_authorities => { :validate => :path, :list => true },
 
         # One or more hex-encoded SHA256 fingerprints to trust as Certificate Authorities
         :ca_trusted_fingerprint => LogStash::PluginMixins::CATrustedFingerprintSupport,
 
         # The JKS truststore to validate the server's certificate.
         # Use either `:truststore` or `:cacert`
-        :truststore => { :validate => :path },
+        :truststore => { :validate => :path, :deprecated => "Set 'ssl_truststore_path' instead." },
+
+        # The JKS truststore to validate the server's certificate.
+        # Use either `:ssl_truststore_path` or `:ssl_certificate_authorities`
+        :ssl_truststore_path => { :validate => :path },
 
         # Set the truststore password
-        :truststore_password => { :validate => :password },
+        :truststore_password => { :validate => :password, :deprecated => "Use 'ssl_truststore_password' instead." },
+
+        # Set the truststore password
+        :ssl_truststore_password => { :validate => :password },
 
         # The keystore used to present a certificate to the server.
         # It can be either .jks or .p12
-        :keystore => { :validate => :path },
+        :keystore => { :validate => :path, :deprecated => "Set 'ssl_keystore_path' instead." },
+
+        # The keystore used to present a certificate to the server.
+        # It can be either .jks or .p12
+        :ssl_keystore_path => { :validate => :path },
 
         # Set the keystore password
-        :keystore_password => { :validate => :password },
+        :keystore_password => { :validate => :password, :deprecated => "Set 'ssl_keystore_password' instead." },
+
+        # Set the keystore password
+        :ssl_keystore_password => { :validate => :password },
 
         :ssl_supported_protocols => { :validate => ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'], :default => [], :list => true },
 

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -28,8 +28,7 @@ module LogStash; module PluginMixins; module ElasticSearch
 
       setup_hosts
 
-
-      params['ssl'] = effectively_ssl? unless params.include?('ssl')
+      params['ssl_enabled'] = effectively_ssl? unless params.include?('ssl_enabled')
 
       # inject the TrustStrategy from CATrustedFingerprintSupport
       if trust_strategy_for_ca_trusted_fingerprint
@@ -74,7 +73,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def effectively_ssl?
-      return @ssl unless @ssl.nil?
+      return @ssl_enabled unless @ssl_enabled.nil?
 
       hosts = Array(@hosts)
       return false if hosts.nil? || hosts.empty?

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.13.1'
+  s.version         = '11.14.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.0'
   s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~>1.0'
   s.add_runtime_dependency 'logstash-mixin-ca_trusted_fingerprint_support', '~>1.0'
+  s.add_runtime_dependency 'logstash-mixin-normalize_config_support', '~>1.0'
 
   s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'logstash-devutils'

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -289,8 +289,8 @@ describe "indexing" do
         "hosts" => [ get_host_port ],
         "user" => user,
         "password" => password,
-        "ssl" => true,
-        "cacert" => cacert,
+        "ssl_enabled" => true,
+        "ssl_certificate_authorities" => cacert,
         "index" => index
       }
     end 
@@ -302,7 +302,7 @@ describe "indexing" do
 
       context "when no keystore nor ca cert set and verification is disabled" do
         let(:config) do
-          super().tap { |config| config.delete('cacert') }.merge('ssl_certificate_verification' => false)
+          super().tap { |config| config.delete('ssl_certificate_authorities') }.merge('ssl_verification_mode' => 'none')
         end
 
         include_examples("an indexer", true)
@@ -311,9 +311,9 @@ describe "indexing" do
       context "when keystore is set and verification is disabled" do
         let(:config) do
           super().merge(
-              'ssl_certificate_verification' => false,
-              'keystore' => 'spec/fixtures/test_certs/test.p12',
-              'keystore_password' => '1234567890'
+              'ssl_verification_mode' => 'none',
+              'ssl_keystore_path' => 'spec/fixtures/test_certs/test.p12',
+              'ssl_keystore_password' => '1234567890'
           )
         end
 
@@ -322,10 +322,10 @@ describe "indexing" do
 
       context "when keystore has self-signed cert and verification is disabled" do
         let(:config) do
-          super().tap { |config| config.delete('cacert') }.merge(
-              'ssl_certificate_verification' => false,
-              'keystore' => 'spec/fixtures/test_certs/test_self_signed.p12',
-              'keystore_password' => '1234567890'
+          super().tap { |config| config.delete('ssl_certificate_authorities') }.merge(
+              'ssl_verification_mode' => 'none',
+              'ssl_keystore_path' => 'spec/fixtures/test_certs/test_self_signed.p12',
+              'ssl_keystore_password' => '1234567890'
           )
         end
 
@@ -349,8 +349,8 @@ describe "indexing" do
         let(:config) do
           {
               "hosts" => ["https://#{CGI.escape(user)}:#{CGI.escape(password)}@elasticsearch:9200"],
-              "ssl" => true,
-              "cacert" => "spec/fixtures/test_certs/test.crt",
+              "ssl_enabled" => true,
+              "ssl_certificate_authorities" => "spec/fixtures/test_certs/test.crt",
               "index" => index
           }
         end
@@ -358,10 +358,10 @@ describe "indexing" do
         include_examples("an indexer", true)
       end
 
-      context "without providing `cacert`" do
+      context "without providing `ssl_certificate_authorities`" do
         let(:config) do
           super().tap do |c|
-            c.delete("cacert")
+            c.delete("ssl_certificate_authorities")
           end
         end
 
@@ -369,10 +369,10 @@ describe "indexing" do
       end
 
       if Gem::Version.new(LOGSTASH_VERSION) >= Gem::Version.new("8.3.0")
-        context "with `ca_trusted_fingerprint` instead of `cacert`" do
+        context "with `ca_trusted_fingerprint` instead of `ssl_certificate_authorities`" do
           let(:config) do
             super().tap do |c|
-              c.delete("cacert")
+              c.delete("ssl_certificate_authorities")
               c.update("ca_trusted_fingerprint" => ca_trusted_fingerprint)
             end
           end

--- a/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
+++ b/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
@@ -114,7 +114,7 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
       {
           'hosts' => [ 'http://127.0.0.1:12345' ],
           'http_compression' => 'true', 'bulk_path' => '_bulk', 'timeout' => '30',
-          'user' => 'elastic', 'password' => 'ForSearch!', 'ssl' => 'false'
+          'user' => 'elastic', 'password' => 'ForSearch!', 'ssl_enabled' => 'false'
       }
     end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -712,14 +712,15 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   describe "SSL deprecated settings" do
+    let(:base_options) { {"ssl" => "true"} }
+
     context "with client certificate" do
       let(:do_register) { true }
       let(:cacert) { Stud::Temporary.file.path }
-      let(:options) { {
-        "ssl" => "true",
+      let(:options) { base_options.merge(
         "cacert" => cacert,
         "ssl_certificate_verification" => false
-      } }
+      ) }
 
       after :each do
         File.delete(cacert)
@@ -744,14 +745,13 @@ describe LogStash::Outputs::ElasticSearch do
       let(:do_register) { true }
       let(:keystore) { Stud::Temporary.file.path }
       let(:truststore) { Stud::Temporary.file.path }
-      let(:options) { {
-        "ssl" => "true",
+      let(:options) { base_options.merge(
         "keystore" => keystore,
         "keystore_password" => "keystore",
         "truststore" => truststore,
         "truststore_password" => "truststore",
         "ssl_certificate_verification" => true
-      } }
+      ) }
 
       let(:spy_http_client_builder!) do
         allow(described_class::HttpClientBuilder).to receive(:build).with(any_args).and_call_original

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -705,12 +705,6 @@ describe LogStash::Outputs::ElasticSearch do
       include_examples("an encrypted client connection")
     end
 
-    context "With the 'ssl_enabled' option" do
-      let(:options) { {"ssl_enabled" => true}}
-
-      include_examples("an encrypted client connection")
-    end
-
     context "With an https host" do
       let(:options) { {"hosts" => "https://localhost"} }
       include_examples("an encrypted client connection")
@@ -731,7 +725,7 @@ describe LogStash::Outputs::ElasticSearch do
         File.delete(cacert)
       end
 
-      it 'should map new configs into params' do
+      it "should map new configs into params" do
         expect(subject.params).to match hash_including(
                                           "ssl_enabled" => true,
                                           "ssl_verification_mode" => "none",
@@ -739,7 +733,7 @@ describe LogStash::Outputs::ElasticSearch do
                                         )
       end
 
-      it 'should set new configs variables' do
+      it "should set new configs variables" do
         expect(subject.instance_variable_get(:@ssl_enabled)).to eql(true)
         expect(subject.instance_variable_get(:@ssl_verification_mode)).to eql("none")
         expect(subject.instance_variable_get(:@ssl_certificate_authorities)).to eql([cacert])
@@ -769,7 +763,7 @@ describe LogStash::Outputs::ElasticSearch do
         File.delete(truststore)
       end
 
-      it 'should map new configs into params' do
+      it "should map new configs into params" do
         expect(subject.params).to match hash_including(
                                           "ssl_enabled" => true,
                                           "ssl_keystore_path" => keystore,
@@ -781,7 +775,7 @@ describe LogStash::Outputs::ElasticSearch do
         expect(subject.params["ssl_truststore_password"].value).to eql("truststore")
       end
 
-      it 'should set new configs variables' do
+      it "should set new configs variables" do
         expect(subject.instance_variable_get(:@ssl_enabled)).to eql(true)
         expect(subject.instance_variable_get(:@ssl_keystore_path)).to eql(keystore)
         expect(subject.instance_variable_get(:@ssl_keystore_password).value).to eql("keystore")

--- a/spec/unit/outputs/elasticsearch_ssl_spec.rb
+++ b/spec/unit/outputs/elasticsearch_ssl_spec.rb
@@ -1,81 +1,197 @@
 require_relative "../../../spec/spec_helper"
 require 'stud/temporary'
 
-describe "SSL option" do
+describe "SSL options" do
   let(:manticore_double) { double("manticoreSSL #{self.inspect}") }
+
+  let(:settings) { { "ssl_enabled" => true, "hosts" => "localhost", "pool_max" => 1, "pool_max_per_route" => 1 } }
+
+  subject do
+    require "logstash/outputs/elasticsearch"
+    LogStash::Outputs::ElasticSearch.new(settings)
+  end
+
   before do
     allow(manticore_double).to receive(:close)
-    
+
     response_double = double("manticore response").as_null_object
     # Allow healtchecks
     allow(manticore_double).to receive(:head).with(any_args).and_return(response_double)
     allow(manticore_double).to receive(:get).with(any_args).and_return(response_double)
-    
     allow(::Manticore::Client).to receive(:new).and_return(manticore_double)
   end
-  
-  context "when using ssl without cert verification" do
-    subject do
-      require "logstash/outputs/elasticsearch"
-      settings = {
-        "hosts" => "localhost",
-        "ssl_enabled" => true,
+
+  after do
+    subject.close
+  end
+
+  context "when ssl_verification_mode" do
+    context "is set to none" do
+      let(:settings) { super().merge(
         "ssl_verification_mode" => 'none',
-        "pool_max" => 1,
-        "pool_max_per_route" => 1
-      }
-      LogStash::Outputs::ElasticSearch.new(settings)
-    end
-    
-    after do
-      subject.close
-    end
-    
-    it "should pass the flag to the ES client" do
-      expect(::Manticore::Client).to receive(:new) do |args|
-        expect(args[:ssl]).to match hash_including(:enabled => true, :verify => :disable)
-      end.and_return(manticore_double)
-      
-      subject.register
+      ) }
+
+      it "should print a warning" do
+        expect(subject.logger).to receive(:warn).with(/You have enabled encryption but DISABLED certificate verification/).at_least(:once)
+        allow(subject.logger).to receive(:warn).with(any_args)
+
+        subject.register
+        allow(LogStash::Outputs::ElasticSearch::HttpClient::Pool).to receive(:start)
+      end
+
+      it "should pass the flag to the ES client" do
+        expect(::Manticore::Client).to receive(:new) do |args|
+          expect(args[:ssl]).to match hash_including(:enabled => true, :verify => :disable)
+        end.and_return(manticore_double)
+
+        subject.register
+      end
     end
 
-    it "should print a warning" do
-      disabled_matcher = /You have enabled encryption but DISABLED certificate verification/
-      expect(subject.logger).to receive(:warn).with(disabled_matcher).at_least(:once)
-      allow(subject.logger).to receive(:warn).with(any_args)
-      
-      subject.register
-      allow(LogStash::Outputs::ElasticSearch::HttpClient::Pool).to receive(:start)
+    context "is set to full" do
+      let(:settings) { super().merge(
+        "ssl_verification_mode" => 'full',
+      ) }
+
+      it "should pass the flag to the ES client" do
+        expect(::Manticore::Client).to receive(:new) do |args|
+          expect(args[:ssl]).to match hash_including(:enabled => true, :verify => :strict)
+        end.and_return(manticore_double)
+
+        subject.register
+      end
     end
   end
 
-  context "when using ssl with client certificates" do
-    let(:keystore_path) { Stud::Temporary.file.path }
-    before do
-      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout lumberjack.key -out #{keystore_path}.pem`
+  context "with the conflicting configs" do
+    context "ssl_certificate_authorities and ssl_truststore_path set" do
+      let(:ssl_truststore_path) { Stud::Temporary.file.path }
+      let(:ssl_certificate_authorities_path) { Stud::Temporary.file.path }
+      let(:settings) { super().merge(
+        "ssl_truststore_path" => ssl_truststore_path,
+        "ssl_certificate_authorities" => ssl_certificate_authorities_path
+      ) }
+
+      after :each do
+        File.delete(ssl_truststore_path)
+        File.delete(ssl_certificate_authorities_path)
+      end
+
+      it "should raise a configuration error" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /Use either "ssl_certificate_authorities\/cacert" or "ssl_truststore_path\/truststore"/)
+      end
     end
+
+    context "ssl_certificate and ssl_keystore_path set" do
+      let(:ssl_keystore_path) { Stud::Temporary.file.path }
+      let(:ssl_certificate_path) { Stud::Temporary.file.path }
+      let(:settings) { super().merge(
+        "ssl_certificate" => ssl_certificate_path,
+        "ssl_keystore_path" => ssl_keystore_path
+      ) }
+
+      after :each do
+        File.delete(ssl_keystore_path)
+        File.delete(ssl_certificate_path)
+      end
+
+      it "should raise a configuration error" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /Use either "ssl_certificate" or "ssl_keystore_path\/keystore"/)
+      end
+    end
+  end
+
+  context "when configured with Java store files" do
+    let(:ssl_truststore_path) { Stud::Temporary.file.path }
+    let(:ssl_keystore_path) { Stud::Temporary.file.path }
 
     after :each do
-      File.delete(keystore_path)
-      subject.close
+      File.delete(ssl_truststore_path)
+      File.delete(ssl_keystore_path)
     end
 
-    subject do
-      require "logstash/outputs/elasticsearch"
-      settings = {
-        "hosts" => "node01",
-        "ssl_enabled" => true,
-        "ssl_certificate_authorities" => keystore_path,
-      }
-      next LogStash::Outputs::ElasticSearch.new(settings)
-    end
+    let(:settings) { super().merge(
+      "ssl_truststore_path" => ssl_truststore_path,
+      "ssl_truststore_type" => "jks",
+      "ssl_truststore_password" => "foo",
+      "ssl_keystore_path" => ssl_keystore_path,
+      "ssl_keystore_type" => "jks",
+      "ssl_keystore_password" => "bar",
+      "ssl_verification_mode" => "full",
+      "ssl_cipher_suites" => ["TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"],
+      "ssl_supported_protocols" => ["TLSv1.3"]
+    ) }
 
-    it "should pass the keystore parameters to the ES client" do
+    it "should pass the parameters to the ES client" do
       expect(::Manticore::Client).to receive(:new) do |args|
-        expect(args[:ssl]).to include(:keystore => keystore_path, :keystore_password => "test")
-      end.and_call_original
+        expect(args[:ssl]).to match hash_including(
+                                      :enabled => true,
+                                      :keystore => ssl_keystore_path,
+                                      :keystore_type => "jks",
+                                      :keystore_password => "bar",
+                                      :truststore => ssl_truststore_path,
+                                      :truststore_type => "jks",
+                                      :truststore_password => "foo",
+                                      :verify => :strict,
+                                      :cipher_suites => ["TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"],
+                                      :protocols => ["TLSv1.3"],
+                                    )
+      end.and_return(manticore_double)
+
+      subject.register
+    end
+  end
+
+  context "when configured with certificate files" do
+    let(:ssl_certificate_authorities_path) { Stud::Temporary.file.path }
+    let(:ssl_certificate_path) { Stud::Temporary.file.path }
+    let(:ssl_key_path) { Stud::Temporary.file.path }
+    let(:settings) { super().merge(
+      "ssl_certificate_authorities" => [ssl_certificate_authorities_path],
+      "ssl_certificate" => ssl_certificate_path,
+      "ssl_key" => ssl_key_path,
+      "ssl_verification_mode" => "full",
+      "ssl_cipher_suites" => ["TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"],
+      "ssl_supported_protocols" => ["TLSv1.3"]
+    ) }
+
+    after :each do
+      File.delete(ssl_certificate_authorities_path)
+      File.delete(ssl_certificate_path)
+      File.delete(ssl_key_path)
+    end
+
+    it "should pass the parameters to the ES client" do
+      expect(::Manticore::Client).to receive(:new) do |args|
+        expect(args[:ssl]).to match hash_including(
+                                      :enabled => true,
+                                      :ca_file => ssl_certificate_authorities_path,
+                                      :client_cert => ssl_certificate_path,
+                                      :client_key => ssl_key_path,
+                                      :verify => :strict,
+                                      :cipher_suites => ["TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"],
+                                      :protocols => ["TLSv1.3"],
+                                    )
+      end.and_return(manticore_double)
+
       subject.register
     end
 
+    context "and only the ssl_certificate is set" do
+      let(:settings) { super().reject { |k| "ssl_key".eql?(k) } }
+
+      it "should raise a configuration error" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /You must set both "ssl_certificate" and "ssl_key"/)
+      end
+    end
+
+    context "and only the ssl_key is set" do
+      let(:settings) { super().reject { |k| "ssl_certificate".eql?(k) } }
+
+      it "should raise a configuration error" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /You must set both "ssl_certificate" and "ssl_key"/)
+      end
+    end
   end
 end
+

--- a/spec/unit/outputs/elasticsearch_ssl_spec.rb
+++ b/spec/unit/outputs/elasticsearch_ssl_spec.rb
@@ -20,7 +20,7 @@ describe "SSL option" do
       settings = {
         "hosts" => "localhost",
         "ssl_enabled" => true,
-        "ssl_certificate_mode" => 'none',
+        "ssl_verification_mode" => 'none',
         "pool_max" => 1,
         "pool_max_per_route" => 1
       }

--- a/spec/unit/outputs/elasticsearch_ssl_spec.rb
+++ b/spec/unit/outputs/elasticsearch_ssl_spec.rb
@@ -19,8 +19,8 @@ describe "SSL option" do
       require "logstash/outputs/elasticsearch"
       settings = {
         "hosts" => "localhost",
-        "ssl" => true,
-        "ssl_certificate_verification" => false,
+        "ssl_enabled" => true,
+        "ssl_certificate_mode" => 'none',
         "pool_max" => 1,
         "pool_max_per_route" => 1
       }
@@ -64,8 +64,8 @@ describe "SSL option" do
       require "logstash/outputs/elasticsearch"
       settings = {
         "hosts" => "node01",
-        "ssl" => true,
-        "cacert" => keystore_path,
+        "ssl_enabled" => true,
+        "ssl_certificate_authorities" => keystore_path,
       }
       next LogStash::Outputs::ElasticSearch.new(settings)
     end

--- a/spec/unit/outputs/elasticsearch_ssl_spec.rb
+++ b/spec/unit/outputs/elasticsearch_ssl_spec.rb
@@ -181,7 +181,7 @@ describe "SSL options" do
       let(:settings) { super().reject { |k| "ssl_key".eql?(k) } }
 
       it "should raise a configuration error" do
-        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /You must set both "ssl_certificate" and "ssl_key"/)
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /Using an "ssl_certificate" requires an "ssl_key"/)
       end
     end
 
@@ -189,7 +189,7 @@ describe "SSL options" do
       let(:settings) { super().reject { |k| "ssl_certificate".eql?(k) } }
 
       it "should raise a configuration error" do
-        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /You must set both "ssl_certificate" and "ssl_key"/)
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /An "ssl_certificate" is required when using an "ssl_key"/)
       end
     end
   end


### PR DESCRIPTION
### What this PR does?
Added the following SSL settings: 
`ssl_truststore_type`: The format of the truststore file
`ssl_keystore_type`: The format of the keystore file
`ssl_certificate`: OpenSSL-style X.509 certificate file to authenticate the client
`ssl_key`: OpenSSL-style RSA private key that corresponds to the `ssl_certificate`
`ssl_cipher_suites`: The list of cipher suites
   
Reviewed and deprecated the following SSL settings to comply with Logstash's naming convention:
`ssl` in favor of `ssl_enabled`
`cacert` in favor of `ssl_certificate_authorities`
`keystore` in favor of `ssl_keystore_path`
`keystore_password` in favor of `ssl_keystore_password`
`truststore` in favor of `ssl_truststore_path`
`truststore_password` in favor of `ssl_truststore_password`
`ssl_certificate_verification` in favor of `ssl_verification_mode`

The behavior standardization across plugins, such as the accepted certificate formats, default values, etc will be tackled in future PRs.

---
Closes https://github.com/elastic/logstash/issues/14924
Closes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/404
Closes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/672
Closes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/676