### PR TITLE
Use integration metadata to create ES actions (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.22.0
+  - Added support for propagating event processing metadata when this output is downstream of an Elastic Integration Filter and configured _without_ explicit `version`, `version_type`, or `routing` directives [#1158](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1158)
+
 ## 11.21.0
   - Added support for propagating event processing metadata when this output is downstream of an Elastic Integration Filter and configured _without_ explicit `index`, `document_id`, or `pipeline` directives [#1155](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1155)
 

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -557,7 +557,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     params[:version] = resolve_version(event, event_version)
     params[:version_type] = resolve_version_type(event, event_version_type)
 
-    params
+    # purge nil valued key-value pairs
+    params.compact
   end
 
   def resolve_version(event, event_version)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -541,12 +541,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # @private shared event params factory between index and data_stream mode
   def common_event_params(event)
     event_control = event.get("[@metadata][_ingest_document]")
-    event_id, event_pipeline, event_index = event_control&.values_at("id","pipeline","index", "routing") rescue nil
+    event_id, event_pipeline, event_index, event_routing = event_control&.values_at("id","pipeline","index", "routing") rescue nil
 
     params = {
         :_id => resolve_document_id(event, event_id),
         :_index => resolve_index!(event, event_index),
-        routing_field_name => resolve_routing(event)
+        routing_field_name => resolve_routing(event, event_routing)
     }
 
     target_pipeline = resolve_pipeline(event, event_pipeline)
@@ -560,7 +560,8 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     params
   end
 
-  def resolve_routing(event)
+  def resolve_routing(event, event_routing)
+    return event_routing if event_routing && !@routing
     @routing ? event.sprintf(@routing) : nil
   end
   private :resolve_routing

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -538,7 +538,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # @private shared event params factory between index and data_stream mode
   def common_event_params(event)
     event_control = event.get("[@metadata][_ingest_document]")
-    event_id, event_pipeline, event_index, event_routing = event_control&.values_at("id","pipeline","index", "routing") rescue nil
+    event_id, event_pipeline, event_index, event_routing, event_version = event_control&.values_at("id","pipeline","index", "routing", "version") rescue nil
 
     params = {
         :_id => resolve_document_id(event, event_id),
@@ -554,11 +554,17 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     #      }
     params[:pipeline] = target_pipeline unless (target_pipeline.nil? || target_pipeline.empty?)
 
-    params[:version] = event.sprintf(@version) if @version
+    params[:version] = resolve_version(event, event_version)
     params[:version_type] = event.sprintf(@version_type) if @version_type
 
     params
   end
+
+  def resolve_version(event, event_version)
+    return event_version if event_version && !@version
+    event.sprintf(@version) if @version
+  end
+  private :resolve_version
 
   def resolve_routing(event, event_routing)
     return event_routing if event_routing && !@routing

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -538,7 +538,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # @private shared event params factory between index and data_stream mode
   def common_event_params(event)
     event_control = event.get("[@metadata][_ingest_document]")
-    event_id, event_pipeline, event_index, event_routing, event_version = event_control&.values_at("id","pipeline","index", "routing", "version") rescue nil
+    event_id, event_pipeline, event_index, event_routing, event_version, event_version_type = event_control&.values_at("id","pipeline","index", "routing", "version", "version_type") rescue nil
 
     params = {
         :_id => resolve_document_id(event, event_id),
@@ -555,7 +555,7 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     params[:pipeline] = target_pipeline unless (target_pipeline.nil? || target_pipeline.empty?)
 
     params[:version] = resolve_version(event, event_version)
-    params[:version_type] = event.sprintf(@version_type) if @version_type
+    params[:version_type] = resolve_version_type(event, event_version_type)
 
     params
   end
@@ -565,6 +565,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     event.sprintf(@version) if @version
   end
   private :resolve_version
+
+  def resolve_version_type(event, event_version_type)
+    return event_version_type if event_version_type && !@version_type
+    event.sprintf(@version_type) if @version_type
+  end
+  private :resolve_version_type
 
   def resolve_routing(event, event_routing)
     return event_routing if event_routing && !@routing

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -554,11 +554,13 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     #      }
     params[:pipeline] = target_pipeline unless (target_pipeline.nil? || target_pipeline.empty?)
 
-    params[:version] = resolve_version(event, event_version)
-    params[:version_type] = resolve_version_type(event, event_version_type)
+    resolved_version = resolve_version(event, event_version)
+    resolved_version_type = resolve_version_type(event, event_version_type)
+    # avoid to add nil valued key-value pairs
+    params[:version] = resolved_version unless resolved_version.nil?
+    params[:version_type] = resolved_version_type unless resolved_version_type.nil?
 
-    # purge nil valued key-value pairs
-    params.compact
+    params
   end
 
   def resolve_version(event, event_version)

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -499,9 +499,6 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
       params[retry_on_conflict_action_name] = @retry_on_conflict
     end
 
-    params[:version] = event.sprintf(@version) if @version
-    params[:version_type] = event.sprintf(@version_type) if @version_type
-
     EventActionTuple.new(action, params, event)
   end
 
@@ -556,6 +553,9 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
     #        pipeline => "%{[@metadata][pipeline]}"
     #      }
     params[:pipeline] = target_pipeline unless (target_pipeline.nil? || target_pipeline.empty?)
+
+    params[:version] = event.sprintf(@version) if @version
+    params[:version_type] = event.sprintf(@version_type) if @version_type
 
     params
   end

--- a/lib/logstash/outputs/elasticsearch.rb
+++ b/lib/logstash/outputs/elasticsearch.rb
@@ -541,12 +541,12 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
   # @private shared event params factory between index and data_stream mode
   def common_event_params(event)
     event_control = event.get("[@metadata][_ingest_document]")
-    event_id, event_pipeline, event_index = event_control&.values_at("id","pipeline","index") rescue nil
+    event_id, event_pipeline, event_index = event_control&.values_at("id","pipeline","index", "routing") rescue nil
 
     params = {
         :_id => resolve_document_id(event, event_id),
         :_index => resolve_index!(event, event_index),
-        routing_field_name => @routing ? event.sprintf(@routing) : nil
+        routing_field_name => resolve_routing(event)
     }
 
     target_pipeline = resolve_pipeline(event, event_pipeline)
@@ -559,6 +559,11 @@ class LogStash::Outputs::ElasticSearch < LogStash::Outputs::Base
 
     params
   end
+
+  def resolve_routing(event)
+    @routing ? event.sprintf(@routing) : nil
+  end
+  private :resolve_routing
 
   def resolve_document_id(event, event_id)
     return event.sprintf(@document_id) if @document_id

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.21.0'
+  s.version         = '11.22.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -298,12 +298,12 @@ describe LogStash::Outputs::ElasticSearch do
         context "when the event contains an integration metadata index" do
           let(:event_fields) { super().merge({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
         
-          it "plugin's configuration metadata index is used" do
+          it "event's metadata index is used" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
           end
 
           context "when datastream settings are NOT configured" do
-            it "plugin's configuration metadata index is used" do
+            it "event's metadata index is used" do
               expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
             end
           end
@@ -311,7 +311,7 @@ describe LogStash::Outputs::ElasticSearch do
           context "when datastream settings are configured" do
             let(:event_fields) { super().merge({"data_stream" => {"type" => "logs", "dataset" => "generic", "namespace" => "default"}}) }
 
-            it "plugin's configuration metadata index is used" do
+            it "event's metadata index is used" do
               expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
             end
           end
@@ -948,24 +948,6 @@ describe LogStash::Outputs::ElasticSearch do
 
       it "interpolates the plugin's pipeline value" do
         expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
-      end
-
-      context "when event contains also _ingest_document pipeline name" do
-        let(:event) { LogStash::Event.new({"pipeline" => "my-ingest-pipeline",
-                                           "@metadata" => {"target_ingest_pipeline" => "meta-ingest-pipeline",
-                                                           "_ingest_document" => {"pipeline" => "integration-pipeline"}}}) }
-
-        it "precedence is given to the integration" do
-          expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
-        end
-
-        context "when settings doesn't configure a pipeline and integration provides one in the event" do
-          let(:options) { { } }
-
-          it "the one provided by user takes precedence on all the others" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "integration-pipeline")
-          end
-        end
       end
 
       context "when the plugin's `pipeline` is constant" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -304,7 +304,7 @@ describe LogStash::Outputs::ElasticSearch do
 
         context "when the event DOESN'T contain an integration metadata version" do
           it "plugin's default id mechanism is used" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:version => nil)
+            expect(subject.send(:event_action_tuple, event)[1]).to_not include(:version)
           end
         end
       end
@@ -338,7 +338,7 @@ describe LogStash::Outputs::ElasticSearch do
 
         context "when the event DOESN'T contain an integration metadata version_type" do
           it "plugin's default id mechanism is used" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => nil)
+            expect(subject.send(:event_action_tuple, event)[1]).to_not include(:version_type)
           end
         end
       end
@@ -372,7 +372,7 @@ describe LogStash::Outputs::ElasticSearch do
 
         context "when the event DOESN'T contain an integration metadata routing" do
           it "plugin's default id mechanism is used" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => nil)
+            expect(subject.send(:event_action_tuple, event)[1]).to_not include(:routing)
           end
         end
       end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -275,6 +275,25 @@ describe LogStash::Outputs::ElasticSearch do
       let(:event_fields) {{}}
       let(:event) { LogStash::Event.new(event_fields)}
 
+      context "which contains routing field in its metadata" do
+        # defines an event with routing in the integration metadata section
+        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"routing" => "meta-document-routing"}}}) }
+
+        context "when routing is specified in plugin settings" do
+          let(:options) { super().merge("routing" => "settings_routing")}
+
+          it "takes precedence over the integration one" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => "settings_routing")
+          end
+        end
+
+        context "when routing is not defined in plugin settings" do
+          it "must use the value from the integration's metadata" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => "meta-document-routing")
+          end
+        end
+      end
+
       context "when plugin's index is specified" do
         let(:options) { super().merge("index" => "index_from_settings")}
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -332,16 +332,11 @@ describe LogStash::Outputs::ElasticSearch do
         end
       end
 
