### PR TITLE
Use integration metadata to create ES actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.21.0
+  - Added support for propagating event processing metadata when this output is downstream of an Elastic Integration Filter and configured _without_ explicit `index`, `document_id`, or `pipeline` directives [#1155](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1155)
+
 ## 11.20.1
   - Doc: Replace `document_already_exist_exception` with `version_conflict_engine_exception` in the `silence_errors_in_log` setting example [#1159](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1159)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -573,7 +573,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     # if is a data stream, sprintf_index could be either the name of a data stream or the value contained in
     # @index without placeholders substitution. If event's metadata index is provided, it takes precedence
     # on datastream name or whatever is returned by the event_target provider.
-    return event_index || sprintf_index
+    return event_index if @index == @default_index && event_index
+    return sprintf_index
   end
   private :resolve_index!
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -549,7 +549,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
         routing_field_name => @routing ? event.sprintf(@routing) : nil
     }
 
-    target_pipeline = resolve_pipeline(event)
+    target_pipeline = resolve_pipeline(event, event_pipeline)
     # convention: empty string equates to not using a pipeline
     # this is useful when using a field reference in the pipeline setting, e.g.
     #      elasticsearch {
@@ -577,7 +577,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   end
   private :resolve_index!
 
-  def resolve_pipeline(event)
+  def resolve_pipeline(event, event_pipeline)
+    return event_pipeline if event_pipeline && !@pipeline
     pipeline_template = @pipeline || event.get("[@metadata][target_ingest_pipeline]")&.to_s
     pipeline_template && event.sprintf(pipeline_template)
   end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -569,10 +569,10 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   def resolve_index!(event, event_index)
     sprintf_index = @event_target.call(event)
     raise IndexInterpolationError, sprintf_index if sprintf_index.match(/%{.*?}/) && dlq_on_failed_indexname_interpolation
-    # if its not a data stream, sprintf_index is the @index with resolved placeholders.
-    # if its a data stream, sprintf_index could be either the name of a data stream or the value contained in
-    # @index without placeholders substitution. In any case if event's metadata index is provided takes precedence
-    # on datastream name or whaterver is returned by the event_target provider.
+    # if it's not a data stream, sprintf_index is the @index with resolved placeholders.
+    # if is a data stream, sprintf_index could be either the name of a data stream or the value contained in
+    # @index without placeholders substitution. If event's metadata index is provided, it takes precedence
+    # on datastream name or whatever is returned by the event_target provider.
     return event_index || sprintf_index
   end
   private :resolve_index!

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.20.1'
+  s.version         = '11.21.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -792,6 +792,24 @@ describe LogStash::Outputs::ElasticSearch do
         expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
       end
 
+      context "when event contains also _ingest_document pipeline name" do
+        let(:event) { LogStash::Event.new({"pipeline" => "my-ingest-pipeline",
+                                           "@metadata" => {"target_ingest_pipeline" => "meta-ingest-pipeline",
+                                                           "_ingest_document" => {"pipeline" => "integration-pipeline"}}}) }
+
+        it "the one provided by user takes precedence on all the others" do
+          expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
+        end
+
+        context "when settings doesn't configure a pipeline and integration provides one in the event" do
+          let(:options) { { } }
+
+          it "the one provided by user takes precedence on all the others" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "integration-pipeline")
+          end
+        end
+      end
+
       context "when the plugin's `pipeline` is constant" do
         let(:options) { super().merge("pipeline" => "my-constant-pipeline") }
          it "uses plugin's pipeline value" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -272,40 +272,38 @@ describe LogStash::Outputs::ElasticSearch do
     end
 
     describe "with event integration metadata" do
-      context "when user doesn't specify index setting and the event contains an index field in metadata" do
+      context "when there isn't any index setting specified and the event contains an integration metadata index" do
         let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
 
-        it "use the index provided by the integration" do
+        it "precedence is given to the integration" do
           expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
         end
       end
 
-      context "when datastream is provided" do
-#         let(:event) { LogStash::Event.new({"data_stream" => {"type" => "logs", "dataset" => "generic", "namespace" => "default"}}) }
-
-        context "event contains an index field in metadata" do
+      context "when datastream is used" do
+        context "event contains an integration metadata index" do
           let(:event) { LogStash::Event.new({"data_stream" => {"type" => "logs", "dataset" => "generic", "namespace" => "default"},
                                              "@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
 
-          it "use the index provided by the integration" do
+          it "precedence is given to the integration" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
           end
         end
       end
 
-      context "when user doesn't specify document_id setting" do
-        context "event's contains one" do
+      context "when there isn't any document_id setting" do
+        context "event contains an integration metadata id" do
           let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"id" => "meta-document-id"}}}) }
 
