### PR TITLE
Add Elastic Api Version header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.17.0
+  - Added request header `Elastic-Api-Version` for serverless [#1147](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1147)
+
 ## 11.16.0
   - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -596,7 +596,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   def install_template
     TemplateManager.install_template(self)
   rescue => e
-    @logger.error("Failed to install template", message: e.message, exception: e.class, backtrace: e.backtrace)
+    details = { message: e.message, exception: e.class, backtrace: e.backtrace }
+    details[:body] = e.response_body if e.respond_to?(:response_body)
+    @logger.error("Failed to install template", details)
   end
 
   def setup_ecs_compatibility_related_defaults

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -209,7 +209,7 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def get(path)
-      response = @pool.get(path, nil)
+      response = @pool.get(path)
       LogStash::Json.load(response.body)
     end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -292,8 +292,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         resp = perform_request_to_url(url, :get, ROOT_URI_PATH)
         return resp, nil
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
-        logger.warn("Failed to get Elasticsearch root endpoint",
-                     code: e.response_code, message: e.message, body: e.response_body)
+        logger.warn("Elasticsearch main endpoint returns #{e.response_code}", message: e.message, body: e.response_body)
         return nil, e
       end
     end

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -49,6 +49,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     }.freeze
 
     BUILD_FLAVOUR_SERVERLESS = 'serverless'.freeze
+    DEFAULT_EAV_HEADER = { "Elastic-Api-Version" => "2023-10-31" }.freeze
 
     def initialize(logger, adapter, initial_urls=[], options={})
       @logger = logger
@@ -334,6 +335,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     end
 
     def perform_request_to_url(url, method, path, params={}, body=nil)
+      params[:headers] = DEFAULT_EAV_HEADER.merge(params[:headers] || {}) if params && serverless?
       @adapter.perform_request(url, method, path, params, body)
     end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -335,7 +335,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     end
 
     def perform_request_to_url(url, method, path, params={}, body=nil)
-      params[:headers] = DEFAULT_EAV_HEADER.merge(params[:headers] || {}) if params && serverless?
+      params[:headers] = DEFAULT_EAV_HEADER.merge(params[:headers] || {}) if serverless?
       @adapter.perform_request(url, method, path, params, body)
     end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -48,7 +48,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       :sniffer_delay => 10,
     }.freeze
 
-    BUILD_FLAVOUR_SERVERLESS = 'serverless'.freeze
+    BUILD_FLAVOR_SERVERLESS = 'serverless'.freeze
     DEFAULT_EAV_HEADER = { "Elastic-Api-Version" => "2023-10-31" }.freeze
 
     def initialize(logger, adapter, initial_urls=[], options={})
@@ -78,7 +78,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       @license_checker = options[:license_checker] || LogStash::PluginMixins::ElasticSearch::NoopLicenseChecker::INSTANCE
 
       @last_es_version = Concurrent::AtomicReference.new
-      @build_flavour = Concurrent::AtomicReference.new
+      @build_flavor = Concurrent::AtomicReference.new
     end
 
     def start
@@ -256,7 +256,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           # We reconnected to this node, check its ES version
           version_info = get_es_version(url)
           es_version = version_info.fetch('number', nil)
-          build_flavour = version_info.fetch('build_flavor', nil)
+          build_flavor = version_info.fetch('build_flavor', nil)
 
           if es_version.nil?
             logger.warn("Failed to retrieve Elasticsearch version data from connected endpoint, connection aborted", :url => url.sanitized.to_s)
@@ -265,7 +265,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
           @state_mutex.synchronize do
             meta[:version] = es_version
             set_last_es_version(es_version, url)
-            set_build_flavour(build_flavour)
+            set_build_flavor(build_flavor)
 
             alive = @license_checker.appropriate_license?(self, url)
             meta[:state] = alive ? :alive : :dead
@@ -496,7 +496,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     end
 
     def serverless?
-      @build_flavour.get == BUILD_FLAVOUR_SERVERLESS
+      @build_flavor.get == BUILD_FLAVOR_SERVERLESS
     end
 
     private
@@ -528,8 +528,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
                    previous_major: @maximum_seen_major_version, new_major: major, node_url: url.sanitized.to_s)
     end
 
-    def set_build_flavour(flavour)
-      @build_flavour.set(flavour)
+    def set_build_flavor(flavor)
+      @build_flavor.set(flavor)
     end
 
   end

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -179,7 +179,9 @@ module LogStash; module PluginMixins; module ElasticSearch
       cluster_info = client.get('/')
       plugin_metadata.set(:cluster_uuid, cluster_info['cluster_uuid'])
     rescue => e