-<<<<<<< HEAD
       context "when plugin's index is specified" do
         let(:options) { super().merge("index" => "index_from_settings")}
 
         context "when the event contains an integration metadata index" do
           let(:event_fields) { super().merge({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
-=======
-      context "when there isn't any index setting specified and the event contains an integration metadata index" do
-        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
->>>>>>> 332e6e3 (Use version setting from ingest_document metadata, if present)
 
           it "plugin's index is used" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "index_from_settings")

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -393,53 +393,6 @@ describe LogStash::Outputs::ElasticSearch do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "index_from_settings")
           end
         end
-
-      context "when plugin's index is NOT specified" do
-        let(:options) { super().merge("index" => nil)}
-        
-        context "when the event contains an integration metadata index" do
-          let(:event_fields) { super().merge({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
-        
-          it "event's metadata index is used" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
-          end
-
-          context "when datastream settings are NOT configured" do
-            it "event's metadata index is used" do
-              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
-            end
-          end
-
-          context "when datastream settings are configured" do
-            let(:event_fields) { super().merge({"data_stream" => {"type" => "logs", "dataset" => "generic", "namespace" => "default"}}) }
-
-            it "event's metadata index is used" do
-              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
-            end
-          end
-        end
-
-        context "when the event DOESN'T contain integration metadata index" do
-          let(:default_index_resolved) { event.sprintf(subject.default_index) }
-
-          it "default index is used" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => default_index_resolved)
-          end
-          
-          context "when datastream settings are NOT configured" do
-            it "default index is used" do
-              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => default_index_resolved)
-            end
-          end
-          
-          context "when datastream settings are configured" do
-            let(:event_fields) { super().merge({"data_stream" => {"type" => "logs", "dataset" => "generic", "namespace" => "default"}}) }
-          
-            it "default index is used" do
-              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => default_index_resolved)
-            end
-          end
-        end
       end
 
       context "when plugin's index is NOT specified" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -372,7 +372,7 @@ describe LogStash::Outputs::ElasticSearch do
 
         context "when the event DOESN'T contain an integration metadata routing" do
           it "plugin's default id mechanism is used" do
-            expect(subject.send(:event_action_tuple, event)[1]).to_not include(:routing)
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => nil)
           end
         end
       end

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -908,7 +908,7 @@ describe LogStash::Outputs::ElasticSearch do
                                            "@metadata" => {"target_ingest_pipeline" => "meta-ingest-pipeline",
                                                            "_ingest_document" => {"pipeline" => "integration-pipeline"}}}) }
 
