### PR TITLE
Fix scheduled runs for GHA (#1270)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,15 +10,30 @@ on:
       - main
       - '11.x'
   schedule:
-    # Run daily at 08:00 UTC on active branches
+    # Daily run that fans out across every active branch via the matrix job
+    # below. A `schedule:` trigger only fires from the workflow file on the
+    # default branch, so this block lives here and the matrix supplies the
+    # per-branch ref.
     - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:
   integration-tests:
+    if: github.event_name != 'schedule'
     uses: logstash-plugins/.ci/.github/workflows/integration-tests.yml@1.x
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}
     with:
+      timeout-minutes: 60
+
+  scheduled:
+    if: github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['main', '11.x']
+    uses: logstash-plugins/.ci/.github/workflows/integration-tests.yml@1.x
+    with:
+      ref: ${{ matrix.branch }}
       timeout-minutes: 60

--- a/.github/workflows/secure-integration-tests.yml
+++ b/.github/workflows/secure-integration-tests.yml
@@ -10,15 +10,30 @@ on:
       - main
       - '11.x'
   schedule:
-    # Run daily at 08:00 UTC on active branches
+    # Daily run that fans out across every active branch via the matrix job
+    # below. A `schedule:` trigger only fires from the workflow file on the
+    # default branch, so this block lives here and the matrix supplies the
+    # per-branch ref.
     - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:
   secure-integration-tests:
+    if: github.event_name != 'schedule'
     uses: logstash-plugins/.ci/.github/workflows/secure-integration-tests.yml@1.x
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}
     with:
+      timeout-minutes: 60
+
+  scheduled:
+    if: github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['main', '11.x']
+    uses: logstash-plugins/.ci/.github/workflows/secure-integration-tests.yml@1.x
+    with:
+      ref: ${{ matrix.branch }}
       timeout-minutes: 60

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,15 +10,30 @@ on:
       - main
       - '11.x'
   schedule:
-    # Run daily at 08:00 UTC on active branches
+    # Daily run that fans out across every active branch via the matrix job
+    # below. A `schedule:` trigger only fires from the workflow file on the
+    # default branch, so this block lives here and the matrix supplies the
+    # per-branch ref.
     - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:
   unit-tests:
+    if: github.event_name != 'schedule'
     uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/11.x' }}
     with:
+      timeout-minutes: 60
+
+  scheduled:
+    if: github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['main', '11.x']
+    uses: logstash-plugins/.ci/.github/workflows/unit-tests.yml@1.x
+    with:
+      ref: ${{ matrix.branch }}
       timeout-minutes: 60


### PR DESCRIPTION
This commit uses the proposed mechanism logstash-plugins/.ci#139 for running scheduled jobs. The schedule fires from only the context of the main branch We construct a matrix of branches to test in the schedule. This adds a separate section to handle the schedule per test type (in this case just unit tests). This allows the PR tests to run against the target branch, and separately the schedule to trigger jobs that target all active branches.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