-      @logger.error("Unable to retrieve Elasticsearch cluster uuid", message: e.message, exception: e.class, backtrace: e.backtrace)
+      details = { message: e.message, exception: e.class, backtrace: e.backtrace }
+      details[:body] = e.response_body if e.respond_to?(:response_body)
+      @logger.error("Unable to retrieve Elasticsearch cluster uuid", details)
     end
 
     def retrying_submit(actions)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.16.0'
+  s.version         = '11.17.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -275,7 +275,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   end
 
 
-  describe "build flavour tracking" do
+  describe "build flavor tracking" do
     let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://somehost:9200")] }
 
     let(:es_version_info) { [ { "number" => '8.9.0', "build_flavor" => "serverless" } ] }
@@ -284,7 +284,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
                                             {"tagline" => "You Know, for Search",
                                                   "version" => {
                                                     "number" => '8.9.0',
-                                                    "build_flavor" => LogStash::Outputs::ElasticSearch::HttpClient::Pool::BUILD_FLAVOUR_SERVERLESS} },
+                                                    "build_flavor" => LogStash::Outputs::ElasticSearch::HttpClient::Pool::BUILD_FLAVOR_SERVERLESS} },
                                             { "X-Elastic-Product" => "Elasticsearch" }
     ) }
 
@@ -293,7 +293,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
       subject.start
     end
 
-    it "picks the build flavour" do
+    it "picks the build flavor" do
       expect(subject.serverless?).to be_truthy
     end
   end

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -7,8 +7,14 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   let(:adapter) { LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter.new(logger, {}) }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }
   let(:options) { {:resurrect_delay => 3, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
-  let(:es_version_info) { [ { "number" => '0.0.0', "build_flavor" => 'default'} ] }
   let(:license_status) { 'active' }
+  let(:root_response) { MockResponse.new(200,
+                                          {"tagline" => "You Know, for Search",
+                                           "version" => {
+                                             "number" => '8.9.0',
+                                             "build_flavor" => 'default'} },
+                                          { "X-Elastic-Product" => "Elasticsearch" }
+  ) }
 
   subject { described_class.new(logger, adapter, initial_urls, options) }
 
@@ -22,7 +28,6 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
 
     allow(::Manticore::Client).to receive(:new).and_return(manticore_double)
 
-    allow(subject).to receive(:get_es_version).with(any_args).and_return(*es_version_info)
     allow(subject.license_checker).to receive(:license_status).and_return(license_status)
   end
 
@@ -37,35 +42,42 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
     end
   end
 
-  describe "the resurrectionist" do
-    before(:each) { subject.start }
-    it "should start the resurrectionist when created" do
-      expect(subject.resurrectionist_alive?).to eql(true)
+  describe "healthcheck" do
+
+    describe "the resurrectionist" do
+      before(:each) { subject.start }
+      it "should start the resurrectionist when created" do
+        expect(subject.resurrectionist_alive?).to eql(true)
+      end
+
+      it "should attempt to resurrect connections after the ressurrect delay" do
+        expect(subject).to receive(:healthcheck!).once
+        sleep(subject.resurrect_delay + 1)
+      end
     end
 
-    it "should attempt to resurrect connections after the ressurrect delay" do
-      expect(subject).to receive(:healthcheck!).once
-      sleep(subject.resurrect_delay + 1)
-    end
-
-    describe "healthcheck url handling" do
+    describe "healthcheck path handling" do
       let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }
-      let(:success_response) { double("Response", :code => 200) }
+      let(:healthcheck_response) { double("Response", :code => 200) }
 
       before(:example) do
+        subject.start
+
+        expect(adapter).to receive(:perform_request).with(anything, :head, eq(healthcheck_path), anything, anything) do |url, _, _, _, _|
+          expect(url.path).to be_empty
+          healthcheck_response
+        end
+
         expect(adapter).to receive(:perform_request).with(anything, :get, "/", anything, anything) do |url, _, _, _, _|
           expect(url.path).to be_empty
+          root_response
         end
       end
 
       context "and not setting healthcheck_path" do
+        let(:healthcheck_path) { "/" }
         it "performs the healthcheck to the root" do
-          expect(adapter).to receive(:perform_request).with(anything, :head, "/", anything, anything) do |url, _, _, _, _|
-            expect(url.path).to be_empty
-
-            success_response
-          end
-          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Could not connect to a compatible version of Elasticsearch")
+          subject.healthcheck!
         end
       end
 
@@ -73,13 +85,65 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
         let(:healthcheck_path) { "/my/health" }
         let(:options) { super().merge(:healthcheck_path => healthcheck_path) }
         it "performs the healthcheck to the healthcheck_path" do
-          expect(adapter).to receive(:perform_request).with(anything, :head, eq(healthcheck_path), anything, anything) do |url, _, _, _, _|
-            expect(url.path).to be_empty
+          subject.healthcheck!
+        end
+      end
+    end
 
-            success_response
-          end
+    describe "register phase" do
+      shared_examples_for "root path returns bad code error" do |err_msg|
+        before :each do
+          subject.update_initial_urls
+          expect(subject).to receive(:elasticsearch?).never
+        end
+
+        it "raises ConfigurationError" do
+          expect(subject).to receive(:health_check_request).with(anything).and_return(["", nil])
+          expect(subject).to receive(:get_root_path).with(anything).and_return([mock_resp,
+                                                                                ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(mock_resp.code, nil, nil, mock_resp.body)])
+          expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, err_msg)
+        end
+      end
+
+      context "with 200 without version" do
+        let(:mock_resp) { MockResponse.new(200, {"tagline" => "You Know, for Search"}) }
+
+        it "raises ConfigurationError" do
+          subject.update_initial_urls
+
+          expect(subject).to receive(:health_check_request).with(anything).and_return(["", nil])
+          expect(subject).to receive(:get_root_path).with(anything).and_return([mock_resp, nil])
           expect { subject.healthcheck! }.to raise_error(LogStash::ConfigurationError, "Could not connect to a compatible version of Elasticsearch")
         end
