### PR TITLE
Add support to Serverless Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.16.0
+  - Added support to Serverless Elasticsearch
+
 ## 11.15.9
   - allow dlq_ settings when using data streams [#1144](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1144)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.16.0
-  - Added support to Serverless Elasticsearch
+  - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)
 
 ## 11.15.9
   - allow dlq_ settings when using data streams [#1144](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1144)

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -93,6 +93,10 @@ module LogStash; module Outputs; class ElasticSearch;
       @pool.maximum_seen_major_version
     end
 
+    def serverless?
+      @pool.serverless?
+    end
+
     def alive_urls_count
       @pool.alive_urls_count
     end

--- a/lib/logstash/outputs/elasticsearch/license_checker.rb
+++ b/lib/logstash/outputs/elasticsearch/license_checker.rb
@@ -11,6 +11,8 @@ module LogStash; module Outputs; class ElasticSearch
     # @param url [LogStash::Util::SafeURI] ES node URL
     # @return [Boolean] true if provided license is deemed appropriate
     def appropriate_license?(pool, url)
+      return true if pool.serverless?
+
       license = extract_license(pool.get_license(url))
       case license_status(license)
       when 'active'

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -64,9 +64,9 @@ module LogStash; module Outputs; class ElasticSearch
         plugin.logger.trace("Resolving ILM template settings: under 'settings' key", :template => template, :template_api => plugin.template_api, :es_version => plugin.maximum_seen_major_version)
         legacy_index_template_settings(template)
       else
-        use_index_template = index_template?(plugin)
-        plugin.logger.trace("Resolving ILM template settings: template doesn't have 'settings' or 'template' fields, falling back to auto detection", :template => template, :template_api => plugin.template_api, :es_version => plugin.maximum_seen_major_version, :index_template => use_index_template)
-        if use_index_template
+        use_index_template_api = index_template_api?(plugin)
+        plugin.logger.trace("Resolving ILM template settings: template doesn't have 'settings' or 'template' fields, falling back to auto detection", :template => template, :template_api => plugin.template_api, :es_version => plugin.maximum_seen_major_version, :index_template_api => use_index_template_api)
+        if use_index_template_api
           composable_index_template_settings(template)
         else
           legacy_index_template_settings(template)
@@ -105,10 +105,10 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.template_endpoint(plugin)
-      index_template?(plugin) ? INDEX_TEMPLATE_ENDPOINT : LEGACY_TEMPLATE_ENDPOINT
+      index_template_api?(plugin) ? INDEX_TEMPLATE_ENDPOINT : LEGACY_TEMPLATE_ENDPOINT
     end
 
-    def self.index_template?(plugin)
+    def self.index_template_api?(plugin)
       case plugin.serverless?
       when true
         true

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -13,7 +13,10 @@ module LogStash; module Outputs; class ElasticSearch
                            "We recommend either setting `template_api => legacy` to continue providing legacy-style templates, " +
                            "or migrating your template to the composable style and setting `template_api => composable`. " +
                            "The legacy template API is slated for removal in Elasticsearch 9.")
+      elsif plugin.template_api == 'legacy' && plugin.serverless?
+        raise LogStash::ConfigurationError, "Invalid template configuration `template_api => legacy`. Serverless Elasticsearch does not support legacy template API."
       end
+
 
       if plugin.template
         plugin.logger.info("Using mapping template from", :path => plugin.template)
@@ -61,11 +64,13 @@ module LogStash; module Outputs; class ElasticSearch
         plugin.logger.trace("Resolving ILM template settings: under 'settings' key", :template => template, :template_api => plugin.template_api, :es_version => plugin.maximum_seen_major_version)
         legacy_index_template_settings(template)
       else
-        template_endpoint = template_endpoint(plugin)
-        plugin.logger.trace("Resolving ILM template settings: template doesn't have 'settings' or 'template' fields, falling back to auto detection", :template => template, :template_api => plugin.template_api, :es_version => plugin.maximum_seen_major_version, :template_endpoint => template_endpoint)
-        template_endpoint == INDEX_TEMPLATE_ENDPOINT ?
-          composable_index_template_settings(template) :
+        use_index_template = index_template?(plugin)
+        plugin.logger.trace("Resolving ILM template settings: template doesn't have 'settings' or 'template' fields, falling back to auto detection", :template => template, :template_api => plugin.template_api, :es_version => plugin.maximum_seen_major_version, :index_template => use_index_template)
+        if use_index_template
+          composable_index_template_settings(template)
+        else
           legacy_index_template_settings(template)
