### PR TITLE
Add http compression level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.17.0
-  - Added support to http compression level. Deprecated `http_compression` in favour of `compression_level` [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
+  - Added support to http compression level. Deprecated `http_compression` in favour of `compression_level` and enabled compression level 1 by default. [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
 
 ## 11.16.0
   - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.17.0
-  - Added support to http compression level. `http_compression` accepts `true`, `false` and 1 to 9 as compression level.
+  - Added support to http compression level. `http_compression` accepts `true`, `false` and `1` to `9` as compression level [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
 
 ## 11.16.0
   - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.17.0
+  - Added support to http compression level. `http_compression` accepts `true`, `false` and 1 to 9 as compression level.
+
 ## 11.16.0
   - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.17.0
-  - Added support to http compression level. `http_compression` accepts `true`, `false` and `1` to `9` as compression level [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
+  - Added support to http compression level. `http_compression` accepts `true`, `false` and `1` ~ `9` as compression level [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
 
 ## 11.16.0
   - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.17.0
-  - Added support to http compression level. `http_compression` accepts `true`, `false`, `0` and `1` ~ `9` as compression level [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
+  - Added support to http compression level. Deprecated `http_compression` in favour of `compression_level` [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
 
 ## 11.16.0
   - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.17.0
-  - Added support to http compression level. `http_compression` accepts `true`, `false` and `1` ~ `9` as compression level [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
+  - Added support to http compression level. `http_compression` accepts `true`, `false`, `0` and `1` ~ `9` as compression level [#1148](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1148)
 
 ## 11.16.0
   - Added support to Serverless Elasticsearch [#1445](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1145)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -469,7 +469,7 @@ For more details, check out the
 The gzip compression level. Setting this value to `0` disables compression.
 The compression level must be in the range of `1` (best speed) to `9` (best compression).
 
-Increasing the compression level will reduce the network usage but will increase the cpu usage.
+Increasing the compression level will reduce the network usage but will increase the CPU usage.
 
 [id="plugins-{type}s-{plugin}-data_stream"]
 ===== `data_stream`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -671,11 +671,10 @@ Any special characters present in the URLs here MUST be URL escaped! This means
 
 [id="plugins-{type}s-{plugin}-http_compression"]
 ===== `http_compression`
+deprecated[11.17.0, Replaced by <<plugins-{type}s-{plugin}-compression_level>>]
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
-
-deprecated[11.17.0, Replaced by <<plugins-{type}s-{plugin}-compression_level>>]
 
 Setting `true` enables gzip compression level 1 on requests.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -310,6 +310,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-ca_trusted_fingerprint>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cloud_auth>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-cloud_id>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-compression_level>> |<<number,number>>, one of `[0 ~ 9]`|No
 | <<plugins-{type}s-{plugin}-custom_headers>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-data_stream>> |<<string,string>>, one of `["true", "false", "auto"]`|No
 | <<plugins-{type}s-{plugin}-data_stream_auto_routing>> |<<boolean,boolean>>|No
@@ -326,7 +327,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-failure_type_logging_whitelist>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-healthcheck_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<uri,uri>>|No
-| <<plugins-{type}s-{plugin}-http_compression>> |<<string,string>>, one of `["true", "false", "0" ~ "9"]`|No
+| <<plugins-{type}s-{plugin}-http_compression>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ilm_enabled>> |<<string,string>>, one of `["true", "false", "auto"]`|No
 | <<plugins-{type}s-{plugin}-ilm_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ilm_policy>> |<<string,string>>|No
@@ -458,6 +459,19 @@ Cloud ID, from the Elastic Cloud web console. If set `hosts` should not be used.
 
 For more details, check out the
 {logstash-ref}/connecting-to-cloud.html[Logstash-to-Cloud documentation].
+
+[id="plugins-{type}s-{plugin}-compression_level"]
+===== `compression_level`
+
+  * Value can be any of: `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`
+  * Default value is `0`
+
+The gzip compression level. Setting this value to `0` disables compression.
+The compression level must be in the range of `1` (best speed) to `9` (best compression).
+
+Increasing the compression level will reduce the network usage but will increase the cpu usage.
+
+The default value is `0`.
 
 [id="plugins-{type}s-{plugin}-data_stream"]
 ===== `data_stream`
@@ -660,13 +674,12 @@ Any special characters present in the URLs here MUST be URL escaped! This means
 [id="plugins-{type}s-{plugin}-http_compression"]
 ===== `http_compression`
 
-  * Value can be any of: `true`, `false`, `0`, 1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`
-  * Default value is `0`
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
 
-Setting the flag to `true` enable gzip compression on requests and use compression level `6`.
-Setting the flag to `false` or `0` disable gzip compression.
+deprecated[11.17.0, Replaced by <<plugins-{type}s-{plugin}-compression_level>>]
 
-Number `1` (best speed) to `9` (best compression) are the gzip compression level.
+Setting `true` enables gzip compression level 6 on requests.
 
 This setting allows you to reduce this plugin's outbound network traffic by
 compressing each bulk _request_ to {es}.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -326,7 +326,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-failure_type_logging_whitelist>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-healthcheck_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<uri,uri>>|No
-| <<plugins-{type}s-{plugin}-http_compression>> |<<string,string>>, one of `["true", "false", "1" ~ "9"]`|No
+| <<plugins-{type}s-{plugin}-http_compression>> |<<string,string>>, one of `["true", "false", "0" ~ "9"]`|No
 | <<plugins-{type}s-{plugin}-ilm_enabled>> |<<string,string>>, one of `["true", "false", "auto"]`|No
 | <<plugins-{type}s-{plugin}-ilm_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ilm_policy>> |<<string,string>>|No
@@ -660,13 +660,13 @@ Any special characters present in the URLs here MUST be URL escaped! This means
 [id="plugins-{type}s-{plugin}-http_compression"]
 ===== `http_compression`
 
-  * Value can be any of: `true`, `false`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`
-  * Default value is `6`
-
-Number `1` ~ `9` are the gzip compression level.
+  * Value can be any of: `true`, `false`, `0`, 1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`
+  * Default value is `0`
 
 Setting the flag to `true` enable gzip compression on requests and use compression level `6`.
-Setting the flag to `false` disable gzip compression.
+Setting the flag to `false` or `0` disable gzip compression.
+
+Number `1` (best speed) to `9` (best compression) are the gzip compression level.
 
 This setting allows you to reduce this plugin's outbound network traffic by
 compressing each bulk _request_ to {es}.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -326,7 +326,7 @@ This plugin supports the following configuration options plus the
 | <<plugins-{type}s-{plugin}-failure_type_logging_whitelist>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-healthcheck_path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-hosts>> |<<uri,uri>>|No
-| <<plugins-{type}s-{plugin}-http_compression>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-http_compression>> |<<string,string>>, one of `["true", "false", "1" ~ "9"]`|No
 | <<plugins-{type}s-{plugin}-ilm_enabled>> |<<string,string>>, one of `["true", "false", "auto"]`|No
 | <<plugins-{type}s-{plugin}-ilm_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ilm_policy>> |<<string,string>>|No
@@ -660,10 +660,13 @@ Any special characters present in the URLs here MUST be URL escaped! This means
 [id="plugins-{type}s-{plugin}-http_compression"]
 ===== `http_compression`
 
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
+  * Value can be any of: `true`, `false`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`
+  * Default value is `6`
 
-Enable gzip compression on requests.
+Number `1` ~ `9` are the gzip compression level.
+
+Setting the flag to `true` enable gzip compression on requests and use compression level `6`.
+Setting the flag to `false` disable gzip compression.
 
 This setting allows you to reduce this plugin's outbound network traffic by
 compressing each bulk _request_ to {es}.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -277,9 +277,9 @@ not reevaluate its DNS value while the keepalive is in effect.
 ==== HTTP Compression
 
 This plugin always reads compressed responses from {es}.
-It _can be configured_ to send compressed bulk requests to {es}.
+By default, it sends compressed bulk requests to {es}.
 
-If you are concerned about bandwidth, you can enable <<plugins-{type}s-{plugin}-http_compression>> to trade a small amount of CPU capacity for a significant reduction in network IO.
+If you are concerned about bandwidth, you can set a higher <<plugins-{type}s-{plugin}-compression_level>> to trade CPU capacity for a reduction in network IO.
 
 ==== Authentication
 
@@ -464,14 +464,12 @@ For more details, check out the
 ===== `compression_level`
 
   * Value can be any of: `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`
-  * Default value is `0`
+  * Default value is `1`
 
 The gzip compression level. Setting this value to `0` disables compression.
 The compression level must be in the range of `1` (best speed) to `9` (best compression).
 
 Increasing the compression level will reduce the network usage but will increase the cpu usage.
-
-The default value is `0`.
 
 [id="plugins-{type}s-{plugin}-data_stream"]
 ===== `data_stream`
@@ -632,7 +630,7 @@ NOTE: Deprecated, refer to <<plugins-{type}s-{plugin}-silence_errors_in_log>>.
 Pass a set of key value pairs as the headers sent in each request to
 an elasticsearch node. The headers will be used for any kind of request
 (_bulk request, template installation, health checks and sniffing).
-These custom headers will be overidden by settings like `http_compression`.
+These custom headers will be overidden by settings like `compression_level`.
 
 [id="plugins-{type}s-{plugin}-healthcheck_path"]
 ===== `healthcheck_path`
@@ -679,7 +677,7 @@ Any special characters present in the URLs here MUST be URL escaped! This means
 
 deprecated[11.17.0, Replaced by <<plugins-{type}s-{plugin}-compression_level>>]
 
-Setting `true` enables gzip compression level 6 on requests.
+Setting `true` enables gzip compression level 1 on requests.
 
 This setting allows you to reduce this plugin's outbound network traffic by
 compressing each bulk _request_ to {es}.

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -369,7 +369,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       end
     end
 
-    params['http_compression'] = DEFAULT_ZIP_LEVEL if params['http_compression'].to_s == "true" # set compression level to 6 for backward compatibility
+    # for backward compatibility, set compression level to 6 when true, and 0 when false
+    params['http_compression'] = DEFAULT_ZIP_LEVEL if params['http_compression'].to_s == "true"
+    params['http_compression'] = 0 if params['http_compression'].to_s == "false"
 
     super(params)
   end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -276,6 +276,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     super
     setup_ecs_compatibility_related_defaults
     setup_ssl_params!
+    setup_compression_level!
   end
 
   def register
@@ -368,10 +369,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
         params['proxy'] = proxy # do not do resolving again
       end
     end
-
-    # for backward compatibility, set compression level to 6 when true, and 0 when false
-    params['http_compression'] = DEFAULT_ZIP_LEVEL if params['http_compression'].to_s == "true"
-    params['http_compression'] = 0 if params['http_compression'].to_s == "false"
 
     super(params)
   end
@@ -672,6 +669,20 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     params['ssl_truststore_path'] = @ssl_truststore_path unless @ssl_truststore_path.nil?
     params['ssl_truststore_password'] = @ssl_truststore_password unless @ssl_truststore_password.nil?
     params['ssl_verification_mode'] = @ssl_verification_mode unless @ssl_verification_mode.nil?
+  end
+
+  def setup_compression_level!
+    @compression_level = normalize_config(:compression_level) do |normalize|
+      normalize.with_deprecated_mapping(:http_compression) do |http_compression|
+        if http_compression == true
+          DEFAULT_ZIP_LEVEL
+        else
+          0
+        end
+      end
+    end
+
+    params['compression_level'] = @compression_level unless @compression_level.nil?
   end
 
   # To be overidden by the -java version

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -368,6 +368,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
         params['proxy'] = proxy # do not do resolving again
       end
     end
+
+    params['http_compression'] = DEFAULT_ZIP_LEVEL if params['http_compression'].to_s == "true" # set compression level to 6 for backward compatibility
+
     super(params)
   end
 

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -298,9 +298,10 @@ module LogStash; module Outputs; class ElasticSearch;
       @_ssl_options ||= client_settings.fetch(:ssl, {})
     end
 
-    # return true if http_compression is [1..9] or true
+    # return true if http_compression is [1..9]
+    # return false if it is 0
     def http_compression?
-      !(client_settings.fetch(:http_compression, false).to_s == "false")
+      client_settings.fetch(:http_compression, 0) > 0
     end
 
     def build_adapter(options)

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -8,7 +8,7 @@ module LogStash; module Outputs; class ElasticSearch;
         :pool_max => params["pool_max"],
         :pool_max_per_route => params["pool_max_per_route"],
         :check_connection_timeout => params["validate_after_inactivity"],
-        :http_compression => params["http_compression"],
+        :compression_level => params["compression_level"],
         :headers => params["custom_headers"] || {}
       }
       

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -187,7 +187,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         :validate_after_inactivity => { :validate => :number, :default => 10000 },
 
         # Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
-        :http_compression => { :validate => [ "true", "false", true, false, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => false },
+        :http_compression => { :validate => [ "true", "false", true, false, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => DEFAULT_ZIP_LEVEL },
 
         # Custom Headers to send on each request to elasticsearch nodes
         :custom_headers => { :validate => :hash, :default => {} },

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -7,7 +7,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     # This module defines common options that can be reused by alternate elasticsearch output plugins such as the elasticsearch_data_streams output.
 
     DEFAULT_HOST = ::LogStash::Util::SafeURI.new("//127.0.0.1")
-    DEFAULT_ZIP_LEVEL = 6
+    DEFAULT_ZIP_LEVEL = 6 # default zip level if http compression is enabled
 
     CONFIG_PARAMS = {
         # Username to authenticate to a secure Elasticsearch cluster
@@ -187,8 +187,12 @@ module LogStash; module PluginMixins; module ElasticSearch
         :validate_after_inactivity => { :validate => :number, :default => 10000 },
 
         # Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
+        # Set `true` to enable compression with level 6
+        # Set `false` to disable compression with level 0
         # Number `1` ~ `9` are the gzip compression level
-        :http_compression => { :validate => [ "true", "false", true, false, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => DEFAULT_ZIP_LEVEL },
+        # Set `0` to disable compression
+        # Set `1` (best speed) to `9` (best compression) to use compression
+        :http_compression => { :validate => [ "true", "false", true, false, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => 0 },
 
         # Custom Headers to send on each request to elasticsearch nodes
         :custom_headers => { :validate => :hash, :default => {} },

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -7,6 +7,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     # This module defines common options that can be reused by alternate elasticsearch output plugins such as the elasticsearch_data_streams output.
 
     DEFAULT_HOST = ::LogStash::Util::SafeURI.new("//127.0.0.1")
+    DEFAULT_ZIP_LEVEL = 6
 
     CONFIG_PARAMS = {
         # Username to authenticate to a secure Elasticsearch cluster
@@ -186,7 +187,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         :validate_after_inactivity => { :validate => :number, :default => 10000 },
 
         # Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
-        :http_compression => { :validate => :boolean, :default => false },
+        :http_compression => { :validate => [ "true", "false", true, false, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => DEFAULT_ZIP_LEVEL },
 
         # Custom Headers to send on each request to elasticsearch nodes
         :custom_headers => { :validate => :hash, :default => {} },

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -187,6 +187,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         :validate_after_inactivity => { :validate => :number, :default => 10000 },
 
         # Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
+        # Number `1` ~ `9` are the gzip compression level
         :http_compression => { :validate => [ "true", "false", true, false, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => DEFAULT_ZIP_LEVEL },
 
         # Custom Headers to send on each request to elasticsearch nodes

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -7,7 +7,7 @@ module LogStash; module PluginMixins; module ElasticSearch
     # This module defines common options that can be reused by alternate elasticsearch output plugins such as the elasticsearch_data_streams output.
 
     DEFAULT_HOST = ::LogStash::Util::SafeURI.new("//127.0.0.1")
-    DEFAULT_ZIP_LEVEL = 6 # default zip level if http compression is enabled
+    DEFAULT_ZIP_LEVEL = 1
 
     CONFIG_PARAMS = {
         # Username to authenticate to a secure Elasticsearch cluster
@@ -187,12 +187,14 @@ module LogStash; module PluginMixins; module ElasticSearch
         :validate_after_inactivity => { :validate => :number, :default => 10000 },
 
         # Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
-        # Set `true` to enable compression with level 6
+        # Set `true` to enable compression with level 1
         # Set `false` to disable compression with level 0
+        :http_compression => { :validate => :boolean, :default => true, :deprecated => "Set 'compression_level' instead." },
+
         # Number `1` ~ `9` are the gzip compression level
         # Set `0` to disable compression
         # Set `1` (best speed) to `9` (best compression) to use compression
-        :http_compression => { :validate => [ "true", "false", true, false, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => 0 },
+        :compression_level => { :validate => [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => DEFAULT_ZIP_LEVEL },
 
         # Custom Headers to send on each request to elasticsearch nodes
         :custom_headers => { :validate => :hash, :default => {} },

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -187,7 +187,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         :validate_after_inactivity => { :validate => :number, :default => 10000 },
 
         # Enable gzip compression on requests. Note that response compression is on by default for Elasticsearch v5.0 and beyond
-        :http_compression => { :validate => [ "true", "false", true, false, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => DEFAULT_ZIP_LEVEL },
+        :http_compression => { :validate => [ "true", "false", true, false, 1, 2, 3, 4, 5, 6, 7, 8, 9 ], :default => false },
 
         # Custom Headers to send on each request to elasticsearch nodes
         :custom_headers => { :validate => :hash, :default => {} },

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.16.0'
+  s.version         = '11.17.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -8,63 +8,64 @@ RSpec::Matchers.define :a_valid_gzip_encoded_string do
   }
 end
 
-describe "indexing with http_compression turned on", :integration => true do
-  let(:event) { LogStash::Event.new("message" => "Hello World!", "type" => type) }
-  let(:index) { 10.times.collect { rand(10).to_s }.join("") }
-  let(:type) { ESHelper.es_version_satisfies?("< 7") ? "doc" : "_doc" }
-  let(:event_count) { 10000 + rand(500) }
-  let(:events) { event_count.times.map { event }.to_a }
-  let(:config) {
-    {
-      "hosts" => get_host_port,
-      "index" => index,
-      "http_compression" => true
+[ {"http_compression" => true}, {"compression_level" => 1} ].each do |compression_config|
+  describe "indexing with http_compression turned on", :integration => true do
+    let(:event) { LogStash::Event.new("message" => "Hello World!", "type" => type) }
+    let(:index) { 10.times.collect { rand(10).to_s }.join("") }
+    let(:type) { ESHelper.es_version_satisfies?("< 7") ? "doc" : "_doc" }
+    let(:event_count) { 10000 + rand(500) }
+    let(:events) { event_count.times.map { event }.to_a }
+    let(:config) {
+      {
+        "hosts" => get_host_port,
+        "index" => index
+      }
     }
-  }
-  subject { LogStash::Outputs::ElasticSearch.new(config) }
+    subject { LogStash::Outputs::ElasticSearch.new(config.merge(compression_config)) }
 
-  let(:es_url) { "http://#{get_host_port}" }
-  let(:index_url) {"#{es_url}/#{index}"}
-  let(:http_client_options) { {} }
-  let(:http_client) do
-    Manticore::Client.new(http_client_options)
-  end
+    let(:es_url) { "http://#{get_host_port}" }
+    let(:index_url) {"#{es_url}/#{index}"}
+    let(:http_client_options) { {} }
+    let(:http_client) do
+      Manticore::Client.new(http_client_options)
+    end
 
-  before do
-    subject.register
-    subject.multi_receive([])
-  end
+    before do
+      subject.register
+      subject.multi_receive([])
+    end
 
-  shared_examples "an indexer" do
-    it "ships events" do
-      subject.multi_receive(events)
+    shared_examples "an indexer" do
+      it "ships events" do
+        subject.multi_receive(events)
 
-      http_client.post("#{es_url}/_refresh").call
+        http_client.post("#{es_url}/_refresh").call
 
-      response = http_client.get("#{index_url}/_count?q=*")
-      result = LogStash::Json.load(response.body)
-      cur_count = result["count"]
-      expect(cur_count).to eq(event_count)
+        response = http_client.get("#{index_url}/_count?q=*")
+        result = LogStash::Json.load(response.body)
+        cur_count = result["count"]
+        expect(cur_count).to eq(event_count)
 
-      response = http_client.get("#{index_url}/_search?q=*&size=1000")
-      result = LogStash::Json.load(response.body)
-      result["hits"]["hits"].each do |doc|
-        if ESHelper.es_version_satisfies?("< 8")
-          expect(doc["_type"]).to eq(type)
-        else
-          expect(doc).not_to include("_type")
+        response = http_client.get("#{index_url}/_search?q=*&size=1000")
+        result = LogStash::Json.load(response.body)
+        result["hits"]["hits"].each do |doc|
+          if ESHelper.es_version_satisfies?("< 8")
+            expect(doc["_type"]).to eq(type)
+          else
+            expect(doc).not_to include("_type")
+          end
+          expect(doc["_index"]).to eq(index)
         end
-        expect(doc["_index"]).to eq(index)
       end
     end
-  end
 
-  it "sets the correct content-encoding header and body is compressed" do
-    expect(subject.client.pool.adapter.client).to receive(:send).
-      with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
-      and_call_original
-    subject.multi_receive(events)
-  end
+    it "sets the correct content-encoding header and body is compressed" do
+      expect(subject.client.pool.adapter.client).to receive(:send).
+        with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
+        and_call_original
+      subject.multi_receive(events)
+    end
 
-  it_behaves_like("an indexer")
+    it_behaves_like("an indexer")
+  end
 end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -262,7 +262,8 @@ describe "indexing" do
     let(:config) {
       {
         "hosts" => get_host_port,
-        "index" => index
+        "index" => index,
+        "http_compression" => false
       }
     }
     it_behaves_like("an indexer")
@@ -273,7 +274,8 @@ describe "indexing" do
     let(:config) {
       {
         "hosts" => get_host_port,
-        "index" => index
+        "index" => index,
+        "http_compression" => false
       }
     }
     it_behaves_like("an indexer")
@@ -291,7 +293,8 @@ describe "indexing" do
         "password" => password,
         "ssl_enabled" => true,
         "ssl_certificate_authorities" => cacert,
-        "index" => index
+        "index" => index,
+        "http_compression" => false
       }
     end 
 
@@ -351,7 +354,8 @@ describe "indexing" do
               "hosts" => ["https://#{CGI.escape(user)}:#{CGI.escape(password)}@elasticsearch:9200"],
               "ssl_enabled" => true,
               "ssl_certificate_authorities" => "spec/fixtures/test_certs/test.crt",
-              "index" => index
+              "index" => index,
+              "http_compression" => false
           }
         end
 

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -183,6 +183,25 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     end
   end
 
+  describe "http_compression?" do
+    subject { described_class.new(base_options) }
+    let(:base_options) { super().merge(:client_settings => {:http_compression => http_compression}) }
+
+    context "with client_settings `http_compression => 6`" do
+      let(:http_compression) { 6 }
+      it "gives true" do
+        expect(subject.http_compression?).to be_truthy
+      end
+    end
+
+    context "with client_settings `http_compression => false`" do
+      let(:http_compression) { false }
+      it "gives false" do
+        expect(subject.http_compression?).to be_falsey
+      end
+    end
+  end
+
   describe "#bulk" do
     subject(:http_client) { described_class.new(base_options) }
 

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -183,21 +183,21 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
     end
   end
 
-  describe "http_compression?" do
+  describe "compression_level?" do
     subject { described_class.new(base_options) }
-    let(:base_options) { super().merge(:client_settings => {:http_compression => http_compression}) }
+    let(:base_options) { super().merge(:client_settings => {:compression_level => compression_level}) }
 
-    context "with client_settings `http_compression => 6`" do
-      let(:http_compression) { 6 }
+    context "with client_settings `compression_level => 1`" do
+      let(:compression_level) { 1 }
       it "gives true" do
-        expect(subject.http_compression?).to be_truthy
+        expect(subject.compression_level?).to be_truthy
       end
     end
 
-    context "with client_settings `http_compression => 0`" do
-      let(:http_compression) { 0 }
+    context "with client_settings `compression_level => 0`" do
+      let(:compression_level) { 0 }
       it "gives false" do
-        expect(subject.http_compression?).to be_falsey
+        expect(subject.compression_level?).to be_falsey
       end
     end
   end
@@ -211,14 +211,14 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
       ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> message}],
     ]}
 
-    [0, 9].each do |http_compression|
-      context "with `http_compression => #{http_compression}`" do
+    [0, 9].each do |compression_level|
+      context "with `compression_level => #{compression_level}`" do
 
-        let(:base_options) { super().merge(:client_settings => {:http_compression => http_compression}) }
-        let(:http_compression_enabled) { http_compression > 0 }
+        let(:base_options) { super().merge(:client_settings => {:compression_level => compression_level}) }
+        let(:compression_level_enabled) { compression_level > 0 }
 
         before(:each) do
-          if http_compression_enabled
+          if compression_level_enabled
             expect(http_client).to receive(:gzip_writer).at_least(:once).and_call_original
           else
             expect(http_client).to_not receive(:gzip_writer)
@@ -232,7 +232,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
           it "should be handled properly" do
             allow(subject).to receive(:join_bulk_responses)
             expect(subject).to receive(:bulk_send).once do |data|
-              if !http_compression_enabled
+              if !compression_level_enabled
                 expect(data.size).to be > target_bulk_bytes
               else
                 expect(Zlib::gunzip(data.string).size).to be > target_bulk_bytes

--- a/spec/unit/outputs/elasticsearch/http_client_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client_spec.rb
@@ -192,13 +192,13 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
       ["index", {:_id=>nil, :_index=>"logstash"}, {"message"=> message}],
     ]}
 
-    [true,false].each do |http_compression_enabled|
-      context "with `http_compression => #{http_compression_enabled}`" do
+    [1, 9, false].each do |http_compression|
+      context "with `http_compression => #{http_compression}`" do
 
-        let(:base_options) { super().merge(:client_settings => {:http_compression => http_compression_enabled}) }
+        let(:base_options) { super().merge(:client_settings => {:http_compression => http_compression}) }
 
         before(:each) do
-          if http_compression_enabled
+          if !!http_compression
             expect(http_client).to receive(:gzip_writer).at_least(:once).and_call_original
           else
             expect(http_client).to_not receive(:gzip_writer)
@@ -212,7 +212,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient do
           it "should be handled properly" do
             allow(subject).to receive(:join_bulk_responses)
             expect(subject).to receive(:bulk_send).once do |data|
-              if !http_compression_enabled
+              if !http_compression
                 expect(data.size).to be > target_bulk_bytes
               else
                 expect(Zlib::gunzip(data.string).size).to be > target_bulk_bytes

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1562,9 +1562,9 @@ describe LogStash::Outputs::ElasticSearch do
     describe "initialize setting" do
       context "with `http_compression` => true" do
         let(:options) { super().merge('http_compression' => true) }
-        it "set compression level to 6" do
+        it "set compression level to 1" do
           subject.register
-          expect(subject.instance_variable_get(:@http_compression)).to eq(6)
+          expect(subject.instance_variable_get(:@compression_level)).to eq(1)
         end
       end
 
@@ -1572,16 +1572,16 @@ describe LogStash::Outputs::ElasticSearch do
         let(:options) { super().merge('http_compression' => false) }
         it "set compression level to 0" do
           subject.register
-          expect(subject.instance_variable_get(:@http_compression)).to eq(0)
+          expect(subject.instance_variable_get(:@compression_level)).to eq(0)
         end
       end
 
       [0, 9].each do |config|
-        context "with `http_compression` => #{config}" do
-          let(:options) { super().merge('http_compression' => config) }
+        context "with `compression_level` => #{config}" do
+          let(:options) { super().merge('compression_level' => config) }
           it "keeps the setting" do
             subject.register
-            expect(subject.instance_variable_get(:@http_compression)).to eq(config)
+            expect(subject.instance_variable_get(:@compression_level)).to eq(config)
           end
         end
       end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1568,7 +1568,15 @@ describe LogStash::Outputs::ElasticSearch do
         end
       end
 
-      [false, 1].each do |config|
+      context "with `http_compression` => false" do
+        let(:options) { super().merge('http_compression' => false) }
+        it "set compression level to 0" do
+          subject.register
+          expect(subject.instance_variable_get(:@http_compression)).to eq(0)
+        end
+      end
+
+      [0, 9].each do |config|
         context "with `http_compression` => #{config}" do
           let(:options) { super().merge('http_compression' => config) }
           it "keeps the setting" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -474,7 +474,7 @@ describe LogStash::Outputs::ElasticSearch do
 
     context "unexpected bulk response" do
       let(:options) do
-        { "hosts" => "127.0.0.1:9999", "index" => "%{foo}", "manage_template" => false }
+        { "hosts" => "127.0.0.1:9999", "index" => "%{foo}", "manage_template" => false, "http_compression" => false }
       end
 
       let(:events) { [ ::LogStash::Event.new("foo" => "bar1"), ::LogStash::Event.new("foo" => "bar2") ] }
@@ -624,6 +624,7 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   context '413 errors' do
+    let(:options) { super().merge("http_compression" => "false") }
     let(:payload_size) { LogStash::Outputs::ElasticSearch::TARGET_BULK_BYTES + 1024 }
     let(:event) { ::LogStash::Event.new("message" => ("a" * payload_size ) ) }
 
@@ -1558,23 +1559,26 @@ describe LogStash::Outputs::ElasticSearch do
   end
 
   describe "http compression" do
-    context "with `http_compression` => true" do
-      let(:options) { super().merge('http_compression' => true) }
-      it "set compression level to 6" do
-        subject.register
-        expect(subject.instance_variable_get(:@http_compression)).to eq(6)
-      end
-    end
-
-    [false, 1].each do |config|
-      context "with `http_compression` => #{config}" do
-        let(:options) { super().merge('http_compression' => config) }
-        it "keeps the setting" do
+    describe "initialize setting" do
+      context "with `http_compression` => true" do
+        let(:options) { super().merge('http_compression' => true) }
+        it "set compression level to 6" do
           subject.register
-          expect(subject.instance_variable_get(:@http_compression)).to eq(config)
+          expect(subject.instance_variable_get(:@http_compression)).to eq(6)
+        end
+      end
+
+      [false, 1].each do |config|
+        context "with `http_compression` => #{config}" do
+          let(:options) { super().merge('http_compression' => config) }
+          it "keeps the setting" do
+            subject.register
+            expect(subject.instance_variable_get(:@http_compression)).to eq(config)
+          end
         end
       end
     end
+
   end
 
   @private

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1557,6 +1557,26 @@ describe LogStash::Outputs::ElasticSearch do
     end
   end
 
+  describe "http compression" do
+    context "with `http_compression` => true" do
+      let(:options) { super().merge('http_compression' => true) }
+      it "set compression level to 6" do
+        subject.register
+        expect(subject.instance_variable_get(:@http_compression)).to eq(6)
+      end
+    end
+
+    [false, 1].each do |config|
+      context "with `http_compression` => #{config}" do
+        let(:options) { super().merge('http_compression' => config) }
+        it "keeps the setting" do
+          subject.register
+          expect(subject.instance_variable_get(:@http_compression)).to eq(config)
+        end
+      end
+    end
+  end
+
   @private
 
   def stub_manticore_client!(manticore_double = nil)


### PR DESCRIPTION
This commit deprecated `http_compression` in favor of `compression_level`.
http_compression `false` mapped to compression_level `0`, and `true` mapped to `1`.
The default setting has changed from disabling compression to enabling compression at level 1 (best speed)

Fix: https://github.com/elastic/ingest-dev/issues/2217