+      end
+
+      context "with 400" do
+        let(:mock_resp) { MockResponse.new(400, "The requested [Elastic-Api-Version] header value of [2024-10-31] is not valid. Only [2023-10-31] is supported") }
+        it_behaves_like "root path returns bad code error", "The Elastic-Api-Version header is not valid"
+      end
+
+      context "with 401" do
+        let(:mock_resp) { MockResponse.new(401, "missing authentication") }
+        it_behaves_like "root path returns bad code error", "Could not connect to a compatible version of Elasticsearch"
+      end
+
+      context "with 403" do
+        let(:mock_resp) { MockResponse.new(403, "Forbidden") }
+        it_behaves_like "root path returns bad code error", "Could not connect to a compatible version of Elasticsearch"
+      end
+    end
+
+    describe "non register phase" do
+      let(:health_bad_code_err) { ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(400, nil, nil, nil) }
+
+      before :each do
+        subject.update_initial_urls
+      end
+
+      it "does not call root path when health check request fails" do
+        expect(subject).to receive(:health_check_request).with(anything).and_return(["", health_bad_code_err])
+        expect(subject).to receive(:get_root_path).never
+        subject.healthcheck!(false)
       end
     end
   end
@@ -251,23 +315,23 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
       ::LogStash::Util::SafeURI.new("http://otherhost:9201")
     ] }
 
-    let(:valid_response) { MockResponse.new(200, {"tagline" => "You Know, for Search",
-                                                          "version" => {
-                                                            "number" => '7.13.0',
-                                                            "build_flavor" => 'default'}
-                                                          }) }
-
-    before(:each) do
-      allow(subject).to receive(:perform_request_to_url).and_return(valid_response)
-      subject.start
-    end
-
-    it "picks the largest major version" do
-      expect(subject.maximum_seen_major_version).to eq(0)
-    end
+    let(:root_response) { MockResponse.new(200, {"tagline" => "You Know, for Search",
+                                                  "version" => {
+                                                    "number" => '0.0.0',
+                                                    "build_flavor" => 'default'}
+    }) }
+    let(:root_response2) { MockResponse.new(200, {"tagline" => "You Know, for Search",
+                                                  "version" => {
+                                                    "number" => '6.0.0',
+                                                    "build_flavor" => 'default'}
+    }) }
 
     context "if there are nodes with multiple major versions" do
-      let(:es_version_info) { [ { "number" => '0.0.0', "build_flavor" => 'default'}, { "number" => '6.0.0', "build_flavor" => 'default'} ] }
+      before(:each) do
+        allow(subject).to receive(:perform_request_to_url).and_return(root_response, root_response2)
+        subject.start
+      end
+
       it "picks the largest major version" do
         expect(subject.maximum_seen_major_version).to eq(6)
       end
@@ -278,9 +342,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
   describe "build flavor tracking" do
     let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://somehost:9200")] }
 
