### PR TITLE
[Doc] `ssl_key` requires PKCS#8 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.22.7
-  - [DOC] `ssl.key` requires PKCS#8 format
+  - [DOC] `ssl.key` requires PKCS#8 format [#1181](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1181)
 
 ## 11.22.6
   - [DOC] Logstash output.elasticsearch index can be alias or datastream [#1179](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.22.7
-  - [DOC] `ssl.key` requires PKCS#8 format [#1181](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1181)
+  - [DOC] `ssl_key` requires PKCS#8 format [#1181](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1181)
 
 ## 11.22.6
   - [DOC] Logstash output.elasticsearch index can be alias or datastream [#1179](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.22.7
+  - [DOC] `ssl.key` requires PKCS#8 format
+
 ## 11.22.6
   - [DOC] Logstash output.elasticsearch index can be alias or datastream [#1179](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1179)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1101,7 +1101,15 @@ If no explicit protocol is specified plain HTTP will be used.
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-OpenSSL-style RSA private key that corresponds to the <<plugins-{type}s-{plugin}-ssl_certificate>>.
+SSL key to use.
+This key must be in the PKCS8 format and PEM encoded.
+You can use the https://www.openssl.org/docs/man1.1.1/man1/openssl-pkcs8.html[openssl pkcs8] command to complete the conversion.
+For example, the command to convert a PEM encoded PKCS1 private key to a PEM encoded, non-encrypted PKCS8 key is:
+
+[source,sh]
+-----
+openssl pkcs8 -inform PEM -in path/to/logstash.key -topk8 -nocrypt -outform PEM -out path/to/logstash.pkcs8.key
+-----
 
 NOTE: This setting can be used only if <<plugins-{type}s-{plugin}-ssl_certificate>> is set.
 

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.22.6'
+  s.version         = '11.22.7'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
copy the doc from [beat-input ](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html#plugins-inputs-beats-ssl_key)ssl_key