+        end
       end
     end
 
@@ -100,12 +105,25 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.template_endpoint(plugin)
-      if plugin.template_api == 'auto'
-        plugin.maximum_seen_major_version < 8 ? LEGACY_TEMPLATE_ENDPOINT : INDEX_TEMPLATE_ENDPOINT
-      elsif plugin.template_api.to_s == 'legacy'
-        LEGACY_TEMPLATE_ENDPOINT
+      index_template?(plugin) ? INDEX_TEMPLATE_ENDPOINT : LEGACY_TEMPLATE_ENDPOINT
+    end
+
+    def self.index_template?(plugin)
+      case plugin.serverless?
+      when true
+        true
       else
-        INDEX_TEMPLATE_ENDPOINT
+        case plugin.template_api
+        when 'auto'
+          plugin.maximum_seen_major_version >= 8
+        when 'composable'
+          true
+        when 'legacy'
+          false
+        else
+          plugin.logger.warn("Invalid template_api value #{plugin.template_api}")
+          true
+        end
       end
     end
 

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -145,6 +145,10 @@ module LogStash; module PluginMixins; module ElasticSearch
       client.maximum_seen_major_version
     end
 
+    def serverless?
+      client.serverless?
+    end
+
     def alive_urls_count
       client.alive_urls_count
     end

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.15.9'
+  s.version         = '11.16.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -59,11 +59,16 @@ module ESHelper
   end
 
   def self.es_version
-    [
-      nilify(RSpec.configuration.filter[:es_version]),
-      nilify(ENV['ES_VERSION']),
-      nilify(ENV['ELASTIC_STACK_VERSION']),
-    ].compact.first
+    {
+      "version" => {
+        "number" => [
+          nilify(RSpec.configuration.filter[:es_version]),
+          nilify(ENV['ES_VERSION']),
+          nilify(ENV['ELASTIC_STACK_VERSION']),
+        ].compact.first,
+        "build_flavor" => 'default'
+      }
+    }
   end
 
   RSpec::Matchers.define :have_hits do |expected|

--- a/spec/es_spec_helper.rb
+++ b/spec/es_spec_helper.rb
@@ -60,14 +60,12 @@ module ESHelper
 
   def self.es_version
     {
-      "version" => {
-        "number" => [
-          nilify(RSpec.configuration.filter[:es_version]),
-          nilify(ENV['ES_VERSION']),
-          nilify(ENV['ELASTIC_STACK_VERSION']),
-        ].compact.first,
-        "build_flavor" => 'default'
-      }
+      "number" => [
+        nilify(RSpec.configuration.filter[:es_version]),
+        nilify(ENV['ES_VERSION']),
+        nilify(ENV['ELASTIC_STACK_VERSION']),
+      ].compact.first,
+      "build_flavor" => 'default'
     }
   end
 

--- a/spec/fixtures/license_check/active.json
+++ b/spec/fixtures/license_check/active.json
@@ -1,0 +1,16 @@
+{
+  "license": {
+    "status": "active",
+    "uid": "d85d2c6a-b96d-3cc6-96db-5571a789b156",
+    "type": "enterprise",
+    "issue_date": "1970-01-01T00:00:00.000Z",
+    "issue_date_in_millis": 0,
+    "expiry_date": "2100-01-01T00:00:00.000Z",
+    "expiry_date_in_millis": 4102444800000,
+    "max_nodes": null,
+    "max_resource_units": 100000,
+    "issued_to": "Elastic Cloud",
+    "issuer": "API",
+    "start_date_in_millis": 0
+  }
+}

--- a/spec/fixtures/license_check/inactive.json
+++ b/spec/fixtures/license_check/inactive.json
@@ -1,0 +1,5 @@
+{
+  "license": {
+    "status": "inactive"
+  }
+}

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -278,7 +278,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   describe "build flavour tracking" do
     let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://somehost:9200")] }
 