-    let(:es_version_info) { [ { "number" => '8.9.0', "build_flavor" => "serverless" } ] }
-
-    let(:valid_response) { MockResponse.new(200,
+    let(:root_response) { MockResponse.new(200,
                                             {"tagline" => "You Know, for Search",
                                                   "version" => {
                                                     "number" => '8.9.0',
@@ -289,7 +351,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
     ) }
 
     before(:each) do
-      allow(subject).to receive(:perform_request_to_url).and_return(valid_response)
+      allow(subject).to receive(:perform_request_to_url).and_return(root_response)
       subject.start
     end
 
@@ -300,7 +362,8 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
 
   describe "license checking" do
     before(:each) do
-      allow(subject).to receive(:health_check_request)
+      allow(subject).to receive(:health_check_request).and_return(["", nil])
+      allow(subject).to receive(:perform_request_to_url).and_return(root_response)
       allow(subject).to receive(:elasticsearch?).and_return(true)
     end
 
@@ -364,7 +427,8 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
     end
 
     before(:each) do
-      allow(subject).to receive(:health_check_request)
+      allow(subject).to receive(:health_check_request).and_return(["", nil])
+      allow(subject).to receive(:perform_request_to_url).and_return(root_response)
       allow(subject).to receive(:elasticsearch?).and_return(true)
     end
 
@@ -418,114 +482,71 @@ describe "#elasticsearch?" do
   let(:adapter) { double("Manticore Adapter") }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://localhost:9200")] }
   let(:options) { {:resurrect_delay => 2, :url_normalizer => proc {|u| u}} } # Shorten the delay a bit to speed up tests
-  let(:es_version_info) { [{ "number" => '0.0.0', "build_flavor" => 'default'}] }
-  let(:license_status) { 'active' }
 
   subject { LogStash::Outputs::ElasticSearch::HttpClient::Pool.new(logger, adapter, initial_urls, options) }
 
-  let(:url) { ::LogStash::Util::SafeURI.new("http://localhost:9200") }
-
-  context "in case HTTP error code" do
-    it "should fail for 401" do
-      allow(adapter).to receive(:perform_request)
-        .with(anything, :get, "/", anything, anything)
-        .and_return(MockResponse.new(401))
-
-      expect(subject.elasticsearch?(url)).to be false
-    end
-
-    it "should fail for 403" do
-      allow(adapter).to receive(:perform_request)
-              .with(anything, :get, "/", anything, anything)
-              .and_return(status: 403)
-      expect(subject.elasticsearch?(url)).to be false
-    end
-  end
-
   context "when connecting to a cluster which reply without 'version' field" do
     it "should fail" do
-      allow(adapter).to receive(:perform_request)
-                    .with(anything, :get, "/", anything, anything)
-                    .and_return(body: {"field" => "funky.com"}.to_json)
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"field" => "funky.com"} )
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
   end
 
   context "when connecting to a cluster with version < 6.0.0" do
     it "should fail" do
-      allow(adapter).to receive(:perform_request)
-                          .with(anything, :get, "/", anything, anything)
-                          .and_return(200, {"version" => { "number" => "5.0.0"}}.to_json)
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"version" => { "number" => "5.0.0" }})
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
   end
 
   context "when connecting to a cluster with version in [6.0.0..7.0.0)" do
     it "must be successful with valid 'tagline'" do
-      allow(adapter).to receive(:perform_request)
-                                .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version" => {"number" => "6.5.0"}, "tagline" => "You Know, for Search"}))
-      expect(subject.elasticsearch?(url)).to be true
+      resp = MockResponse.new(200, {"version" => {"number" => "6.5.0"}, "tagline" => "You Know, for Search"} )
+      expect(subject.send(:elasticsearch?, resp)).to be true
     end
 
     it "should fail if invalid 'tagline'" do
-      allow(adapter).to receive(:perform_request)
-                                .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version" => {"number" => "6.5.0"}, "tagline" => "You don't know"}))
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"version" => {"number" => "6.5.0"}, "tagline" => "You don't know"} )
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
 
     it "should fail if 'tagline' is not present" do
-      allow(adapter).to receive(:perform_request)
-                                .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version" => {"number" => "6.5.0"}}))
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"version" => {"number" => "6.5.0"}} )
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
   end
 
   context "when connecting to a cluster with version in [7.0.0..7.14.0)" do
     it "must be successful is 'build_flavor' is 'default' and tagline is correct" do
