### PR TITLE
Vendor Elasticsearch 9 templates in the generated gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.22.9
+ - Vendor ECS template for Elasticsearch 9.x in built gem [#1188](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1188)
+
 ## 11.22.8
   - Added ECS template for Elasticsearch 9.x [#1187](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1187)
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,13 @@ task :'vendor-ecs-schemata' do
   download_ecs_schemata(:v1, elasticsearch_major: 6, ecs_release_tag: 'v1.10.0') # WARNING: v1.11 breaks 6.x (see: https://github.com/elastic/ecs/issues/1649)
   download_ecs_schemata(:v1, elasticsearch_major: 7, ecs_release_tag: 'v1.12.1')
   download_ecs_schemata(:v1, elasticsearch_major: 8, ecs_release_tag: 'v1.12.1', generated_for: 7)
+  download_ecs_schemata(:v1, elasticsearch_major: 9, ecs_release_tag: 'v1.12.1', generated_for: 7)
 
   # PRERELEASE: 8.0 branch
   # when pinning to released tag, remove BETA warning.
   download_ecs_schemata(:v8, elasticsearch_major: 7, ecs_release_tag: '8.0')
   download_ecs_schemata(:v8, elasticsearch_major: 8, ecs_release_tag: '8.0')
+  download_ecs_schemata(:v8, elasticsearch_major: 9, ecs_release_tag: '8.0')
 end
 
 task :vendor => :'vendor-ecs-schemata'

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.22.8'
+  s.version         = '11.22.9'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Release notes
Vendor ECS template for Elasticsearch 9.x in built gem


## What does this PR do?

Update `Rakefile` to vendor ECS schema template v8 for Elasticsearch 9

## Why is it important/What is the impact to the user?

Let the plugin work with Elaticsearch 9 templates

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] vendor and build locally the gem

## How to test this PR locally

- vendor the gem
```sh
rake vendor
gem build 
```
- unpack the gem and verify that  contains the templates
```sh
gem unpack logstash-output-elasticsearch-11.22.9-java.gem
tree logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch/templates/
```

## Related issues

- Relates #1187

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```
[WARN ] 2024-09-13 09:54:08.763 [[test2]-pipeline-manager] javapipeline - 'pipeline.ordered' is enabled and is likely less efficient, consider disabling if preserving event order is not necessary
[INFO ] 2024-09-13 09:54:08.766 [Ruby-0-Thread-14: /path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/plugin_mixins/elasticsearch/common.rb:164] elasticsearch - Using a default mapping template {:es_version=>9, :ecs_compatibility=>:v8}
[INFO ] 2024-09-13 09:54:08.766 [Ruby-0-Thread-15: /path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/plugin_mixins/elasticsearch/common.rb:164] elasticsearch - Using a default mapping template {:es_version=>9, :ecs_compatibility=>:v8}
[ERROR] 2024-09-13 09:54:08.766 [Ruby-0-Thread-14: /path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/plugin_mixins/elasticsearch/common.rb:164] 
	elasticsearch - Failed to install template {
		:message=>"Failed to load default template for Elasticsearch v9 with ECS v8; caused by: #<LogStash::ConfigurationError: Failed to load template file '/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch/templates/ecs-v8/elasticsearch-9x.json': Template file '/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch/templates/ecs-v8/elasticsearch-9x.json' could not be found>", 
		:exception=>LogStash::ConfigurationError, 
		:backtrace=>[
		"/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch/template_manager.rb:40:in `load_default_template'", 
		"/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch/template_manager.rb:27:in `install_template'", "/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch.rb:663:in `install_template'", 
		"/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch.rb:371:in `finish_register'", 
		"/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/outputs/elasticsearch.rb:328:in `block in register'", 
		"/path/to/logstash-9.0.0-SNAPSHOT/vendor/bundle/jruby/3.1.0/gems/logstash-output-elasticsearch-11.22.8-java/lib/logstash/plugin_mixins/elasticsearch/common.rb:172:in `block in after_successful_connection'"
		]
	}
```	

https://buildkite.com/elastic/logstash-pull-request-pipeline/builds/1457#0191e54c-3934-4a5d-a1df-636cbe9358df/2224-2521