-    let(:es_version_info) { [ { "number" => '8.9.0', "build_flavor" => LogStash::Outputs::ElasticSearch::HttpClient::Pool::BUILD_FLAVOUR_SERVERLESS } ] }
+    let(:es_version_info) { [ { "number" => '8.9.0', "build_flavor" => "serverless" } ] }
 
     let(:valid_response) { MockResponse.new(200,
                                             {"tagline" => "You Know, for Search",

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -7,7 +7,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger, {}) }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }
   let(:options) { {:resurrect_delay => 2, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
-  let(:es_node_versions) { [ "0.0.0" ] }
+  let(:es_version_info) { [ { "number" => '0.0.0', "build_flavor" => 'default'} ] }
   let(:license_status) { 'active' }
 
   subject { described_class.new(logger, adapter, initial_urls, options) }
@@ -22,7 +22,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
 
     allow(::Manticore::Client).to receive(:new).and_return(manticore_double)
 
-    allow(subject).to receive(:get_es_version).with(any_args).and_return(*es_node_versions)
+    allow(subject).to receive(:get_es_version).with(any_args).and_return(*es_version_info)
     allow(subject.license_checker).to receive(:license_status).and_return(license_status)
   end
 
@@ -267,10 +267,34 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
     end
 
     context "if there are nodes with multiple major versions" do
-      let(:es_node_versions) { [ "0.0.0", "6.0.0" ] }
+      let(:es_version_info) { [ { "number" => '0.0.0', "build_flavor" => 'default'}, { "number" => '6.0.0', "build_flavor" => 'default'} ] }
       it "picks the largest major version" do
         expect(subject.maximum_seen_major_version).to eq(6)
       end
+    end
+  end
+
+
+  describe "build flavour tracking" do
+    let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://somehost:9200")] }
+
+    let(:es_version_info) { [ { "number" => '8.9.0', "build_flavor" => LogStash::Outputs::ElasticSearch::HttpClient::Pool::BUILD_FLAVOUR_SERVERLESS } ] }
+
+    let(:valid_response) { MockResponse.new(200,
+                                            {"tagline" => "You Know, for Search",
+                                                  "version" => {
+                                                    "number" => '8.9.0',
+                                                    "build_flavor" => LogStash::Outputs::ElasticSearch::HttpClient::Pool::BUILD_FLAVOUR_SERVERLESS} },
+                                            { "X-Elastic-Product" => "Elasticsearch" }
+    ) }
+
+    before(:each) do
+      allow(subject).to receive(:perform_request_to_url).and_return(valid_response)
+      subject.start
+    end
+
+    it "picks the build flavour" do
+      expect(subject.serverless?).to be_truthy
     end
   end
 
@@ -364,7 +388,7 @@ describe "#elasticsearch?" do
   let(:adapter) { double("Manticore Adapter") }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }
   let(:options) { {:resurrect_delay => 2, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
-  let(:es_node_versions) { [ "0.0.0" ] }
+  let(:es_version_info) { [{ "number" => '0.0.0', "build_flavor" => 'default'}] }
   let(:license_status) { 'active' }
 
   subject { LogStash::Outputs::ElasticSearch::HttpClient::Pool.new(logger, adapter, initial_urls, options) }

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -6,7 +6,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   let(:logger) { Cabin::Channel.get }
   let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger, {}) }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }
-  let(:options) { {:resurrect_delay => 2, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
+  let(:options) { {:resurrect_delay => 3, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
   let(:es_version_info) { [ { "number" => '0.0.0', "build_flavor" => 'default'} ] }
   let(:license_status) { 'active' }
 

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -159,9 +159,23 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
         it "should use legacy template API" do
           expect(plugin).to receive(:maximum_seen_major_version).never
           endpoint = described_class.template_endpoint(plugin)
-          expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager:: INDEX_TEMPLATE_ENDPOINT)
+          expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::INDEX_TEMPLATE_ENDPOINT)
         end
       end
+    end
+
+    describe "in serverless" do
+      [:auto, :composable, :legacy].each do |api|
+        let(:plugin_settings) { {"manage_template" => true, "template_api" => api.to_s} }
+        let(:plugin) { LogStash::Outputs::ElasticSearch.new(plugin_settings) }
+
+        it "use index template API when template_api set to #{api}" do
+          expect(plugin).to receive(:serverless?).and_return(true)
+          endpoint = described_class.template_endpoint(plugin)
+          expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::INDEX_TEMPLATE_ENDPOINT)
+        end
+      end
+
     end
   end
 end

--- a/spec/unit/outputs/elasticsearch/template_manager_spec.rb
+++ b/spec/unit/outputs/elasticsearch/template_manager_spec.rb
@@ -73,6 +73,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
         let(:template_api) { "composable" }
 
         it 'resolves composable index template API compatible setting' do
+          expect(plugin).to receive(:serverless?).and_return(false)
           expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(8) # required to log
           template = {}
           described_class.resolve_template_settings(plugin, template)
@@ -84,6 +85,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
         let(:template_api) { "legacy" }
 
         it 'resolves legacy index template API compatible setting' do
+          expect(plugin).to receive(:serverless?).and_return(false)
           expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(7) # required to log
           template = {}
           described_class.resolve_template_settings(plugin, template)
@@ -97,6 +99,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
         describe "with ES < 8 versions" do
 
           it 'resolves legacy index template API compatible setting' do
+            expect(plugin).to receive(:serverless?).and_return(false)
             expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(7)
             template = {}
             described_class.resolve_template_settings(plugin, template)
@@ -106,6 +109,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
         describe "with ES >= 8 versions" do
           it 'resolves composable index template API compatible setting' do
+            expect(plugin).to receive(:serverless?).and_return(false)
             expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(8)
             template = {}
             described_class.resolve_template_settings(plugin, template)
@@ -123,6 +127,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
       describe "in version 8+" do
         it "should use index template API" do
+          expect(plugin).to receive(:serverless?).and_return(false)
           expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(8)
           endpoint = described_class.template_endpoint(plugin)
           expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::INDEX_TEMPLATE_ENDPOINT)
