### PR TITLE
Support both, encoded and non encoded api-key formats on plugin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.7
+ - Support both, encoded and non encoded api-key formats on plugin configuration [#1223](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1223)
+
 ## 12.0.6
  - Add headers reporting uncompressed size and doc count for bulk requests [#1217](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1217)
 

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -188,9 +188,14 @@ module LogStash; module Outputs; class ElasticSearch;
     def self.setup_api_key(logger, params)
       api_key = params["api_key"]
 
-      return {} unless (api_key && api_key.value)
+      return {} unless (api_key&.value)
 
-      { "Authorization" => "ApiKey " + Base64.strict_encode64(api_key.value) }
+      api_key_value = api_key.value
+      if api_key_value =~ /\A[^:]+:[^:]+\z/
+        api_key_value = Base64.strict_encode64(api_key_value)
+      end
+
+      { "Authorization" => "ApiKey " + api_key_value }
     end
 
     private

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -190,12 +190,9 @@ module LogStash; module Outputs; class ElasticSearch;
 
       return {} unless (api_key&.value)
 
-      api_key_value = api_key.value
-      if api_key_value =~ /\A[^:]+:[^:]+\z/
-        api_key_value = Base64.strict_encode64(api_key_value)
-      end
+      value = self.is_base64?(api_key.value) ?  api_key.value : Base64.strict_encode64(api_key.value)
 
-      { "Authorization" => "ApiKey " + api_key_value }
+      { "Authorization" => "ApiKey #{value}" }
     end
 
     private
@@ -212,6 +209,14 @@ module LogStash; module Outputs; class ElasticSearch;
 
     def self.query_param_separator(url)
       url.match?(/\?[^\s#]+/) ? '&' : '?'
+    end
+
+    def self.is_base64?(string)
+      begin
+        string == Base64.strict_encode64(Base64.strict_decode64(string))
+      rescue ArgumentError
+        false
+      end
     end
   end
 end; end; end

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -190,32 +190,34 @@ module LogStash; module Outputs; class ElasticSearch;
 
       return {} unless (api_key&.value)
 
-      value = self.is_base64?(api_key.value) ?  api_key.value : Base64.strict_encode64(api_key.value)
+      value = is_base64?(api_key.value) ?  api_key.value : Base64.strict_encode64(api_key.value)
 
       { "Authorization" => "ApiKey #{value}" }
     end
 
-    private
-    def self.dedup_slashes(url)
-      url.gsub(/\/+/, "/")
-    end
+    class << self
+      private
+      def dedup_slashes(url)
+        url.gsub(/\/+/, "/")
+      end
 
-    # Set a `filter_path` query parameter if it is not already set to be
-    # `filter_path=errors,items.*.error,items.*.status` to reduce the payload between Logstash and Elasticsearch
-    def self.resolve_filter_path(url)
-      return url if url.match?(/(?:[&|?])filter_path=/)
-      ("#{url}#{query_param_separator(url)}filter_path=errors,items.*.error,items.*.status")
-    end
+      # Set a `filter_path` query parameter if it is not already set to be
+      # `filter_path=errors,items.*.error,items.*.status` to reduce the payload between Logstash and Elasticsearch
+      def resolve_filter_path(url)
+        return url if url.match?(/(?:[&|?])filter_path=/)
+        ("#{url}#{query_param_separator(url)}filter_path=errors,items.*.error,items.*.status")
+      end
 
-    def self.query_param_separator(url)
-      url.match?(/\?[^\s#]+/) ? '&' : '?'
-    end
+      def query_param_separator(url)
+        url.match?(/\?[^\s#]+/) ? '&' : '?'
+      end
 
-    def self.is_base64?(string)
-      begin
-        string == Base64.strict_encode64(Base64.strict_decode64(string))
-      rescue ArgumentError
-        false
+      def is_base64?(string)
+        begin
+          string == Base64.strict_encode64(Base64.strict_decode64(string))
+        rescue ArgumentError
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
Avoid double-encoding opaque Elasticsearch API keys.

Previously, API keys that were already in encoded format were incorrectly re-encoded, causing connection failures. This update ensures that only raw keys are encoded, supporting both opaque and `id:api-key` formats without issue.

Closes [#1222](https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1222)

