### PR TITLE
Fixes the undefined `shutdown_requested` method error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.15.5
+  - Fixes `undefined 'shutdown_requested' method` error when plugin receives shutdown request [#1134](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1134)
+
 ## 11.15.4
   - Improved connection handling under several partial-failure scenarios [#1130](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1130)
    - Ensures an HTTP connection can be established before adding the connection to the pool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.15.5
-  - Fixes `undefined 'shutdown_requested' method` error when plugin receives shutdown request [#1134](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1134)
+  - Fixes `undefined 'shutdown_requested' method` error when plugin checks if shutdown request is received [#1134](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1134)
 
 ## 11.15.4
   - Improved connection handling under several partial-failure scenarios [#1130](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1130)

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -376,9 +376,9 @@ module LogStash; module PluginMixins; module ElasticSearch
     end
 
     def pipeline_shutdown_requested?
-        return super if defined?(super) # since LS 8.1.0
-        execution_context&.pipeline&.shutdown_requested
-      end
+      return super if defined?(super) # since LS 8.1.0
+      execution_context&.pipeline&.shutdown_requested?
+    end
 
     def abort_batch_if_available!
       raise org.logstash.execution.AbortedBatchException.new if abort_batch_present?

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.15.4'
+  s.version         = '11.15.5'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
### Description
When plugin check if shutdown is received, it tries to call [`shutdown_requested?` java API](https://github.com/mashhurs/logstash/blob/6ab14e4e8a8c25ab8b6229b19923564e735a6fa0/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java#L819) but in ruby code we are missing `?` mark after method. Since there is no `shutdown_requested` in core, plugin stops with the `(NoMethodError) undefined method 'shutdown_requested'` error.

- Closes: #1133 