-      allow(adapter).to receive(:perform_request)
-                                .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavor": "default"}, "tagline": "You Know, for Search"}))
-      expect(subject.elasticsearch?(url)).to be true
+      resp = MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavor": "default"}, "tagline": "You Know, for Search"} )
+      expect(subject.send(:elasticsearch?, resp)).to be true
     end
 
     it "should fail if 'build_flavor' is not 'default' and tagline is correct" do
-      allow(adapter).to receive(:perform_request)
-                                .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavor": "oss"}, "tagline": "You Know, for Search"}))
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"version": {"number": "7.5.0", "build_flavor": "oss"}, "tagline": "You Know, for Search"} )
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
 
     it "should fail if 'build_flavor' is not present and tagline is correct" do
-      allow(adapter).to receive(:perform_request)
-                                .with(anything, :get, "/", anything, anything)
-                                .and_return(MockResponse.new(200, {"version": {"number": "7.5.0"}, "tagline": "You Know, for Search"}))
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"version": {"number": "7.5.0"}, "tagline": "You Know, for Search"} )
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
   end
 
   context "when connecting to a cluster with version >= 7.14.0" do
     it "should fail if 'X-elastic-product' header is not present" do
-      allow(adapter).to receive(:perform_request)
-                    .with(anything, :get, "/", anything, anything)
-                    .and_return(MockResponse.new(200, {"version": {"number": "7.14.0"}}))
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"version": {"number": "7.14.0"}} )
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
 
     it "should fail if 'X-elastic-product' header is present but with bad value" do
-      allow(adapter).to receive(:perform_request)
-                    .with(anything, :get, "/", anything, anything)
-                    .and_return(MockResponse.new(200, {"version": {"number": "7.14.0"}}, {'X-elastic-product' => 'not good'}))
-      expect(subject.elasticsearch?(url)).to be false
+      resp = MockResponse.new(200, {"version": {"number": "7.14.0"}}, {'X-elastic-product' => 'not good'} )
+      expect(subject.send(:elasticsearch?, resp)).to be false
     end
 
     it "must be successful when 'X-elastic-product' header is present with 'Elasticsearch' value" do
-      allow(adapter).to receive(:perform_request)
-                    .with(anything, :get, "/", anything, anything)
-                    .and_return(MockResponse.new(200, {"version": {"number": "7.14.0"}}, {'X-elastic-product' => 'Elasticsearch'}))
-      expect(subject.elasticsearch?(url)).to be true
+      resp = MockResponse.new(200, {"version": {"number": "7.14.0"}}, {'X-elastic-product' => 'Elasticsearch'} )
+      expect(subject.send(:elasticsearch?, resp)).to be true
     end
   end
 end

--- a/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/pool_spec.rb
@@ -327,6 +327,36 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::Pool do
     end
   end
 
+  describe "elastic api version header" do
+    let(:eav) { "Elastic-Api-Version" }
+
+    context "when it is serverless" do
+      before(:each) do
+        expect(subject).to receive(:serverless?).and_return(true)
+      end
+
+      it "add the default header" do
+        expect(adapter).to receive(:perform_request).with(anything, :get, "/", anything, anything) do |_, _, _, params, _|
+          expect(params[:headers]).to eq({ "User-Agent" => "chromium",  "Elastic-Api-Version" => "2023-10-31"})
+        end
+        subject.perform_request_to_url(initial_urls, :get, "/", { :headers => { "User-Agent" => "chromium" }} )
+      end
+    end
+
+    context "when it is stateful" do
+      before(:each) do
+        expect(subject).to receive(:serverless?).and_return(false)
+      end
+
+      it "add the default header" do
+        expect(adapter).to receive(:perform_request).with(anything, :get, "/", anything, anything) do |_, _, _, params, _|
+          expect(params[:headers]).to be_nil
+        end
+        subject.perform_request_to_url(initial_urls, :get, "/" )
+      end
+    end
+  end
+
   # TODO: extract to ElasticSearchOutputLicenseChecker unit spec
   describe "license checking with ElasticSearchOutputLicenseChecker" do
     let(:options) do

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -135,7 +135,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     }
 
     it "returns the hash response" do
-      expect(subject.pool).to receive(:get).with(path, nil).and_return(get_response)
+      expect(subject.pool).to receive(:get).with(path).and_return(get_response)
       expect(subject.get(path)["body"]).to eq(body)
     end
   end


### PR DESCRIPTION
This commit adds "Elastic-Api-Version" : "2023-10-31" to request header when the Elasticsearch is serverless
Rename "flavour" to "flavor"