-          it "use the _id provided by the integration" do
+          it "precedence is given to the integration" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_id => "meta-document-id")
           end
         end
 
-        context "event doesn't contains one" do
+        context "event doesn't contain an integration metadata id" do
           let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {}}}) }
 
-          it "use the _id provided by the integration" do
+          it "let Elasticsearch to assign one" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_id => nil)
           end
         end
@@ -797,7 +795,7 @@ describe LogStash::Outputs::ElasticSearch do
                                            "@metadata" => {"target_ingest_pipeline" => "meta-ingest-pipeline",
                                                            "_ingest_document" => {"pipeline" => "integration-pipeline"}}}) }
 
-        it "the one provided by user takes precedence on all the others" do
+        it "precedence is given to the integration" do
           expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
         end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -271,6 +271,24 @@ describe LogStash::Outputs::ElasticSearch do
       end
     end
 
+    describe "with event integration metadata" do
+      context "when user doesn't specify index setting and the event present an index field in metadata" do
+        let(:event) { LogStash::Event.new({"[@metadata][_ingest_document][index]" => "meta-document-index"}) }
+
+        it "use the index provided by the integration" do
+          expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
+        end
+      end
+
+      context "when user doesn't specify document_id setting and the event's contains one" do
+        let(:event) { LogStash::Event.new({"[@metadata][_ingest_document][id]" => "meta-document-id"}) }
+
+        it "use the _id provided by the integration" do
+          expect(subject.send(:event_action_tuple, event)[1]).to include(:_id => "meta-document-id")
+        end
+      end
+    end
+
     describe "with auth" do
       let(:user) { "myuser" }
       let(:password) { ::LogStash::Util::Password.new("mypassword") }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Use integration metadata to interact with Elasticsearch.

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Change the creation of actions that are passed down to Elasticsearch to use also the metadata fields set by an integration.
The interested fields are `id` (document_id), `index` and `pipeline`, the field values are taken verbatim without placeholders resolution.
The index, document_id and pipeline that are configured in the plugin settings have precedence on the integration ones because manifest an explicit choice made by the user.



## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
This PR fixes an interoperability issue with Agent's integrations, where some metadata valued by integration has to be used down to Elasticsearch.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] use the plugin with an integration that configures the document id, and in case of same id no new documents are indexed.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- create a new deployment in Elastic cloud, it's the easiest way to have Elasticsearch, Kibana, and Fleet. Take note of the credentials when create the deployment, because later must be used in the configuration of `logstash-outpiut-elasticsearch`.
- install an ElasticAgent and enroll in Fleet. It's only used to create a policy to install an integration (m365_defender), so that all the necessary pipelines are installed in Elastisearch.
- in Logstash configure a pipeline like the following:
```
input {
  file {
    path => "/tmp/defender_singleline.json"
    sincedb_path => "/tmp/defender_sincedb"
    mode => "read"
    file_completed_action => "log"
    file_completed_log_path => "/tmp/processed.log"
    codec => json
  }
}

filter {
  elastic_integration {
    cloud_id   => "<clopud_id of your deployment>"
    cloud_auth => "elastic:<credentials showed you when the deployment was created>"
    geoip_database_directory => "/<your Logstash home>/vendor/bundle/jruby/3.1.0/gems/logstash-filter-geoip-7.2.13-java/vendor/GeoLite2-City.mmdb"
  }
}

output {
  stdout {
    codec => rubydebug { metadata => true }
  }

  elasticsearch {
cloud_id => "<clopud_id of your deployment>"
    api_key => "<retrieve from cloud deployment>"
    data_stream => true
    ssl => true
  }
}
```
- now use a sample data event (like [this](https://docs.elastic.co/integrations/m365_defender#incident)) and create a one-line json file (named `/tmp/defender_singleline.json`). To squash all lines in one use:
```sh
cat <file_in>.json | awk '{for(i=1;i<=NF;i++) printf "%s",$i}' > <file_out>.json
```
or use the file [defender_singleline.json](https://github.com/logstash-plugins/logstash-output-elasticsearch/files/13190987/defender_singleline.json)
- install this plugin, setting the path to this branch into `Gemfile`.
- run Logstash with 
```sh
bin/logstash -f "/path_to/pipeline.conf"
```
- stop, rm the sincedb file with `rm /tmp/defender_sincedb`
- start again Logstash with same command line.
- verify in a datastream index related to defender, something like `.ds-logs-m365_defender.incident-ep-`, that only one document is present.

This means that despite the 2 distinct runs, the Defender integration that generate an unique id from the Incident fields was correctly executed and used.
The proof can be done by executing the same flow above, with shipped ES output plugin, and verify that the document result duplicated, so no unique document_id is generated by the integration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #1156

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->