### PR TITLE
allow dlq_ settings when using data streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.15.9
+  - allow dlq_ settings when using data streams [#1144](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1144)
+
 ## 11.15.8
   - Fixes a regression introduced in 11.14.0 which could prevent Logstash 8.8 from establishing a connection to Elasticsearch for Central Management and Monitoring core features [#1141](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1141)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -267,14 +267,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # ILM policy to use, if undefined the default policy will be used.
   config :ilm_policy, :validate => :string, :default => DEFAULT_POLICY
 
-  # List extra HTTP's error codes that are considered valid to move the events into the dead letter queue.
-  # It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
-  # The option accepts a list of natural numbers corresponding to HTTP errors codes.
-  config :dlq_custom_codes, :validate => :number, :list => true, :default => []
-
-  # if enabled, failed index name interpolation events go into dead letter queue.
-  config :dlq_on_failed_indexname_interpolation, :validate => :boolean, :default => true
-
   attr_reader :client
   attr_reader :default_index
   attr_reader :default_ilm_rollover_alias

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -213,7 +213,15 @@ module LogStash; module PluginMixins; module ElasticSearch
         :retry_initial_interval => { :validate => :number, :default => 2 },
 
         # Set max interval in seconds between bulk retries.
-        :retry_max_interval => { :validate => :number, :default => 64 }
+        :retry_max_interval => { :validate => :number, :default => 64 },
+
+        # List extra HTTP's error codes that are considered valid to move the events into the dead letter queue.
+        # It's considered a configuration error to re-use the same predefined codes for success, DLQ or conflict.
+        # The option accepts a list of natural numbers corresponding to HTTP errors codes.
+        :dlq_custom_codes => { :validate => :number, :list => true, :default => [] },
+
+        # if enabled, failed index name interpolation events go into dead letter queue.
+        :dlq_on_failed_indexname_interpolation => { :validate => :boolean, :default => true }
     }.freeze
 
     def self.included(base)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.15.8'
+  s.version         = '11.15.9'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
+++ b/spec/unit/outputs/elasticsearch/data_stream_support_spec.rb
@@ -164,7 +164,9 @@ describe LogStash::Outputs::ElasticSearch::DataStreamSupport do
         'data_stream_dataset' => 'any',
         'data_stream_namespace' => 'any',
         'data_stream_sync_fields' => true,
-        'data_stream_auto_routing' => true)
+        'data_stream_auto_routing' => true,
+        'dlq_custom_codes' => [ 404 ],
+        'dlq_on_failed_indexname_interpolation' => false)
       }
 
       it 'should enable data-streams by default' do


### PR DESCRIPTION
move dlq_ setting definition to shared parameters (could be used by other ES outputs) so it is allowed to work with data streams

fixes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1135