### PR TITLE
Fixed abort condition in case of shutdown is requested during connection wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.15.6
+  - Fix: avoid to reject a batch when the Elasticsearch connection is alive and the processing should continue [#1132](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1132).
+
 ## 11.15.5
   - Fixes `undefined 'shutdown_requested' method` error when plugin checks if shutdown request is received [#1134](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1134)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -432,7 +432,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     return unless after_successful_connection_done
     stoppable_sleep 1 until (after_successful_connection_done.true? || pipeline_shutdown_requested?)
 
-    if pipeline_shutdown_requested?
+    if pipeline_shutdown_requested? && !after_successful_connection_done.true?
       logger.info "Aborting the batch due to shutdown request while waiting for connections to become live"
       abort_batch_if_available!
     end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -432,7 +432,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     return unless after_successful_connection_done
     stoppable_sleep 1 until (after_successful_connection_done.true? || pipeline_shutdown_requested?)
 
-    if pipeline_shutdown_requested? && !after_successful_connection_done.true?
+    if pipeline_shutdown_requested? ##&& !after_successful_connection_done.true?
       logger.info "Aborting the batch due to shutdown request while waiting for connections to become live"
       abort_batch_if_available!
     end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -432,7 +432,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     return unless after_successful_connection_done
     stoppable_sleep 1 until (after_successful_connection_done.true? || pipeline_shutdown_requested?)
 
-    if pipeline_shutdown_requested? ##&& !after_successful_connection_done.true?
+    if pipeline_shutdown_requested? && !after_successful_connection_done.true?
       logger.info "Aborting the batch due to shutdown request while waiting for connections to become live"
       abort_batch_if_available!
     end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.15.5'
+  s.version         = '11.15.6'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -96,16 +96,13 @@ describe LogStash::Outputs::ElasticSearch do
     context "on a reachable ES instance" do
       let(:events) { [ ::LogStash::Event.new("foo" => "bar1"), ::LogStash::Event.new("foo" => "bar2") ] }
 
-      let(:shutdown_value) { true }
-
       let(:logger) { double("logger") }
+
       before(:each) do
         allow(subject).to receive(:logger).and_return(logger)
         allow(logger).to receive(:info)
 
-        allow(subject).to receive(:pipeline_shutdown_requested?) do
-          shutdown_value
-        end
+        allow(subject).to receive(:pipeline_shutdown_requested?).and_return(true)
         allow(subject).to receive(:retrying_submit)
       end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -107,6 +107,7 @@ describe LogStash::Outputs::ElasticSearch do
       end
 
       it "the #multi_receive doesn't abort when waiting for a connection on alive ES and a shutdown is requested" do
+        subject.multi_receive(events)
         expect(logger).to_not have_received(:info).with(/Aborting the batch due to shutdown request while waiting for connections to become live/i)
       end
     end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -155,6 +155,9 @@ describe LogStash::Outputs::ElasticSearch do
         end
 
         it "should exit the retry with an abort exception if shutdown is requested" do
+          # trigger the shutdown signal
+          allow(subject).to receive(:pipeline_shutdown_requested?) { true }
+
           # execute in another thread because it blocks in a retry loop until the shutdown is triggered
           th = Thread.new do
             subject.multi_receive([event])
@@ -162,9 +165,6 @@ describe LogStash::Outputs::ElasticSearch do
             # return exception's class so that it can be verified when retrieving the thread's value
             e.class
           end
-
-          # trigger the shutdown signal
-          allow(subject).to receive(:pipeline_shutdown_requested?) { true }
 
           expect(th.value).to eq(org.logstash.execution.AbortedBatchException)
         end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -58,7 +58,27 @@ describe LogStash::Outputs::ElasticSearch do
 
       let(:logger) { double("logger") }
 
+      let(:never_ending) { Thread.new { sleep 1 while true } }
+
+      let(:do_register) { false }
+
       before(:each) do
+        spy_http_client_builder!
+        stub_http_client_pool!
+
+        allow(subject).to receive(:finish_register) # stub-out thread completion (to avoid error log entries)
+
+        # emulate 'failed' ES connection, which sleeps forever
+        allow(subject).to receive(:after_successful_connection) { |&block| never_ending }
+        allow(subject).to receive(:stop_after_successful_connection_thread)
+
+        subject.register
+
+        allow(subject.client).to receive(:maximum_seen_major_version).at_least(:once).and_return(maximum_seen_major_version)
+        allow(subject.client).to receive(:get_xpack_info)
+
+        subject.client.pool.adapter.manticore.respond_with(:body => "{}")
+
         allow(subject).to receive(:logger).and_return(logger)
         allow(logger).to receive(:info)
 
@@ -70,6 +90,27 @@ describe LogStash::Outputs::ElasticSearch do
       it "the #multi_receive abort while waiting on unreachable and a shutdown is requested" do
         expect { subject.multi_receive(events) }.to raise_error(org.logstash.execution.AbortedBatchException)
         expect(logger).to have_received(:info).with(/Aborting the batch due to shutdown request while waiting for connections to become live/i)
+      end
+    end
+
+    context "on a reachable ES instance" do
+      let(:events) { [ ::LogStash::Event.new("foo" => "bar1"), ::LogStash::Event.new("foo" => "bar2") ] }
+
+      let(:shutdown_value) { true }
+
+      let(:logger) { double("logger") }
+      before(:each) do
+        allow(subject).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:info)
+
+        allow(subject).to receive(:pipeline_shutdown_requested?) do
+          shutdown_value
+        end
+        allow(subject).to receive(:retrying_submit)
+      end
+
+      it "the #multi_receive doesn't abort when waiting for a connection on alive ES and a shutdown is requested" do
+        expect(logger).to_not have_received(:info).with(/Aborting the batch due to shutdown request while waiting for connections to become live/i)
       end
     end
 


### PR DESCRIPTION
## Release notes
Fix the abort of batch also when the ES connection is alive and the processing should continue.


## What does this PR do?

Fixes the exit condition while waiting for valid connection. It could happen that while waiting both conditions becomes true:
- a connection was established
- the shutdown was requested

If the shutdown is requested *and* a valid ES connection is created the processing must take place and shouldn't abort the batch.

#### Technical observation
While waiting for connection to be established, the busy wait loop that also check for shutdown request. The abort of the batch should happen if no connection was successful established and there is a shutdown request; else it could be that the loop exit condition is trigger with both parts satisfied and it's not correct to abort the batch if a connection was created.

In this condition is important that at least one time Elasticsearch is reached before the flag `after_successful_connection_done`  reaches a final status, so it means that at least one `health_check!` is executed before the `#multi_receive` enter the wait loop.
This is granted by the fact that `health_check!` is executed during the `#register`.


## Why is it important/What is the impact to the user?
It exposed in https://github.com/elastic/logstash/issues/15040 essentially running the command:
```sh
echo "foo" | bin/logstash -e 'input { stdin { } } output { elasticsearch {} }'
```

The `foo` message is not processed also if the ES is up and running.
Due to scheduling could be that `stdin` reached an EOF and request the shutdown while the ES output is waiting for connection. In this case, given that ES is up and running it should process the batch till the memory queue is completely consumed.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] test that Logstash's 37K integration test is green with this plugin's fix.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- in a local clone of Logstash set the elasticsearch output plugin to this PR checkout:
```
gem "logstash-output-elasticsearch", :path => "/path/to/logstash-output-elasticsearch"
bin/logstash-plugin install --no-verify
```
- run the integration test with
```sh
./gradlew runIntegrationTests -PrubyIntegrationSpecs="specs/es_output_how_spec.rb"
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Fixes https://github.com/elastic/logstash/issues/15040
- Closes https://github.com/elastic/logstash/issues/15009

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