-        it "the one provided by user takes precedence on all the others" do
+        it "precedence is given to the integration" do
           expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
         end
 

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -291,6 +291,53 @@ describe LogStash::Outputs::ElasticSearch do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "index_from_settings")
           end
         end
+
+      context "when plugin's index is NOT specified" do
+        let(:options) { super().merge("index" => nil)}
+        
+        context "when the event contains an integration metadata index" do
+          let(:event_fields) { super().merge({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
+        
+          it "plugin's configuration metadata index is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
+          end
+
+          context "when datastream settings are NOT configured" do
+            it "plugin's configuration metadata index is used" do
+              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
+            end
+          end
+
+          context "when datastream settings are configured" do
+            let(:event_fields) { super().merge({"data_stream" => {"type" => "logs", "dataset" => "generic", "namespace" => "default"}}) }
+
+            it "plugin's configuration metadata index is used" do
+              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "meta-document-index")
+            end
+          end
+        end
+
+        context "when the event DOESN'T contain integration metadata index" do
+          let(:default_index_resolved) { event.sprintf(subject.default_index) }
+
+          it "default index is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => default_index_resolved)
+          end
+          
+          context "when datastream settings are NOT configured" do
+            it "default index is used" do
+              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => default_index_resolved)
+            end
+          end
+          
+          context "when datastream settings are configured" do
+            let(:event_fields) { super().merge({"data_stream" => {"type" => "logs", "dataset" => "generic", "namespace" => "default"}}) }
+          
+            it "default index is used" do
+              expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => default_index_resolved)
+            end
+          end
+        end
       end
 
       context "when plugin's index is NOT specified" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -294,6 +294,25 @@ describe LogStash::Outputs::ElasticSearch do
         end
       end
 
