### PR TITLE
move async finish_register to bottom of register to avoid race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.15.1
+ - Move async finish_register to bottom of register to avoid race condition [#1125](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1125)
+
 ## 11.15.0
  - Added the ability to negatively acknowledge the batch under processing if the plugin is blocked in a retry-error-loop and a shutdown is requested. [#1119](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1119)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -314,18 +314,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     setup_template_manager_defaults(data_stream_enabled)
 
-    @after_successful_connection_thread = after_successful_connection do
-      begin
-        finish_register
-        true # thread.value
-      rescue => e
-        # we do not want to halt the thread with an exception as that has consequences for LS
-        e # thread.value
-      ensure
-        @after_successful_connection_done.make_true
-      end
-    end
-
     # To support BWC, we check if DLQ exists in core (< 5.4). If it doesn't, we use nil to resort to previous behavior.
     @dlq_writer = dlq_enabled? ? execution_context.dlq_writer : nil
 
@@ -353,6 +341,18 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     if ecs_compatibility == :v8
       @logger.warn("Elasticsearch Output configured with `ecs_compatibility => v8`, which resolved to an UNRELEASED preview of version 8.0.0 of the Elastic Common Schema. " +
                    "Once ECS v8 and an updated release of this plugin are publicly available, you will need to update this plugin to resolve this warning.")
+    end
+
+    @after_successful_connection_thread = after_successful_connection do
+      begin
+        finish_register
+        true # thread.value
+      rescue => e
+        # we do not want to halt the thread with an exception as that has consequences for LS
+        e # thread.value
+      ensure
+        @after_successful_connection_done.make_true
+      end
     end
   end
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.15.0'
+  s.version         = '11.15.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -48,19 +48,19 @@ describe "index template expected behavior", :integration => true do
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search(index: 'logstash-*')
+        r = @es.search(index: 'logstash')
         expect(r).to have_hits(8)
       end
     end
 
     it "permits phrase searching on string fields" do
-      results = @es.search(:q => "message:\"sample message\"")
+      results = @es.search(index: 'logstash', q: "message:\"sample message\"")
       expect(results).to have_hits(1)
       expect(results["hits"]["hits"][0]["_source"]["message"]).to eq("sample message here")
     end
 
     it "numbers dynamically map to a numeric type and permit range queries" do
-      results = @es.search(:q => "somevalue:[5 TO 105]")
+      results = @es.search(index: 'logstash', q: "somevalue:[5 TO 105]")
       expect(results).to have_hits(2)
 
       values = results["hits"]["hits"].collect { |r| r["_source"]["somevalue"] }
@@ -70,22 +70,22 @@ describe "index template expected behavior", :integration => true do
     end
 
     it "does not create .keyword field for top-level message field" do
-      results = @es.search(:q => "message.keyword:\"sample message here\"")
+      results = @es.search(index: 'logstash', q: "message.keyword:\"sample message here\"")
       expect(results).to have_hits(0)
     end
 
     it "creates .keyword field for nested message fields" do
-      results = @es.search(:q => "somemessage.message.keyword:\"sample nested message here\"")
+      results = @es.search(index: 'logstash', q: "somemessage.message.keyword:\"sample nested message here\"")
       expect(results).to have_hits(1)
     end
 
     it "creates .keyword field from any string field which is not_analyzed" do
-      results = @es.search(:q => "country.keyword:\"us\"")
+      results = @es.search(index: 'logstash', q: "country.keyword:\"us\"")
       expect(results).to have_hits(1)
       expect(results["hits"]["hits"][0]["_source"]["country"]).to eq("us")
 
       # partial or terms should not work.
-      results = @es.search(:q => "country.keyword:\"u\"")
+      results = @es.search(index: 'logstash', q: "country.keyword:\"u\"")
       expect(results).to have_hits(0)
     end
 
@@ -94,7 +94,7 @@ describe "index template expected behavior", :integration => true do
     end
 
     it "aggregate .keyword results correctly " do
-      results = @es.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
+      results = @es.search(index: 'logstash', body: { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
       terms = results["buckets"].collect { |b| b["key"] }
 
       expect(terms).to include("us")

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -48,19 +48,19 @@ describe "index template expected behavior", :integration => true do
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search(index: 'logstash')
+        r = @es.search(index: 'logstash*')
         expect(r).to have_hits(8)
       end
     end
 
     it "permits phrase searching on string fields" do
-      results = @es.search(index: 'logstash', q: "message:\"sample message\"")
+      results = @es.search(index: 'logstash*', q: "message:\"sample message\"")
       expect(results).to have_hits(1)
       expect(results["hits"]["hits"][0]["_source"]["message"]).to eq("sample message here")
     end
 
     it "numbers dynamically map to a numeric type and permit range queries" do
-      results = @es.search(index: 'logstash', q: "somevalue:[5 TO 105]")
+      results = @es.search(index: 'logstash*', q: "somevalue:[5 TO 105]")
       expect(results).to have_hits(2)
 
       values = results["hits"]["hits"].collect { |r| r["_source"]["somevalue"] }
@@ -70,22 +70,22 @@ describe "index template expected behavior", :integration => true do
     end
 
     it "does not create .keyword field for top-level message field" do
-      results = @es.search(index: 'logstash', q: "message.keyword:\"sample message here\"")
+      results = @es.search(index: 'logstash*', q: "message.keyword:\"sample message here\"")
       expect(results).to have_hits(0)
     end
 
     it "creates .keyword field for nested message fields" do
-      results = @es.search(index: 'logstash', q: "somemessage.message.keyword:\"sample nested message here\"")
+      results = @es.search(index: 'logstash*', q: "somemessage.message.keyword:\"sample nested message here\"")
       expect(results).to have_hits(1)
     end
 
     it "creates .keyword field from any string field which is not_analyzed" do
-      results = @es.search(index: 'logstash', q: "country.keyword:\"us\"")
+      results = @es.search(index: 'logstash*', q: "country.keyword:\"us\"")
       expect(results).to have_hits(1)
       expect(results["hits"]["hits"][0]["_source"]["country"]).to eq("us")
 
       # partial or terms should not work.
-      results = @es.search(index: 'logstash', q: "country.keyword:\"u\"")
+      results = @es.search(index: 'logstash*', q: "country.keyword:\"u\"")
       expect(results).to have_hits(0)
     end
 
@@ -94,7 +94,7 @@ describe "index template expected behavior", :integration => true do
     end
 
     it "aggregate .keyword results correctly " do
-      results = @es.search(index: 'logstash', body: { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
+      results = @es.search(index: 'logstash*', body: { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
       terms = results["buckets"].collect { |b| b["key"] }
 
       expect(terms).to include("us")

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -48,19 +48,19 @@ describe "index template expected behavior", :integration => true do
 
       # Wait or fail until everything's indexed.
       Stud::try(20.times) do
-        r = @es.search(index: 'logstash*')
+        r = @es.search(index: 'logstash-*')
         expect(r).to have_hits(8)
       end
     end
 
     it "permits phrase searching on string fields" do
-      results = @es.search(index: 'logstash*', q: "message:\"sample message\"")
+      results = @es.search(:q => "message:\"sample message\"")
       expect(results).to have_hits(1)
       expect(results["hits"]["hits"][0]["_source"]["message"]).to eq("sample message here")
     end
 
     it "numbers dynamically map to a numeric type and permit range queries" do
-      results = @es.search(index: 'logstash*', q: "somevalue:[5 TO 105]")
+      results = @es.search(:q => "somevalue:[5 TO 105]")
       expect(results).to have_hits(2)
 
       values = results["hits"]["hits"].collect { |r| r["_source"]["somevalue"] }
@@ -70,22 +70,22 @@ describe "index template expected behavior", :integration => true do
     end
 
     it "does not create .keyword field for top-level message field" do
-      results = @es.search(index: 'logstash*', q: "message.keyword:\"sample message here\"")
+      results = @es.search(:q => "message.keyword:\"sample message here\"")
       expect(results).to have_hits(0)
     end
 
     it "creates .keyword field for nested message fields" do
-      results = @es.search(index: 'logstash*', q: "somemessage.message.keyword:\"sample nested message here\"")
+      results = @es.search(:q => "somemessage.message.keyword:\"sample nested message here\"")
       expect(results).to have_hits(1)
     end
 
     it "creates .keyword field from any string field which is not_analyzed" do
-      results = @es.search(index: 'logstash*', q: "country.keyword:\"us\"")
+      results = @es.search(:q => "country.keyword:\"us\"")
       expect(results).to have_hits(1)
       expect(results["hits"]["hits"][0]["_source"]["country"]).to eq("us")
 
       # partial or terms should not work.
-      results = @es.search(index: 'logstash*', q: "country.keyword:\"u\"")
+      results = @es.search(:q => "country.keyword:\"u\"")
       expect(results).to have_hits(0)
     end
 
@@ -94,7 +94,7 @@ describe "index template expected behavior", :integration => true do
     end
 
     it "aggregate .keyword results correctly " do
-      results = @es.search(index: 'logstash*', body: { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
+      results = @es.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
       terms = results["buckets"].collect { |b| b["key"] }
 
       expect(terms).to include("us")

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1459,7 +1459,7 @@ describe LogStash::Outputs::ElasticSearch do
 
     context 'during register/finish_register' do
 
-      let(:options) { { 'hosts' => '127.0.0.1:9999' } }
+      let(:options) { { 'hosts' => '127.0.0.1:9999', 'data_stream' => 'true' } }
       let(:es_version) { '8.7.0' } # DS default on LS 8.x
       let(:latch) { Concurrent::CountDownLatch.new }
 
@@ -1477,7 +1477,7 @@ describe LogStash::Outputs::ElasticSearch do
       # after `ilm_in_use?` is called but before `setup_ilm`
       it 'doesn\'t have a race condition leading to resetting back to ILM' do
         ilm_in_use = subject.method(:ilm_in_use?)
-        expect(subject).to receive(:ilm_in_use?).once do |params|
+        expect(subject).to receive(:ilm_in_use?) do |params|
           ret = ilm_in_use.call
           sleep 3
           ret

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1461,7 +1461,6 @@ describe LogStash::Outputs::ElasticSearch do
 
       let(:options) { { 'hosts' => '127.0.0.1:9999', 'data_stream' => 'true' } }
       let(:es_version) { '8.7.0' } # DS default on LS 8.x
-      let(:latch) { Concurrent::CountDownLatch.new }
 
       before do
         allow(subject).to receive(:discover_cluster_uuid)

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1456,6 +1456,43 @@ describe LogStash::Outputs::ElasticSearch do
       end
 
     end
+
+    context 'during register/finish_register' do
+
+      let(:options) { { 'hosts' => '127.0.0.1:9999' } }
+      let(:es_version) { '8.7.0' } # DS default on LS 8.x
+      let(:latch) { Concurrent::CountDownLatch.new }
+
+      before do
+        allow(subject).to receive(:discover_cluster_uuid)
+        allow(subject).to receive(:maybe_create_rollover_alias)
+        allow(subject).to receive(:maybe_create_ilm_policy)
+        allow(subject).to receive(:build_client)
+      end
+
+      # this test could not have been done using latches as the fix to the race
+      # condition alters the order of the instructions in elasticsearch.rb
+      #
+      # the race condition happened when the @index was set to the datastream
+      # after `ilm_in_use?` is called but before `setup_ilm`
+      it 'doesn\'t have a race condition leading to resetting back to ILM' do
+        ilm_in_use = subject.method(:ilm_in_use?)
+        expect(subject).to receive(:ilm_in_use?).once do |params|
+          ret = ilm_in_use.call
+          sleep 3
+          ret
+        end
+        setup_mapper_and_target = subject.method(:setup_mapper_and_target)
+        expect(subject).to receive(:setup_mapper_and_target).once do |params|
+          sleep 1
+          setup_mapper_and_target.call(params)
+        end
+        subject.register
+        sleep 6
+        expect(subject.index).to eq("logs-generic-default")
+      end
+
+    end
   end
 
   @private


### PR DESCRIPTION
This PR fixes a race condition between the thread running `register` and the one running `finish_register`.

The issue can be observed by having 20-30 simple pipelines in `pipelines.yml` like:

```
input {
 java_generator { eps => 1.1 }
}
output {
  elasticsearch {
    user => elastic
    password => ".."
    data_stream => true
  }
```


```yml
- pipeline.id: test_0
  pipeline.workers: 1
  pipeline.batch.size: 1
  path.config: "/tmp/logstash-8.7.0/cfg"
```

```
ruby -ryaml -e '30.times.each {|i| puts "- pipeline.id: test_#{i}\n  pipeline.workers: 1\n  pipeline.batch.size: 1\n  path.config: \"/tmp/logstash-8.7.0/cfg\""}' > config/pipelines.yml
```
Run Logstash w/ pipeline reloading:
```
bin/logstash -r
```

Changing the pipeline config a few times and letting Logstash reload will eventually show one or more pipelines overwriting the index with "ecs-logstash":

```
[2023-04-20T12:08:33,181][WARN ][logstash.outputs.elasticsearch][test_0] Overwriting supplied index logs-generic-default with rollover alias ecs-logstash
```

Putting `finish_register` at the end of register ensures there are no concurrent instructions manipulating `@index` and other internal state variables.


fixes #1126 