### PR TITLE
Fix 11.14.0 CHANGELOG PR link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.14.0
- - Added SSL settings for: [#1115](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1115)
+ - Added SSL settings for: [#1118](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1118)
    - `ssl_truststore_type`: The format of the truststore file
    - `ssl_keystore_type`: The format of the keystore file
    - `ssl_certificate`: OpenSSL-style X.509 certificate file to authenticate the client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.14.1
+ - [DOC] Fixed incorrect pull request link on the CHANGELOG `11.14.0` entry
+
 ## 11.14.0
  - Added SSL settings for: [#1118](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1118)
    - `ssl_truststore_type`: The format of the truststore file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.14.1
- - [DOC] Fixed incorrect pull request link on the CHANGELOG `11.14.0` entry
+ - [DOC] Fixed incorrect pull request link on the CHANGELOG `11.14.0` entry [#1122](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1122)
 
 ## 11.14.0
  - Added SSL settings for: [#1118](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1118)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.14.0'
+  s.version         = '11.14.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixed the `11.14.0` changelog entry, the correct PR link is #1118 instead of #1115.
 
---
https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1118#discussion_r1144004936
