### PR TITLE
Check pipeline shutdown status while waiting for valid connection or while issuing a bulk to ES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.15.0
+ - Added the ability to negatively acknowledge the batch under processing if the plugin is blocked in a retry-error-loop and a shutdown is requested. [#1119](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1119)
+
 ## 11.14.1
  - [DOC] Fixed incorrect pull request link on the CHANGELOG `11.14.0` entry [#1122](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1122)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -435,7 +435,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     if execution_context&.pipeline&.shutdown_requested?
       @logger.info "Aborting the batch due to shutdown request while waiting for connections to become live"
-      raise org.logstash.execution.AbortedBatchException.new
+      abort_batch_if_available!
     end
 
     status = @after_successful_connection_thread && @after_successful_connection_thread.value

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -431,10 +431,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   def wait_for_successful_connection
     after_successful_connection_done = @after_successful_connection_done
     return unless after_successful_connection_done
-    stoppable_sleep 1 until (after_successful_connection_done.true? || execution_context&.pipeline&.shutdown_requested?)
+    stoppable_sleep 1 until (after_successful_connection_done.true? || pipeline_shutdown_requested?)
 
-    if execution_context&.pipeline&.shutdown_requested?
-      @logger.info "Aborting the batch due to shutdown request while waiting for connections to become live"
+    if pipeline_shutdown_requested?
+      logger.info "Aborting the batch due to shutdown request while waiting for connections to become live"
       abort_batch_if_available!
     end
 

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -351,7 +351,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         end
 
         sleep_interval = sleep_for_interval(sleep_interval)
-        if execution_context&.pipeline&.shutdown_requested?
+        if pipeline_shutdown_requested?
           # In case ES side changes access credentials and a pipeline reload is triggered
           # this error becomes a retry on restart
           abort_batch_if_available!

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -192,6 +192,9 @@ module LogStash; module PluginMixins; module ElasticSearch
           if submit_actions && submit_actions.size > 0
             @logger.info("Retrying individual bulk actions that failed or were rejected by the previous bulk request", count: submit_actions.size)
           end
+        rescue org.logstash.execution.AbortedBatchException => e
+          # if aborting the batch, bubble the exception up so that the pipeline can handle it
+          raise e
         rescue => e
           @logger.error("Encountered an unexpected error submitting a bulk request, will retry",
                         message: e.message, exception: e.class, backtrace: e.backtrace)

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -339,6 +339,11 @@ module LogStash; module PluginMixins; module ElasticSearch
 
         sleep_interval = sleep_for_interval(sleep_interval)
         @bulk_request_metrics.increment(:failures)
+        if pipeline_shutdown_requested?
+          # when any connection is available and a shutdown is requested
+          # the batch can be aborted, eventually for future retry.
+          abort_batch_if_available!
+        end
         retry unless @stopping.true?
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         @bulk_request_metrics.increment(:failures)

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -373,6 +373,11 @@ module LogStash; module PluginMixins; module ElasticSearch
       end
     end
 
+    def pipeline_shutdown_requested?
+        return super if defined?(super) # since LS 8.1.0
+        execution_context&.pipeline&.shutdown_requested
+      end
+
     def abort_batch_if_available!
       raise org.logstash.execution.AbortedBatchException.new if abort_batch_present?
     end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.14.1'
+  s.version         = '11.15.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Introduce the ability to negatively acknowledge the batch under processing if the plugin is blocked in a retry-error-loop and a shutdown is requested.


## What does this PR do?
Updates the wait_for_successful_connection method and safe_bulk to react to shutdown requests.
When the plugin is in a retry loop and Logstash it's running into provide the ability to negatively ACK the batch under processing and a pipeline shutdown was requested then the plugin terminate signalling that the batch under processing shouldn't be acknowledged, raising an AbortedBatchException.


## Why is it important/What is the impact to the user?
Let the user to update the configuration of the plugin, when managed by CPM, resuming from a retry-loop due to bad configuration values (or expired credentials);

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Test with cloud instance

## How to test this PR locally
This PR has to be tested in lockstep with the changes on Logstash core applied with https://github.com/elastic/logstash/pull/14940
Checkout a branch which contains that change or a release if already published.
The test plan needs to create an Elasticsearch instance in Elastic cloud, recording the following data:
- `cloud_id`
- `cloud_auth`
- `api_key`

### Test plan
After created the Elastic deployment execute the following steps:
-  checkout this  branch
- install this plugin in your Logstash instance
```sh
gem "logstash-output-elasticsearch", :path => "/path/to/logstash-output-elasticsearch"
bin/logstash-plugin install --no-verify
```
- configure your Logstash's `config/logstash.yml` file to connect to central pipeline management (CPM) in Elastic cloud
```yaml
xpack.management.enabled: true
xpack.management.pipeline.id: ["test*"]
xpack.management.elasticsearch.cloud_id: "<your cloud_id>"
xpack.management.elasticsearch.cloud_auth: "<your cloud_auth>"
```
- in CPM create a new pipeline like the following:
```
input {
  tcp {
    port => 1234
  }
}

output {
  elasticsearch {
    cloud_id => "<your cloud_id>"
    api_key => "<your api_key>"
    index => "andsel_test"
    ssl => true
  }
  stdout{}
}
```
- run Logstash (`bin/logstash`)
- verify that it can process some input
```sh
echo "test input line" | netcat localhost 1234
```
- now update the the pipeline definition on CPM, corrupting the `api_key` such as removing last char of the key (remember somewhere the correct key)
- the output should start blaming a connectivity problem with log lines such as:
```
[2023-03-22T14:38:23,927][WARN ][logstash.outputs.elasticsearch][test_remote_1] Attempted to resurrect connection to dead ES instance, but got an error {:url=>"https://blabla.gcp.cloud.es.io:443/", :exception=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError, :message=>"Got response code '401' contacting Elasticsearch at URL 'https://blabla.gcp.cloud.es.io:443/'"}
```
- in CPM restore the correct `api_key`. Without this fix the previous lines continues and no shutdown and restart of the pipeline happens, With this change you should fine a line like
```
[INFO ][org.logstash.execution.WorkerLoop][test_remote_1] Worker loop notified of aborting a batch
```
and the pipeline effectively reloads and is back to normal functioning.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Superseed #1107
- Superseed #1117
- Relates https://github.com/elastic/logstash/pull/14940
- Relates https://github.com/elastic/logstash/pull/13811
- Fix https://github.com/elastic/logstash/issues/14739

## Use cases
As a user using the central pipeline management I want that once a credential is updated the pipeline running the plugin is effectively restarted with the updated values without manual intervention on the Logstash instance.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
