### PR TITLE
Fix #1120: Get rid of warning message about unreleased ECS schema v8

### DIFF
--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -349,11 +349,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     @bulk_request_metrics = metric.namespace(:bulk_requests)
     @document_level_metrics = metric.namespace(:documents)
-
-    if ecs_compatibility == :v8
-      @logger.warn("Elasticsearch Output configured with `ecs_compatibility => v8`, which resolved to an UNRELEASED preview of version 8.0.0 of the Elastic Common Schema. " +
-                   "Once ECS v8 and an updated release of this plugin are publicly available, you will need to update this plugin to resolve this warning.")
-    end
   end
 
   # @override post-register when ES connection established


### PR DESCRIPTION
Fix #1120 by deleting the if-blocks that cause the log lines to be logged. 
