### PR TITLE
Add X-Elastic-Product-Origin

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -2,7 +2,7 @@ require 'manticore'
 require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch; class HttpClient;
-  DEFAULT_HEADERS = { "Content-Type" => "application/json" }
+  DEFAULT_HEADERS = { "Content-Type" => "application/json", "X-Elastic-Product-Origin": "logstash" }
   
   class ManticoreAdapter
     attr_reader :manticore, :logger


### PR DESCRIPTION
Add the `X-Elastic-Product-Origin` header set to `logstash` (similar to https://github.com/elastic/beats/blob/3f44bd1f9bf0b3e17c8254119c464cbb7e872c71/libbeat/common/productorigin/productorigin.go#L24).


