### PR TITLE
Add drop_error_types config option to not retry after certain error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.0.8
+## 12.1.0
 - Add drop_error_types config option to not retry after certain error types [#1228](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1228)
 
 ## 12.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.0.8
+- Add drop_error_types config option to not retry after certain error types [#1228](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1228)
+
 ## 12.0.7
  - Support both, encoded and non encoded api-key formats on plugin configuration [#1223](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1223)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -644,6 +644,18 @@ If you don't set a value for this option:
 - for elasticsearch clusters 8.x: no value will be used;
 - for elasticsearch clusters 7.x: the value of '_doc' will be used.
 
+[id="plugins-{type}s-{plugin}-drop_error_types"]
+===== `drop_error_types`
+
+  * Value type is <<array,array>>
+  * Default value is `[]`
+
+In most cases, a bulk request is retried when Elasticsearch returns an error.
+This config option defines a list of error types for which the bulk request will not be retried.
+A warning message will be logged indicating that the request had failed, unless the error type is
+listed in the <<plugins-{type}s-{plugin}-silence_errors_in_log>> config option.
+Note that the events are not added to the Dead Letter Queue (DLQ), regardless of whether one is enabled.
+
 [id="plugins-{type}s-{plugin}-ecs_compatibility"]
 ===== `ecs_compatibility`
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -650,11 +650,10 @@ If you don't set a value for this option:
   * Value type is <<array,array>>
   * Default value is `[]`
 
-In most cases, a bulk request is retried when Elasticsearch returns an error.
-This config option defines a list of error types for which the bulk request will not be retried.
-A warning message will be logged indicating that the request had failed, unless the error type is
+Lists the set of error types for which individual bulk request actions will not be retried. Unless an individual - document level - action returns 409 or an error from this list, failures will be retried indefinitely.
+A warning message will be logged indicating that the action failed, unless the error type is
 listed in the <<plugins-{type}s-{plugin}-silence_errors_in_log>> config option.
-Note that the events are not added to the Dead Letter Queue (DLQ), regardless of whether one is enabled.
+Note that the events are not added to the Dead Letter Queue (DLQ), regardless of whether it is enabled.
 
 [source,ruby]
     output {

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -656,6 +656,13 @@ A warning message will be logged indicating that the request had failed, unless 
 listed in the <<plugins-{type}s-{plugin}-silence_errors_in_log>> config option.
 Note that the events are not added to the Dead Letter Queue (DLQ), regardless of whether one is enabled.
 
+[source,ruby]
+    output {
+      elasticsearch {
+        drop_error_types => ["role_restriction_exception"]
+      }
+    }
+
 [id="plugins-{type}s-{plugin}-ecs_compatibility"]
 ===== `ecs_compatibility`
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -659,7 +659,7 @@ Note that the events are not added to the Dead Letter Queue (DLQ), regardless of
 [source,ruby]
     output {
       elasticsearch {
-        drop_error_types => ["role_restriction_exception"]
+        drop_error_types => ["index_closed_exception"]
       }
     }
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -373,6 +373,7 @@ Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
 | <<plugins-{type}s-{plugin}-doc_as_upsert>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-document_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-document_type>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-drop_error_types>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-failure_type_logging_whitelist>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-healthcheck_path>> |<<string,string>>|No

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -204,7 +204,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         # if enabled, failed index name interpolation events go into dead letter queue.
         :dlq_on_failed_indexname_interpolation => { :validate => :boolean, :default => true },
 
-        # The bulk request will not be retried for these error types; the events will be dropped.
+        # Failures on actions from a bulk request will not be retried for these error types; the events will be dropped.
         # The events won't be added to the DLQ either.
         :drop_error_types => { :validate => :string, :list => true, :default => [] },
 

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -204,6 +204,10 @@ module LogStash; module PluginMixins; module ElasticSearch
         # if enabled, failed index name interpolation events go into dead letter queue.
         :dlq_on_failed_indexname_interpolation => { :validate => :boolean, :default => true },
 
+        # The bulk request will not be retried for these error types; the events will be dropped.
+        # The events won't be added to the DLQ either.
+        :drop_error_types => { :validate => :string, :list => true, :default => [] },
+
         # Obsolete Settings
         :ssl => { :obsolete => "Set 'ssl_enabled' instead." },
         :ssl_certificate_verification => { :obsolete => "Set 'ssl_verification_mode' instead." },

--- a/lib/logstash/plugin_mixins/elasticsearch/common.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/common.rb
@@ -281,7 +281,7 @@ module LogStash; module PluginMixins; module ElasticSearch
         type = error["type"] if error
         action = actions[idx]
 
-        # Retry logic: If it is success, we move on. If it is a failure, we have 3 paths:
+        # Retry logic: If it is success, we move on. If it is a failure, we have the following paths:
         # - For 409, we log and drop. there is nothing we can do
         # - For any error types set in the 'drop_error_types' config, log and drop.
         # - For a mapping error, we send to dead letter queue for a human to intervene at a later point.

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '12.0.8'
+  s.version         = '12.1.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '12.0.7'
+  s.version         = '12.0.8'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1501,7 +1501,9 @@ describe LogStash::Outputs::ElasticSearch do
 
   context 'drop_error_types config option' do
 
-    let(:options) { super().merge('drop_error_types' => ['role_restriction_exception']) }
+    let(:error_type) { 'role_restriction_exception' }
+
+    let(:options) { super().merge('drop_error_types' => [error_type]) }
 
     let(:events) { [ LogStash::Event.new("foo" => "bar") ] }
 
@@ -1514,7 +1516,7 @@ describe LogStash::Outputs::ElasticSearch do
         "took"=>1, "ingest_took"=>11, "errors"=>true, "items"=>
         [{
            "index"=>{"_index"=>"bar", "_type"=>"_doc", "_id"=>'bar', "status" => error_code,
-                     "error"=>{"type" => "role_restriction_exception", "reason" => "TEST" }
+                     "error"=>{"type" => error_type, "reason" => "TEST" }
            }
          }]
       }
@@ -1536,6 +1538,7 @@ describe LogStash::Outputs::ElasticSearch do
     end
 
     context 'DLQ is not enabled' do
+
       it 'does not write the event to the DLQ' do
         allow(subject).to receive(:dlq_enabled?).and_return(false)
         expect(dlq_writer).not_to receive(:write)
@@ -1561,7 +1564,7 @@ describe LogStash::Outputs::ElasticSearch do
 
       let(:logger) { subject.logger }
 
-      let(:options) { super().merge('silence_errors_in_log' => ['role_restriction_exception']) }
+      let(:options) { super().merge('silence_errors_in_log' => [error_type]) }
 
       it 'does not log the error' do
         expect(logger).not_to receive(:warn)


### PR DESCRIPTION
This PR adds a config option `drop_error_types` that allows a user to set a list of error types for which a failed bulk request should not be retried and the events should be dropped. The events are not added to the DLQ. A warn message is logged, if the error type is not listed in the config option `silence_errors_in_log`.

Closes #1225 