### PR TITLE
Replace document_already_exist_exception with version_conflict_engine_exception in the silence_errors_in_log setting example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.20.1
+- Replace `document_already_exist_exception` with `version_conflict_engine_exception` in the `silence_errors_in_log` setting example [#1159](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1159)
+
 ## 11.20.0
   - Changed the register to initiate pipeline shutdown upon bootstrap failure instead of simply logging the error [#1151](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1151)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -988,12 +988,12 @@ if enabled, script is in charge of creating non-existent document (scripted upda
 
 Defines the list of Elasticsearch errors that you don't want to log.
 A useful example is when you want to skip all 409 errors
-which are `document_already_exists_exception`.
+which are `version_conflict_engine_exception`.
 
 [source,ruby]
     output {
       elasticsearch {
-        silence_errors_in_log => ["document_already_exists_exception"]
+        silence_errors_in_log => ["version_conflict_engine_exception"]
       }
     }
 

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -149,7 +149,7 @@ module LogStash; module PluginMixins; module ElasticSearch
 
         # Defines the list of Elasticsearch errors that you don't want to log.
         # A useful example is when you want to skip all 409 errors
-        # which are `document_already_exists_exception`.
+        # which are `version_conflict_engine_exception`.
         # Deprecates `failure_type_logging_whitelist`.
         :silence_errors_in_log => { :validate => :array, :default => [] },
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.20.0'
+  s.version         = '11.20.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/error_whitelist_spec.rb
+++ b/spec/unit/outputs/error_whitelist_spec.rb
@@ -25,7 +25,7 @@ describe "whitelisting error types in expected behavior" do
           "create" => {
             "status" => 409, 
             "error" => {
-              "type" => "document_already_exists_exception",
+              "type" => "version_conflict_engine_exception",
               "reason" => "[shard] document already exists"
             }
           }
@@ -46,7 +46,7 @@ describe "whitelisting error types in expected behavior" do
   end
 
   describe "when failure logging is disabled for document exists error" do
-    let(:settings) { super().merge("silence_errors_in_log" => ["document_already_exists_exception"]) }
+    let(:settings) { super().merge("silence_errors_in_log" => ["version_conflict_engine_exception"]) }
 
     it "should log a failure on the action" do
       expect(subject.logger).not_to have_received(:warn).with("Failed action", anything)


### PR DESCRIPTION
The example reported in documentation for the setting [`silence_errors_in_log`](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-silence_errors_in_log) does not appear to work with modern version of Elasticsearch. The correct value should be `version_conflict_engine_exception`, which as per  https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/ElasticsearchException.java#L1271C1-L1272C replaced the exception `document_already_exist_exception`.


This PR replace in the example for silence_errors_in_log the deprecated/not more existent `document_already_exist_exception` with the value `version_conflict_engine_exception`.
