### PR TITLE
[11.x] Replace deprecated File.exists? in Rakefile.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ def download_and_transform(source_url:, ecs_major:, es_major:)
     response = http.get(source_url)
     fail "#{response.code} #{response.message}" unless (200...300).cover?(response.code.to_i)
     template_directory = File.expand_path("../lib/logstash/outputs/elasticsearch/templates/ecs-#{ecs_major}", __FILE__)
-    Dir.mkdir(template_directory) unless File.exists?(template_directory)
+    Dir.mkdir(template_directory) unless File.exist?(template_directory)
     File.open(File.join(template_directory, "/elasticsearch-#{es_major}x.json"), "w") do |handle|
       template = JSON.load(response.body)
       replace_index_patterns!(template, ECS_LOGSTASH_INDEX_PATTERNS)


### PR DESCRIPTION
Replaces deprecated `File.exists?` with `File.exist` in Rakefile in 11.x branch.
Fixes the CI failures (e.g: - https://app.travis-ci.com/github/logstash-plugins/logstash-output-elasticsearch/jobs/638934137) of upcoming PR (e.g - https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1258)

- Related: https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1238/