@@ -131,6 +136,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
       describe "in version < 8" do
         it "should use legacy template API" do
+          expect(plugin).to receive(:serverless?).and_return(false)
           expect(plugin).to receive(:maximum_seen_major_version).at_least(:once).and_return(7)
           endpoint = described_class.template_endpoint(plugin)
           expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::LEGACY_TEMPLATE_ENDPOINT)
@@ -144,6 +150,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
       describe "in version 8+" do
         it "should use legacy template API" do
+          expect(plugin).to receive(:serverless?).and_return(false)
           expect(plugin).to receive(:maximum_seen_major_version).never
           endpoint = described_class.template_endpoint(plugin)
           expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::LEGACY_TEMPLATE_ENDPOINT)
@@ -157,6 +164,7 @@ describe LogStash::Outputs::ElasticSearch::TemplateManager do
 
       describe "in version 8+" do
         it "should use legacy template API" do
+          expect(plugin).to receive(:serverless?).and_return(false)
           expect(plugin).to receive(:maximum_seen_major_version).never
           endpoint = described_class.template_endpoint(plugin)
           expect(endpoint).to be_equal(LogStash::Outputs::ElasticSearch::TemplateManager::INDEX_TEMPLATE_ENDPOINT)

--- a/spec/unit/outputs/license_check_spec.rb
+++ b/spec/unit/outputs/license_check_spec.rb
@@ -21,5 +21,37 @@ describe LogStash::Outputs::ElasticSearch::LicenseChecker do
       expect(LogStash::Outputs::ElasticSearch::HttpClient::Pool.instance_methods).to include(:get_license)
     end
   end
+
+  context "appropriate license" do
+    let(:logger) { double("logger") }
+    let(:url) { LogStash::Util::SafeURI.new("https://cloud.elastic.co") }
+    let(:pool) { double("pool") }
+    subject { described_class.new(logger) }
+
+    it "is true when connect to serverless" do
+      allow(pool).to receive(:serverless?).and_return(true)
+      expect(subject.appropriate_license?(pool, url)).to eq true
+    end
+
+    it "is true when license status is active" do
+      allow(pool).to receive(:serverless?).and_return(false)
+      allow(pool).to receive(:get_license).with(url).and_return(LogStash::Json.load File.read("spec/fixtures/license_check/active.json"))
+      expect(subject.appropriate_license?(pool, url)).to eq true
+    end
+
+    it "is true when license status is inactive" do
+      allow(logger).to receive(:warn).with(instance_of(String), anything)
+      allow(pool).to receive(:serverless?).and_return(false)
+      allow(pool).to receive(:get_license).with(url).and_return(LogStash::Json.load File.read("spec/fixtures/license_check/inactive.json"))
+      expect(subject.appropriate_license?(pool, url)).to eq true
+    end
+
+    it "is false when no license return" do
+      allow(logger).to receive(:error).with(instance_of(String), anything)
+      allow(pool).to receive(:serverless?).and_return(false)
+      allow(pool).to receive(:get_license).with(url).and_return(LogStash::Json.load('{}'))
+      expect(subject.appropriate_license?(pool, url)).to eq false
+    end
+  end
 end
 


### PR DESCRIPTION
The pool stores build flavour in health check to determinate if the Elasticsearch is serverless.
In serverless, ilm, legacy template API and license checker are disabled. The plugin throws ConfigurationError when ilm_enabled => true or template_api => legacy

todo: add integration test against serverless 

fixes: https://github.com/elastic/ingest-dev/issues/2277

