### PR TITLE
Update CHANGELOG.md to fix PR number and link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.22.10
- - Add `x-elastic-product-origin` header to Elasticsearch requests [#1194](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1194)
+ - Add `x-elastic-product-origin` header to Elasticsearch requests [#1195](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1195)
 
 ## 11.22.9
  - Vendor ECS template for Elasticsearch 9.x in built gem [#1188](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1188)


### PR DESCRIPTION
Changelog entry merged in #1195 incorrectly links to #1194 which is still WIP. 
If we go with this approach to make the correction, we'll have to fix it again in release notes for all releases that are locked to this plugin version. 
