### PR TITLE
Add slack notifications on failure

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   integration-tests:
     uses: logstash-plugins/.ci/.github/workflows/integration-tests.yml@1.x
+    secrets: inherit
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}

--- a/.github/workflows/secure-integration-tests.yml
+++ b/.github/workflows/secure-integration-tests.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   secure-integration-tests:
     uses: logstash-plugins/.ci/.github/workflows/secure-integration-tests.yml@1.x
+    secrets: inherit
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   unit-tests:
     uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
+    secrets: inherit
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}


### PR DESCRIPTION
This commit utilizes the new pattern in https://github.com/logstash-plugins/.ci/pull/134 the shared action to send faiure notifications to slack. The current architecture inherets the slack secret from the shared workflow repo. This is still being evaluated, but this PR shows how consumers will use the pattern. 