### PR TITLE
Support Base64 and Elastic Cloud org level api keys.

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -458,8 +458,12 @@ For more details on actions, check out the {ref}/docs-bulk.html[Elasticsearch bu
 Authenticate using Elasticsearch API key.
 Note that this option also requires SSL/TLS, which can be enabled by supplying a <<plugins-{type}s-{plugin}-cloud_id>>, a list of HTTPS <<plugins-{type}s-{plugin}-hosts>>, or by setting <<plugins-{type}s-{plugin}-ssl,`ssl_enabled => true`>>.
 
-Format is `id:api_key` where `id` and `api_key` are as returned by the
-Elasticsearch {ref}/security-api-create-api-key.html[Create API key API].
+The format is `id:api_key`, where `id` and `api_key` are as returned by the
+Elasticsearch
+{ref}/security-api-create-api-key.html[Create
+API key API]. The base64-encoded form of that pair is also accepted, as is an
+https://www.elastic.co/docs/deploy-manage/api-keys/elastic-cloud-api-keys[Elastic Cloud API key]
+(prefixed with `essu_`), which is used as-is.
 
 [id="plugins-{type}s-{plugin}-bulk_path"]
 ===== `bulk_path`

--- a/lib/logstash/outputs/elasticsearch/http_client_builder.rb
+++ b/lib/logstash/outputs/elasticsearch/http_client_builder.rb
@@ -188,9 +188,38 @@ module LogStash; module Outputs; class ElasticSearch;
     def self.setup_api_key(logger, params)
       api_key = params["api_key"]
 
-      return {} unless (api_key && api_key.value)
+      return {} unless (api_key&.value)
 
-      { "Authorization" => "ApiKey " + Base64.strict_encode64(api_key.value) }
+      token = resolve_api_key(api_key.value)
+      { "Authorization" => "ApiKey #{token}" }
+    end
+
+    # Resolves the `api_key` value into the credential used in the
+    # `Authorization: ApiKey` header. An already base64-encoded key and an Elastic
+    # Cloud API key are used as-is; a raw `id:api_key` pair is base64-encoded. An
+    # unrecognized value is rejected so a malformed key surfaces at startup rather
+    # than as a later authentication failure.
+    def self.resolve_api_key(key_value)
+      if base64?(key_value) || cloud_api_key?(key_value)
+        key_value
+      elsif key_value.match?(/\A[^:]+:[^:]+\z/)
+        Base64.strict_encode64(key_value)
+      else
+        raise LogStash::ConfigurationError, "Invalid api_key format. Expected a base64-encoded key, an 'id:api_key' pair, or a Cloud API key (essu_ prefix)."
+      end
+    end
+
+    # Elastic Cloud API keys (such as the unified Serverless keys) are opaque
+    # tokens prefixed with `essu_` that Elasticsearch accepts verbatim in the
+    # `Authorization: ApiKey` header, with no base64 encoding.
+    def self.cloud_api_key?(string)
+      string.match?(/\Aessu_.+/)
+    end
+
+    def self.base64?(string)
+      string == Base64.strict_encode64(Base64.strict_decode64(string))
+    rescue ArgumentError
+      false
     end
 
     private

--- a/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/elasticsearch/api_configs.rb
@@ -16,7 +16,8 @@ module LogStash; module PluginMixins; module ElasticSearch
         :password => { :validate => :password },
 
         # Authenticate using Elasticsearch API key.
-        # format is id:api_key (as returned by https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key])
+        # Format is either the `id:api_key` pair (as returned by https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html[Create API key]),
+        # its base64-encoded form, or an https://www.elastic.co/docs/deploy-manage/api-keys/elastic-cloud-api-keys[Elastic Cloud API key] (prefixed with `essu_`) can be used.
         :api_key => { :validate => :password },
 
         # Cloud authentication string ("<username>:<password>" format) is an alternative for the `user`/`password` configuration.

--- a/spec/unit/outputs/elasticsearch_spec.rb
+++ b/spec/unit/outputs/elasticsearch_spec.rb
@@ -1618,6 +1618,32 @@ describe LogStash::Outputs::ElasticSearch do
       end; end
     end
 
+    context "with an already base64-encoded API key" do
+      let(:api_key) { Base64.strict_encode64("some_id:some_api_key") }
+      let(:options) { { "ssl_enabled" => true, "api_key" => ::LogStash::Util::Password.new(api_key) } }
+      let(:base64_api_key) { "ApiKey #{api_key}" }
+
+      it_behaves_like 'secure api-key authenticated client'
+    end
+
+    context "with an Elastic Cloud API key (essu_ prefix)" do
+      let(:api_key) { "essu_VFZGblZreFhTekJ4ZDB4M2NHUnZRMEU2YzNWd1pYSnpaV055WlhRPQ==AAAAAAAA" }
+      let(:options) { { "ssl_enabled" => true, "api_key" => ::LogStash::Util::Password.new(api_key) } }
+
+      it "sets the Authorization header verbatim without re-encoding" do
+        expect(manticore_options[:headers]).to eq({ "Authorization" => "ApiKey #{api_key}" })
+      end
+    end
+
+    context "with an unrecognized api_key format" do
+      let(:do_register) { false }
+      let(:options) { { "ssl_enabled" => true, "api_key" => ::LogStash::Util::Password.new("not-a-valid-key") } }
+
+      it "fails registration with a configuration error" do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError, /Invalid api_key format/)
+      end
+    end
+
     context "when set without ssl_enabled => true" do
       let(:do_register) { false } # this is what we want to test, so we disable the before(:each) call
       let(:options) { { "api_key" => api_key } }


### PR DESCRIPTION
## Align API key handling with main branch

Backports the `api_key` format handling from the `main` branch to `4.x`, which ships with Logstash 8.19.x.

### Changes

The `api_key` option now accepts three formats:

- **`id:api_key`** — raw pair, base64-encoded automatically by the plugin (existing behavior)
- **Base64-encoded value** — passed through as-is, avoiding double-encoding (e.g. the `encoded` field returned by the Create API Key API, available since ES 7.16.0)
- **Elastic Cloud API key (`essu_` prefix)** — passed through verbatim, enabling authentication against Serverless projects using organization-level Cloud API keys

Unrecognized formats are rejected at startup with a clear `ConfigurationError`, so misconfigured keys surface immediately rather than as opaque authentication failures at runtime.