+      context "which contains version_type field" do
+        # defines an event with version_type in the integration metadata section
+        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version_type" => "external"}}}) }
+
+        context "when version_type is also specified in plugin settings" do
+          let(:options) { super().merge("version_type" => "internal")}
+
+          it "takes precedence over the integration one" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => "internal")
+          end
+        end
+
+        context "when version_type is not defined in plugin settings" do
+          it "must use the value from the integration's metadata" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => "external")
+          end
+        end
+      end
+
       context "which contains routing field in its metadata" do
         # defines an event with routing in the integration metadata section
         let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"routing" => "meta-document-routing"}}}) }

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -275,6 +275,25 @@ describe LogStash::Outputs::ElasticSearch do
       let(:event_fields) {{}}
       let(:event) { LogStash::Event.new(event_fields)}
 
+      context "which contains version field" do
+        # defines an event with version in the integration metadata section
+        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version" => "456"}}}) }
+
+        context "when version is also specified in plugin settings" do
+          let(:options) { super().merge("version" => "123")}
+
+          it "takes precedence over the integration one" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version => "123")
+          end
+        end
+
+        context "when version is not defined in plugin settings" do
+          it "must use the value from the integration's metadata" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version => "456")
+          end
+        end
+      end
+
       context "which contains routing field in its metadata" do
         # defines an event with routing in the integration metadata section
         let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"routing" => "meta-document-routing"}}}) }
@@ -294,11 +313,16 @@ describe LogStash::Outputs::ElasticSearch do
         end
       end
 
+<<<<<<< HEAD
       context "when plugin's index is specified" do
         let(:options) { super().merge("index" => "index_from_settings")}
 
         context "when the event contains an integration metadata index" do
           let(:event_fields) { super().merge({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
+=======
+      context "when there isn't any index setting specified and the event contains an integration metadata index" do
+        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"index" => "meta-document-index"}}}) }
+>>>>>>> 332e6e3 (Use version setting from ingest_document metadata, if present)
 
           it "plugin's index is used" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:_index => "index_from_settings")

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -903,6 +903,24 @@ describe LogStash::Outputs::ElasticSearch do
         expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
       end
 
+      context "when event contains also _ingest_document pipeline name" do
+        let(:event) { LogStash::Event.new({"pipeline" => "my-ingest-pipeline",
+                                           "@metadata" => {"target_ingest_pipeline" => "meta-ingest-pipeline",
+                                                           "_ingest_document" => {"pipeline" => "integration-pipeline"}}}) }
+
+        it "the one provided by user takes precedence on all the others" do
+          expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "my-ingest-pipeline")
+        end
+
+        context "when settings doesn't configure a pipeline and integration provides one in the event" do
+          let(:options) { { } }
+
+          it "the one provided by user takes precedence on all the others" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:pipeline => "integration-pipeline")
+          end
+        end
+      end
+
       context "when the plugin's `pipeline` is constant" do
         let(:options) { super().merge("pipeline" => "my-constant-pipeline") }
          it "uses plugin's pipeline value" do

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -275,59 +275,104 @@ describe LogStash::Outputs::ElasticSearch do
       let(:event_fields) {{}}
       let(:event) { LogStash::Event.new(event_fields)}
 
-      context "which contains version field" do
-        # defines an event with version in the integration metadata section
-        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version" => "456"}}}) }
+      context "when plugin's version is specified" do
+        let(:options) { super().merge("version" => "123")}
 
