### PR TITLE
[11.x] Replace File.exists? with File.exist? (#1238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.22.14
+ - Fix: replace deprecated `File.exists?` with `File.exist?` for Ruby 3.4 (JRuby 10) compatibility [#1238](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1238)
+
 ## 11.22.13
  - Add headers reporting uncompressed size and doc count for bulk requests [#1217](https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1217)
 

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ def download_and_transform(source_url:, ecs_major:, es_major:)
     response = http.get(source_url)
     fail "#{response.code} #{response.message}" unless (200...300).cover?(response.code.to_i)
     template_directory = File.expand_path("../lib/logstash/outputs/elasticsearch/templates/ecs-#{ecs_major}", __FILE__)
-    Dir.mkdir(template_directory) unless File.exists?(template_directory)
+    Dir.mkdir(template_directory) unless File.exist?(template_directory)
     File.open(File.join(template_directory, "/elasticsearch-#{es_major}x.json"), "w") do |handle|
       template = JSON.load(response.body)
       replace_index_patterns!(template, ECS_LOGSTASH_INDEX_PATTERNS)

--- a/lib/logstash/outputs/elasticsearch/template_manager.rb
+++ b/lib/logstash/outputs/elasticsearch/template_manager.rb
@@ -99,7 +99,7 @@ module LogStash; module Outputs; class ElasticSearch
     end
 
     def self.read_template_file(template_path)
-      raise LogStash::ConfigurationError, "Template file '#{template_path}' could not be found" unless ::File.exists?(template_path)
+      raise LogStash::ConfigurationError, "Template file '#{template_path}' could not be found" unless ::File.exist?(template_path)
       template_data = ::IO.read(template_path)
       LogStash::Json.load(template_data)
     rescue => e

--- a/logstash-output-elasticsearch.gemspec
+++ b/logstash-output-elasticsearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch'
-  s.version         = '11.22.13'
+  s.version         = '11.22.14'
   s.licenses        = ['apache-2.0']
   s.summary         = "Stores logs in Elasticsearch"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1557,7 +1557,7 @@ describe LogStash::Outputs::ElasticSearch do
             expect( event ).to be_a LogStash::Event
             expect( event ).to be events.first
             expect( reason ).to start_with "Could not index event to Elasticsearch. status: #{error_code}, action: [\"index\""
-            expect( reason ).to match /_id=>"bar".*"foo"=>"bar".*response:.*"reason"=>"TEST"/
+            expect( reason ).to match /_id(?::| ?=>) ?"bar".*"foo" ?=> ?"bar".*response:.*"reason" ?=> ?"TEST"/
 
             method.call(*args) # won't hurt to call LogStash::Util::DummyDeadLetterQueueWriter
           end.once


### PR DESCRIPTION
Backports https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1238 and https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1250 to 11.x

* Replace File.exists? with File.exist? for Ruby 3.4 compatibility

File.exists? was deprecated in Ruby 3.2 and removed in Ruby 3.4 (JRuby 10). Use File.exist? instead, which has been available since Ruby 1.0

(cherry picked from commit e369b80ad39ca0774b4b55ef4fbc211834cd25b7 and https://github.com/mashhurs/logstash-output-elasticsearch/commit/27b5c6cca077d055c7f6d5f1307c7d15bcc34287)
