### PR TITLE
Set x-elastic-product-origin header for ES requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.22.10
+ - Add `x-elastic-product-origin` header to Elasticsearch requests [#1194](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1194)
+
 ## 11.22.9
  - Vendor ECS template for Elasticsearch 9.x in built gem [#1188](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1188)
 

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -2,7 +2,7 @@ require 'manticore'
 require 'cgi'
 
 module LogStash; module Outputs; class ElasticSearch; class HttpClient;
-  DEFAULT_HEADERS = { "Content-Type" => "application/json" }
+  DEFAULT_HEADERS = { "Content-Type" => "application/json", 'x-elastic-product-origin' => 'logstash-output-elasticsearch' }
   
   class ManticoreAdapter
     attr_reader :manticore, :logger

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.22.9'
+  s.version         = '11.22.10'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -32,6 +32,13 @@ end
     let(:http_client) do
       Manticore::Client.new(http_client_options)
     end
+    let(:expected_headers) {
+      {
+        "Content-Encoding" => "gzip",
+        "Content-Type" => "application/json",
+        'x-elastic-product-origin' => 'logstash-output-elasticsearch'
+      }
+    }
 
     before do
       subject.register
@@ -64,7 +71,7 @@ end
 
     it "sets the correct content-encoding header and body is compressed" do
       expect(subject.client.pool.adapter.client).to receive(:send).
-        with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
+        with(anything, anything, {:headers=> expected_headers, :body => a_valid_gzip_encoded_string}).
         and_call_original
       subject.multi_receive(events)
     end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -214,10 +214,13 @@ describe "indexing" do
     end
 
     it "sets the correct content-type header" do
-      expected_manticore_opts = {:headers => {"Content-Type" => "application/json"}, :body => anything}
+      expected_manticore_opts = {
+        :headers => {"Content-Type" => "application/json", 'x-elastic-product-origin' => 'logstash-output-elasticsearch'},
+        :body => anything
+      }
       if secure
         expected_manticore_opts = {
-          :headers => {"Content-Type" => "application/json"},
+          :headers => {"Content-Type" => "application/json", 'x-elastic-product-origin' => 'logstash-output-elasticsearch'},
           :body => anything,
           :auth => {
             :user => user,

--- a/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/elasticsearch/http_client/manticore_adapter_spec.rb
@@ -34,7 +34,7 @@ describe LogStash::Outputs::ElasticSearch::HttpClient::ManticoreAdapter do
       
       expect(subject.manticore).to receive(:get).
         with(expected_uri.to_s, {
-          :headers => {"Content-Type" => "application/json"},
+          :headers => LogStash::Outputs::ElasticSearch::HttpClient::DEFAULT_HEADERS,
           :auth => {
             :user => user,
             :password => password,


### PR DESCRIPTION
This commit updates the `Elasticsearch::Client` used to make requests to ES to
send along a header identifying the request as originating from an internal
component.

closes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1191