### PR TITLE
Remove irrelevant warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.1
+ - Remove irrelevant log warning about elastic stack version [#1200](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1200)
+
 ## 12.0.0
   - SSL settings that were marked deprecated in version `11.14.0` are now marked obsolete, and will prevent the plugin from starting.
   - These settings are:

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -515,18 +515,11 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       major = major_version(version)
       if @maximum_seen_major_version.nil?
         @logger.info("Elasticsearch version determined (#{version})", es_version: major)
-        set_maximum_seen_major_version(major)
+        @maximum_seen_major_version = major
       elsif major > @maximum_seen_major_version
         warn_on_higher_major_version(major, url)
         @maximum_seen_major_version = major
       end
-    end
-
-    def set_maximum_seen_major_version(major)
-      if major >= 6
-        @logger.warn("Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type", es_version: major)
-      end
-      @maximum_seen_major_version = major
     end
 
     def warn_on_higher_major_version(major, url)

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '12.0.0'
+  s.version         = '12.0.1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This commit removes an old warning which is no longer relevant to any supported
stack version. It is noisy and there is no action for the user to take.


Closes https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1198