### PR TITLE
Resync CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,8 +139,6 @@
 
 ## 11.5.0
  - Feat: add ssl_supported_protocols option [#1055](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1055)
-
-## 11.4.2
  - [DOC] Add `v8` to supported values for ecs_compatiblity defaults [#1059](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1059)
 
 ## 11.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,10 @@
  - Feat: add ssl_supported_protocols option [#1055](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1055)
  - [DOC] Add `v8` to supported values for ecs_compatiblity defaults [#1059](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1059)
 
+## 11.4.2
+- Fixes an issue where events containing non-unicode strings could fail to serialize correctly when compression is enabled [#1169](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1169)
+  - NOTE: This is a backport of the relevant fix from v11.22.3 to the 11.4 series for inclusion with Logstash 7.17 maintenance releases
+
 ## 11.4.1
  - Feat: upgrade manticore (http-client) library [#1063](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1063)
    - the underlying changes include latest HttpClient (4.5.13)


### PR DESCRIPTION
 - The changelog on `main` had a docs-only entry for `11.4.2` that was not packaged and released until `11.5.0`; update the changelog to reflect where it was actually packaged
 - We recently _backported_ a fix that was first available in `v11.22.3` to a new `11.4-maintenance` branch (cut from the `v11.4.1` tag), and released that fix with `v11.4.2`; we forward-port its changelog entry to `main`, along with a caveat so that users don't assume the fix's availability in intermediate releases.