-        context "when version is also specified in plugin settings" do
-          let(:options) { super().merge("version" => "123")}
+        context "when the event contains an integration metadata version" do
+          let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version" => "456"}}}) }
 
-          it "takes precedence over the integration one" do
+          it "plugin's version is used" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:version => "123")
           end
         end
 
-        context "when version is not defined in plugin settings" do
-          it "must use the value from the integration's metadata" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:version => "456")
+        context "when the event DOESN'T contains an integration metadata version" do
+          it "plugin's version is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version => "123")
           end
         end
       end
 
-      context "which contains version_type field" do
-        # defines an event with version_type in the integration metadata section
-        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version_type" => "external"}}}) }
+      context "when plugin's version is NOT specified" do
+        context "when the event contains an integration metadata version" do
+          let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version" => "456"}}}) }
 
-        context "when version_type is also specified in plugin settings" do
-          let(:options) { super().merge("version_type" => "internal")}
+          it "event's metadata version is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version => "456")
+          end
+        end
 
-          it "takes precedence over the integration one" do
+        context "when the event DOESN'T contain an integration metadata version" do
+          it "plugin's default id mechanism is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version => nil)
+          end
+        end
+      end
+
+      context "when plugin's version_type is specified" do
+        let(:options) { super().merge("version_type" => "internal")}
+
+        context "when the event contains an integration metadata version_type" do
+          let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version_type" => "external"}}}) }
+
+          it "plugin's version_type is used" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => "internal")
           end
         end
 
-        context "when version_type is not defined in plugin settings" do
-          it "must use the value from the integration's metadata" do
-            expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => "external")
+        context "when the event DOESN'T contains an integration metadata version_type" do
+          it "plugin's version_type is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => "internal")
           end
         end
       end
 
-      context "which contains routing field in its metadata" do
-        # defines an event with routing in the integration metadata section
-        let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"routing" => "meta-document-routing"}}}) }
+      context "when plugin's version_type is NOT specified" do
+        context "when the event contains an integration metadata version_type" do
+          let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"version_type" => "external"}}}) }
 
-        context "when routing is specified in plugin settings" do
-          let(:options) { super().merge("routing" => "settings_routing")}
+          it "event's metadata version_type is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => "external")
+          end
+        end
 
-          it "takes precedence over the integration one" do
+        context "when the event DOESN'T contain an integration metadata version_type" do
+          it "plugin's default id mechanism is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:version_type => nil)
+          end
+        end
+      end
+
+      context "when plugin's routing is specified" do
+        let(:options) { super().merge("routing" => "settings_routing")}
+
+        context "when the event contains an integration metadata routing" do
+          let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"routing" => "meta-document-routing"}}}) }
+
+          it "plugin's routing is used" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => "settings_routing")
           end
         end
 
-        context "when routing is not defined in plugin settings" do
-          it "must use the value from the integration's metadata" do
+        context "when the event DOESN'T contains an integration metadata routing" do
+          it "plugin's routing is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => "settings_routing")
+          end
+        end
+      end
+
+      context "when plugin's routing is NOT specified" do
+        context "when the event contains an integration metadata routing" do
+          let(:event) { LogStash::Event.new({"@metadata" => {"_ingest_document" => {"routing" => "meta-document-routing"}}}) }
+
+          it "event's metadata routing is used" do
             expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => "meta-document-routing")
+          end
+        end
+
+        context "when the event DOESN'T contain an integration metadata routing" do
+          it "plugin's default id mechanism is used" do
+            expect(subject.send(:event_action_tuple, event)[1]).to include(:routing => nil)
           end
         end
       end


### PR DESCRIPTION
## Release notes

Added support for propagating event processing metadata when this output is downstream of an Elastic Integration Filter and configured _without_ explicit `version`, `version_type`, or `routing` directives

## What does this PR do?

Change the creation of actions that are passed down to Elasticsearch to use also the metadata fields set by an integration.
The interested fields are `version`, `version_type` and `routing`, the field values are taken verbatim without placeholders resolution.
The version, version_type and routing that are configured in the plugin settings have precedence on the integration ones because manifest an explicit choice made by the user.



## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
This PR complete the fix related to interoperability issue with Agent's integrations (started with #1155), where some metadata valued by integration has to be used down to Elasticsearch.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] use the plugin with an integration that configures the document id, and in case of same id no new documents are indexed.

## How to test this PR locally
Please refer to the same flow used in #1155

## Related issues

- Closes #1157 