### PR TITLE
Index target no date math for data stream nor alias

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -843,9 +843,9 @@ The indexing target to write events to.
 Can point to an {ref}/index-mgmt.html[index], {ref}/aliases.html[alias], or {ref}/data-streams.html[data stream]. 
 This can be dynamic using the `%{foo}` syntax.
 
-Dynamic syntax might make sense with data streams and aliases, but results should be
-validated against cluster index templates and Index lifecycle management (ILM) setup.
-Placeholder date math should not normally be used with aliases nor data streams.
+NOTE: When using dynamic syntax, verify that the resolved index names align with your cluster index templates and Index Lifecycle Management (ILM) configuration.
+
+WARNING: Date math (e.g. `%{+yyyy.MM.dd}`) is not recommended for use with aliases or data streams.
 
 The default value will partition your indices by day so you can more easily
 delete old data or only search specific date ranges.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -842,10 +842,15 @@ NOTE: `ilm_rollover_alias` does NOT support dynamic variable substitution as
 The indexing target to write events to. 
 Can point to an {ref}/index-mgmt.html[index], {ref}/aliases.html[alias], or {ref}/data-streams.html[data stream]. 
 This can be dynamic using the `%{foo}` syntax.
+
+Dynamic syntax might make sense with data streams and aliases, but results should be
+validated against cluster index templates and Index lifecycle management (ILM) setup.
+Placeholder date math should not normally be used with aliases nor data streams.
+
 The default value will partition your indices by day so you can more easily
 delete old data or only search specific date ranges.
 Indexes may not contain uppercase characters.
-For weekly indexes ISO 8601 format is recommended, eg. logstash-%{+xxxx.ww}.
+For weekly indexes ISO 8601 format is recommended, eg. `logstash-%{+xxxx.ww}`.
 Logstash uses
 http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html[Joda
 formats] and the `@timestamp` field of each event is being used as source for the date.


### PR DESCRIPTION
👋 Regarding https://github.com/elastic/docs-content/issues/2761 & https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/1252, 

Attempts to reduce doc pain point surface area to explicitly note to users to stop using date math with aliases or data streams. 

Aliases will not ILM rollover bootstrap & data streams will bootstrap but incur multiple data streams which then fail to progress through ILM rollover as expected.