### PR TITLE
make requests return exception only on 2xx codes

### DIFF
--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -181,20 +181,15 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def bulk_send(body_stream, batch_actions)
       params = compression_level? ? {:headers => {"Content-Encoding" => "gzip"}} : {}
-
-      begin
-        response = @pool.post(@bulk_path, params, body_stream.string)
-      rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
-        if e.response_code == 413 # special handling for 413, treat it as a document level issue
-          logger.warn("Bulk request rejected: `413 Payload Too Large`", :action_count => batch_actions.size, :content_length => body_stream.size)
-          emulate_batch_error_response(batch_actions, 413, 'payload_too_large')
-        else
-          raise e
-        end
-      ensure
-        code = e ? e.response_code : response.code
-        @bulk_response_metrics.increment(code.to_s)
-      end
+      response = @pool.post(@bulk_path, params, body_stream.string)
+    rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
+      raise e unless e.response_code == 413
+      # special handling for 413, treat it as a document level issue
+      logger.warn("Bulk request rejected: `413 Payload Too Large`", :action_count => batch_actions.size, :content_length => body_stream.size)
+      emulate_batch_error_response(batch_actions, 413, 'payload_too_large')
+    ensure
+      code = e ? e.response_code : response.code
+      @bulk_response_metrics.increment(code.to_s)
     end
 
     def emulate_batch_error_response(actions, http_code, reason)

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -185,14 +185,14 @@ module LogStash; module Outputs; class ElasticSearch;
       begin
         response = @pool.post(@bulk_path, params, body_stream.string)
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
-        if response.code == 413 # special handling for 413, treat it as a document level issue
+        if e.response_code == 413 # special handling for 413, treat it as a document level issue
           logger.warn("Bulk request rejected: `413 Payload Too Large`", :action_count => batch_actions.size, :content_length => body_stream.size)
-          emulate_batch_error_response(batch_actions, response.code, 'payload_too_large')
+          emulate_batch_error_response(batch_actions, 413, 'payload_too_large')
         else
           raise e
         end
       ensure
-        code = e ? e.code : response.code
+        code = e ? e.response_code : response.code
         @bulk_response_metrics.increment(code.to_s)
       end
     end

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -181,17 +181,22 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def bulk_send(body_stream, batch_actions)
       params = compression_level? ? {:headers => {"Content-Encoding" => "gzip"}} : {}
-      response = @pool.post(@bulk_path, params, body_stream.string)
+
+      begin
+        response = @pool.post(@bulk_path, params, body_stream.string)
+      rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
+        @bulk_response_metrics.increment(e.response_code.to_s)
+        raise e unless e.response_code == 413
+        # special handling for 413, treat it as a document level issue
+        logger.warn("Bulk request rejected: `413 Payload Too Large`", :action_count => batch_actions.size, :content_length => body_stream.size)
+        emulate_batch_error_response(batch_actions, 413, 'payload_too_large')
+      rescue => e # it may be a network issue instead, re-raise
+        raise e
+      end
+
       @bulk_response_metrics.increment(response.code.to_s)
+
       LogStash::Json.load(response.body)
-    rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
-      @bulk_response_metrics.increment(e.response_code.to_s)
-      raise e unless e.response_code == 413
-      # special handling for 413, treat it as a document level issue
-      logger.warn("Bulk request rejected: `413 Payload Too Large`", :action_count => batch_actions.size, :content_length => body_stream.size)
-      emulate_batch_error_response(batch_actions, 413, 'payload_too_large')
-    else # it may be a network issue instead, re-raise
-      raise e
     end
 
     def emulate_batch_error_response(actions, http_code, reason)

--- a/lib/logstash/outputs/elasticsearch/http_client.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client.rb
@@ -184,6 +184,7 @@ module LogStash; module Outputs; class ElasticSearch;
 
       begin
         response = @pool.post(@bulk_path, params, body_stream.string)
+        @bulk_response_metrics.increment(response.code.to_s)
       rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
         @bulk_response_metrics.increment(e.response_code.to_s)
         raise e unless e.response_code == 413
@@ -193,8 +194,6 @@ module LogStash; module Outputs; class ElasticSearch;
       rescue => e # it may be a network issue instead, re-raise
         raise e
       end
-
-      @bulk_response_metrics.increment(response.code.to_s)
 
       LogStash::Json.load(response.body)
     end

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -77,7 +77,7 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
       end
 
       code = resp.code
-      if code < 200 || code > 299 #&& code != 404
+      if code < 200 || code > 299 # assume anything not 2xx is an error that the layer above needs to interpret
         raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(code, request_uri, body, resp.body)
       end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/manticore_adapter.rb
@@ -76,11 +76,8 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
         raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError.new(e, request_uri_as_string)
       end
 
-      # 404s are excluded because they are valid codes in the case of
-      # template installation. We might need a better story around this later
-      # but for our current purposes this is correct
       code = resp.code
-      if code < 200 || code > 299 && code != 404
+      if code < 200 || code > 299 #&& code != 404
         raise ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError.new(code, request_uri, body, resp.body)
       end
 

--- a/lib/logstash/outputs/elasticsearch/http_client/pool.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client/pool.rb
@@ -253,13 +253,11 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     def health_check_request(url)
       logger.debug("Running health check to see if an Elasticsearch connection is working",
                    :healthcheck_url => url.sanitized.to_s, :path => @healthcheck_path)
-      begin
-        response = perform_request_to_url(url, :head, @healthcheck_path)
-        return response, nil
-      rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
-        logger.warn("Health check failed", code: e.response_code, url: e.url, message: e.message)
-        return nil, e
-      end
+      response = perform_request_to_url(url, :head, @healthcheck_path)
+      return response, nil
+    rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
+      logger.warn("Health check failed", code: e.response_code, url: e.url, message: e.message)
+      return nil, e
     end
 
     def healthcheck!(register_phase = true)
@@ -312,13 +310,11 @@ module LogStash; module Outputs; class ElasticSearch; class HttpClient;
     end
 
     def get_root_path(url, params={})
-      begin
-        resp = perform_request_to_url(url, :get, ROOT_URI_PATH, params)
-        return resp, nil
-      rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
-        logger.warn("Elasticsearch main endpoint returns #{e.response_code}", message: e.message, body: e.response_body)
-        return nil, e
-      end
+      resp = perform_request_to_url(url, :get, ROOT_URI_PATH, params)
+      return resp, nil
+    rescue ::LogStash::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError => e
+      logger.warn("Elasticsearch main endpoint returns #{e.response_code}", message: e.message, body: e.response_body)
+      return nil, e
     end
 
     def test_serverless_connection(url, root_response)


### PR DESCRIPTION
attempting a different strategy from https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1199 to reduce duplication.

failing tests still present at this point.